### PR TITLE
Fix lag in long games

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -467,4 +467,24 @@ function Public.subtract_threat(entity)
 	return true
 end
 
+-- biter reanimation based on module/biter_reanimator.lua
+local function reanimate(entity, cut_off)
+	if math_random(1, 10000) > cut_off then	return end
+
+	local revived_entity = entity.clone({position = entity.position, surface = entity.surface, force = entity.force})
+	revived_entity.health = revived_entity.prototype.max_health
+
+	entity.destroy()
+end
+
+Public.on_entity_died = function(event)
+	local entity = event.entity
+	if not entity.valid then return end
+	if entity.type ~= "unit" then return end
+	-- Skip when under 100 evo
+	local cut_off = global.reanimate[entity.force.index]
+	if not cut_off then return end
+	reanimate(entity, cut_off)
+end
+
 return Public

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -11,8 +11,8 @@ local bb_config = {
 	["random_scrap"] = true,							--Generate harvestable scrap around worms randomly?
 
 	--BITER SETTINGS--
-	["max_active_biters"] = 1280,					--Maximum total amount of attacking units per side.
-	["max_group_size"] = 288,							--Maximum unit group size.
+	["max_active_biters"] = 2048,					--Maximum total amount of attacking units per side.
+	["max_group_size"] = 512,							--Maximum unit group size.
 	["biter_timeout"] = 162000,						--Time it takes in ticks for an attacking unit to be deleted. This prevents permanent stuck units.
 	["bitera_area_distance"] = 512					--Distance to the biter area.
 }

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -28,7 +28,7 @@ local function set_biter_endgame_modifiers(force)
 	force.set_ammo_damage_modifier("flamethrower", damage_mod)
 	force.set_ammo_damage_modifier("laser-turret", damage_mod)
 
-	global.reanimate[force.index] = math.floor((global.bb_evolution[force.name] - 1) * 10000)
+	global.reanimate[force.index] = math.floor((global.bb_evolution[force.name] - 1) * 4000)
 end
 
 local function get_enemy_team_of(team)

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -1,5 +1,4 @@
 local bb_config = require "maps.biter_battles_v2.config"
-local Force_health_booster = require "modules.force_health_booster"
 local Functions = require "maps.biter_battles_v2.functions"
 local Server = require 'utils.server'
 
@@ -28,8 +27,6 @@ local function set_biter_endgame_modifiers(force)
 	force.set_ammo_damage_modifier("artillery-shell", damage_mod)
 	force.set_ammo_damage_modifier("flamethrower", damage_mod)
 	force.set_ammo_damage_modifier("laser-turret", damage_mod)
-	
-	Force_health_booster.set_health_modifier(force.index, Functions.get_health_modifier(force))
 end
 
 local function get_enemy_team_of(team)

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -27,6 +27,8 @@ local function set_biter_endgame_modifiers(force)
 	force.set_ammo_damage_modifier("artillery-shell", damage_mod)
 	force.set_ammo_damage_modifier("flamethrower", damage_mod)
 	force.set_ammo_damage_modifier("laser-turret", damage_mod)
+
+	global.reanimate[force.index] = math.floor((global.bb_evolution[force.name] - 1) * 10000)
 end
 
 local function get_enemy_team_of(team)

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -107,11 +107,6 @@ function Public.get_random_target_entity(force_index)
 	end
 end
 
-function Public.get_health_modifier(force)
-	if global.bb_evolution[force.name] < 1 then return 1 end
-	return math_round((global.bb_evolution[force.name] - 1) * 3, 3) + 1
-end
-
 function Public.biters_landfill(entity)
 	if not landfill_biters[entity.name] then return end	
 	local position = entity.position

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -184,7 +184,7 @@ function Public.create_main_gui(player)
 		local l = t.add  { type = "label", caption = "Evo:"}
 		--l.style.minimal_width = 25
 		local biter_force = game.forces[gui_value.biter_force]
-		local tooltip = gui_value.t1 .. "\nHealth: " .. Functions.get_health_modifier(biter_force) * 100 .. "%" .. "\nDamage: " .. (biter_force.get_ammo_damage_modifier("melee") + 1) * 100 .. "%"
+		local tooltip = gui_value.t1 .. "\nDamage: " .. (biter_force.get_ammo_damage_modifier("melee") + 1) * 100 .. "%"
 		
 		l.tooltip = tooltip		
 		

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -1,5 +1,4 @@
 local Terrain = require "maps.biter_battles_v2.terrain"
-local Force_health_booster = require "modules.force_health_booster"
 local Score = require "comfy_panel.score"
 local Tables = require "maps.biter_battles_v2.tables"
 
@@ -133,7 +132,6 @@ end
 
 function Public.tables()
 	local get_score = Score.get_table()
-	Force_health_booster.reset_tables()
 	get_score.score_table = {}
 	global.science_logs_text = nil
 	global.science_logs_total_north = nil

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -172,6 +172,7 @@ function Public.tables()
 			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
 		}
 	}
+	global.reanimate = {}
 	global.difficulty_votes_timeout = 36000
 	global.next_attack = "north"
 	if math.random(1,2) == 1 then global.next_attack = "south" end

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -158,9 +158,5 @@ Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)
 Event.add(defines.events.on_tick, on_tick)
 Event.on_init(on_init)
 
-Event.add_event_filter(defines.events.on_entity_damaged, {filter = "type", type = "unit"})
-Event.add_event_filter(defines.events.on_entity_damaged, {filter = "type", type = "unit-spawner"})
-Event.add_event_filter(defines.events.on_entity_damaged, {filter = "type", type = "turret"})
-
 require "maps.biter_battles_v2.spec_spy"
 require "maps.biter_battles_v2.difficulty_vote"

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -143,6 +143,7 @@ end
 
 local Event = require 'utils.event'
 Event.add(defines.events.on_research_finished, Ai.unlock_satellite)			--free silo space tech
+Event.add(defines.events.on_entity_died, Ai.on_entity_died)
 Event.add(defines.events.on_built_entity, on_built_entity)
 Event.add(defines.events.on_chunk_generated, on_chunk_generated)
 Event.add(defines.events.on_console_chat, on_console_chat)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -625,7 +625,6 @@ function Public.minable_wrecks(event)
 	
 	local loot_worth = math_floor(math_abs(entity.position.x * 0.02)) + math_random(16, 32)	
 	local blacklist = LootRaffle.get_tech_blacklist(math_abs(entity.position.x * 0.0001) + 0.10)
-	for k, _ in pairs(blacklist) do print(k) end
 	for k, _ in pairs(loot_blacklist) do blacklist[k] = true end
 	local item_stacks = LootRaffle.roll(loot_worth, math_random(1, 3), blacklist)
 		


### PR DESCRIPTION
### Brief description of the changes:
Removed biter health booster that causes lag due to `on_entity_damaged` firing for every damage tick to biters.
Add chance of biter revival as it used to be (`on_entity_died` happens much less often).
For future PR, balance biters after 350% evo. Currently they are indestructible as they get `0.4%` revival chance for each `1%` over `100%` evo.
Also, removed annoying spam on `stdout`.

### Tested Changes
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.

1. I started the scenario and it didn't crash.
2. I started the scenario with biter revival changes, turned on `training mode`, in `editor mode` fed white flasks and built defenses. Observed that biters revive at `280%` evo.