### PR TITLE
Flamers firestream nerf

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -288,7 +288,9 @@ function Public.forces()
 				.set_turret_attack_modifier(turret_category, value)
 		end
 	end
-
+	for _, force in pairs(Tables.ammo_modified_forces_list) do
+		game.forces[force].set_gun_speed_modifier("flamethrower",-0.9)
+	end
 end
 
 return Public


### PR DESCRIPTION
### Brief description of the changes:
nerfing stackable flamethrower damage, decreasing oil consumption at the same rate (90%in the example)

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
