### PR TITLE
damage updates customizable

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -17,14 +17,69 @@ local function proj_buff(current_value,force_name)
 	global.combat_balance[force_name].bullet = global.combat_balance[force_name].bullet + current_value
 	game.forces[force_name].set_ammo_damage_modifier("bullet", global.combat_balance[force_name].bullet)
 end
+local function laser_buff(current_value,force_name)
+		if not global.combat_balance[force_name].laser_damage then global.combat_balance[force_name].laser_damage = get_turret_attack_modifier("laser-turret") end
+		global.combat_balance[force_name].laser_damage = global.combat_balance[force_name].laser_damage + current_value - get_upgrade_modifier("laser-turret")
+		game.forces[force_name].set_turret_attack_modifier("laser-turret", current_value)	
+end
+local function flamer_buff(current_value_ammo,current_value_turret,force_name)
+		if not global.combat_balance[force_name].flame_damage then global.combat_balance[force_name].flame_damage = get_ammo_modifier("flamethrower") end
+		global.combat_balance[force_name].flame_damage = global.combat_balance[force_name].flame_damage + current_value_ammo - get_upgrade_modifier("flamethrower")
+		game.forces[force_name].set_ammo_damage_modifier("flamethrower", global.combat_balance[force_name].flame_damage)
+		
+		if not global.combat_balance[force_name].flamethrower_damage then global.combat_balance[force_name].flamethrower_damage = get_turret_attack_modifier("flamethrower-turret") end
+		global.combat_balance[force_name].flamethrower_damage = global.combat_balance[force_name].flamethrower_damage +current_value_turret - get_upgrade_modifier("flamethrower-turret")
+		game.forces[force_name].set_turret_attack_modifier("flamethrower-turret", global.combat_balance[force_name].flamethrower_damage)	
+end
 local balance_functions = {
 	["refined-flammables"] = function(force_name)
-		if not global.combat_balance[force_name].flamethrower_damage then global.combat_balance[force_name].flamethrower_damage = get_ammo_modifier("flamethrower") end
-		global.combat_balance[force_name].flamethrower_damage = global.combat_balance[force_name].flamethrower_damage + get_upgrade_modifier("flamethrower")
-		game.forces[force_name].set_turret_attack_modifier("flamethrower-turret", global.combat_balance[force_name].flamethrower_damage)								
-		game.forces[force_name].set_ammo_damage_modifier("flamethrower", global.combat_balance[force_name].flamethrower_damage)
+		flamer_buff(get_upgrade_modifier("flamethrower")*2,get_upgrade_modifier("flamethrower-turret")*2,force_name)
 	end,
-	
+	["refined-flammables-1"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["refined-flammables-2"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["refined-flammables-3"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["refined-flammables-4"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["refined-flammables-5"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["refined-flammables-6"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["refined-flammables-7"] = function(force_name)
+		flamer_buff(0.03,0.03,force_name)
+	end,
+	["energy-weapons-damage"] = function(force_name)
+		laser_buff(get_upgrade_modifier("laser-turret")*2,force_name)
+	end,
+	["energy-weapons-damage-1"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
+	["energy-weapons-damage-2"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
+	["energy-weapons-damage-3"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
+	["energy-weapons-damage-4"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
+	["energy-weapons-damage-5"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
+	["energy-weapons-damage-6"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
+	["energy-weapons-damage-7"] = function(force_name)
+		laser_buff(0.3,force_name)
+	end,
 	["stronger-explosives"] = function(force_name)
 		if not global.combat_balance[force_name].grenade_damage then global.combat_balance[force_name].grenade_damage = get_ammo_modifier("grenade") end			
 		global.combat_balance[force_name].grenade_damage = global.combat_balance[force_name].grenade_damage + get_upgrade_modifier("grenade")
@@ -367,6 +422,13 @@ function get_ammo_modifier(ammo_category)
 	local result = 0
 	if Tables.base_ammo_modifiers[ammo_category] then
         result = Tables.base_ammo_modifiers[ammo_category]
+	end
+    return result
+end
+function get_turret_attack_modifier(turret_category)
+	local result = 0
+	if Tables.base_turret_attack_modifiers[turret_category] then
+        result = Tables.base_turret_attack_modifiers[turret_category]
 	end
     return result
 end

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -38,6 +38,7 @@ local balance_functions = {
 		if not global.combat_balance[force_name].shotgun then global.combat_balance[force_name].shotgun = get_ammo_modifier("shotgun-shell") end
 		global.combat_balance[force_name].shotgun = global.combat_balance[force_name].shotgun + get_upgrade_modifier("shotgun-shell")	
 		game.forces[force_name].set_ammo_damage_modifier("shotgun-shell", global.combat_balance[force_name].shotgun)
+		game.forces[force_name].set_turret_attack_modifier("gun-turret",0)
 	end,
 	["physical-projectile-damage-1"] = function(force_name)
 		proj_buff(0.3,force_name)

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -12,6 +12,11 @@ local string_find = string.find
 
 -- Only add upgrade research balancing logic in this section
 -- All values should be in tables.lua
+local function proj_buff(current_value,force_name)
+	if not global.combat_balance[force_name].bullet then global.combat_balance[force_name].bullet = get_ammo_modifier("bullet") end
+	global.combat_balance[force_name].bullet = global.combat_balance[force_name].bullet + current_value
+	game.forces[force_name].set_ammo_damage_modifier("bullet", global.combat_balance[force_name].bullet)
+end
 local balance_functions = {
 	["refined-flammables"] = function(force_name)
 		if not global.combat_balance[force_name].flamethrower_damage then global.combat_balance[force_name].flamethrower_damage = get_ammo_modifier("flamethrower") end
@@ -33,6 +38,27 @@ local balance_functions = {
 		if not global.combat_balance[force_name].shotgun then global.combat_balance[force_name].shotgun = get_ammo_modifier("shotgun-shell") end
 		global.combat_balance[force_name].shotgun = global.combat_balance[force_name].shotgun + get_upgrade_modifier("shotgun-shell")	
 		game.forces[force_name].set_ammo_damage_modifier("shotgun-shell", global.combat_balance[force_name].shotgun)
+	end,
+	["physical-projectile-damage-1"] = function(force_name)
+		proj_buff(0.3,force_name)
+	end,
+	["physical-projectile-damage-2"] = function(force_name)
+		proj_buff(0.3,force_name)
+	end,
+	["physical-projectile-damage-3"] = function(force_name)
+		proj_buff(0.3,force_name)
+	end,
+	["physical-projectile-damage-4"] = function(force_name)
+		proj_buff(0.3,force_name)
+	end,
+	["physical-projectile-damage-5"] = function(force_name)
+		proj_buff(0.3,force_name)
+	end,
+	["physical-projectile-damage-6"] = function(force_name)
+		proj_buff(0.3,force_name)
+	end,
+	["physical-projectile-damage-7"] = function(force_name)
+		proj_buff(0.3,force_name)
 	end,
 }
 
@@ -146,7 +172,6 @@ function Public.combat_balance(event)
 		if balance_functions[key] then
 			if not global.combat_balance[force_name] then global.combat_balance[force_name] = {} end
 			balance_functions[key](force_name)
-			return
 		end
 	end
 end

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -16,11 +16,14 @@ Public.base_ammo_modifiers = {
 
 -- turret attack modifier via set_turret_attack_modifier
 Public.base_turret_attack_modifiers = {
-	["flamethrower-turret"] = -0.8
+	["flamethrower-turret"] = -0.8,
+	["laser-turret"] = 0.0
 }
 
 Public.upgrade_modifiers = {
 	["flamethrower"] = 0.02,
+	["flamethrower-turret"] = 0.02,
+	["laser-turret"] = 0.3,
 	["shotgun-shell"] = 0.6,
 	["grenade"] = 0.4,
 	["landmine"] = 0.03


### PR DESCRIPTION
### Brief description of the changes:
 damage upgrades now can be changed independently, unused function in refined-flammables and energy-weapons-damage lists can be deleted without any consequences if value inside function is matching value inside Public.upgrade_modifiers. For example, all laser damage function rn matching data from table, so they all can be removed, while all flame damage do not match values and can't be removed (not working like that for bullets). branch of #117 

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
