### PR TITLE
Improve biter pathfinding

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -266,28 +266,42 @@ local function send_group(unit_group, force_name, side_target)
 	if position then
 		if math.abs(position.y) < math.abs(unit_group.position.y) then
 			commands[#commands + 1] = {
-				type = defines.command.attack_area,
+				type = defines.command.go_to_location,
 				destination = position,
-				radius = 16,
+				radius = 64,
 				distraction = defines.distraction.by_enemy,
 				pathfind_flags = group_path_flags_cache_straight_lowprio
 			}
 		end
 	end
 	
+    commands[#commands + 1] = {
+		type = defines.command.go_to_location,
+		destination = target,
+		radius = 64,
+		distraction = defines.distraction.by_enemy,
+		pathfind_flags = group_path_flags_nocache_straight
+	}
+	
 	commands[#commands + 1] = {
 		type = defines.command.attack_area,
 		destination = target,
-		radius = 32,
+		radius = 16,
 		distraction = defines.distraction.by_enemy,
-		pathfind_flags = group_path_flags_nocache_straight
+	}
+	
+    commands[#commands + 1] = {
+		type = defines.command.go_to_location,
+		destination = global.rocket_silo[force_name].position,
+        radius = 64,
+		distraction = defines.distraction.by_damage,
+		pathfind_flags = group_path_flags_nocache_nobreak
 	}
 	
 	commands[#commands + 1] = {
 		type = defines.command.attack,
 		target = global.rocket_silo[force_name],
 		distraction = defines.distraction.by_damage,
-		pathfind_flags = group_path_flags_nocache_nobreak
 	}
 	
 	unit_group.set_command({

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -240,9 +240,10 @@ local group_path_flags_cache_straight_lowprio =
   low_priority = true
 }
 
-local group_path_flags_nocache =
+local group_path_flags_nocache_nobreak =
 {
-  cache = false
+  cache = false,
+  no_break = true
 }
 
 local function send_group(unit_group, force_name, side_target)
@@ -286,7 +287,7 @@ local function send_group(unit_group, force_name, side_target)
 		type = defines.command.attack,
 		target = global.rocket_silo[force_name],
 		distraction = defines.distraction.by_damage,
-		pathfind_flags = group_path_flags_nocache
+		pathfind_flags = group_path_flags_nocache_nobreak
 	}
 	
 	unit_group.set_command({

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -228,6 +228,23 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	return valid_biters
 end
 
+local group_path_flags_nocache_straight =
+{
+  cache = false,
+  prefer_straight_paths = true
+}
+
+local group_path_flags_cache_straight_lowprio =
+{
+  prefer_straight_paths = true,
+  low_priority = true
+}
+
+local group_path_flags_nocache =
+{
+  cache = false
+}
+
 local function send_group(unit_group, force_name, side_target)
 	local target
 	if side_target then
@@ -251,7 +268,8 @@ local function send_group(unit_group, force_name, side_target)
 				type = defines.command.attack_area,
 				destination = position,
 				radius = 16,
-				distraction = defines.distraction.by_enemy
+				distraction = defines.distraction.by_enemy,
+				pathfind_flags = group_path_flags_cache_straight_lowprio
 			}
 		end
 	end
@@ -260,13 +278,15 @@ local function send_group(unit_group, force_name, side_target)
 		type = defines.command.attack_area,
 		destination = target,
 		radius = 32,
-		distraction = defines.distraction.by_enemy
+		distraction = defines.distraction.by_enemy,
+		pathfind_flags = group_path_flags_nocache_straight
 	}
 	
 	commands[#commands + 1] = {
 		type = defines.command.attack,
 		target = global.rocket_silo[force_name],
-		distraction = defines.distraction.by_damage
+		distraction = defines.distraction.by_damage,
+		pathfind_flags = group_path_flags_nocache
 	}
 	
 	unit_group.set_command({

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -9,14 +9,12 @@ local vector_radius = 512
 local attack_vectors = {}
 attack_vectors.north = {}
 attack_vectors.south = {}
-for x = vector_radius * -1, vector_radius, 1 do
-	for y = 0, vector_radius, 1 do
-		local r = math.sqrt(x ^ 2 + y ^ 2)
-		if r < vector_radius and r > vector_radius - 1 then
-			attack_vectors.north[#attack_vectors.north + 1] = {x, y * -1}
-			attack_vectors.south[#attack_vectors.south + 1] = {x, y}
-		end
-	end
+for p = 0.3, 0.71, 0.05 do
+	local a = math.pi * p
+	local x = vector_radius * math.cos(a)
+	local y = vector_radius * math.sin(a)
+	attack_vectors.north[#attack_vectors.north + 1] = {x, y * -1}
+	attack_vectors.south[#attack_vectors.south + 1] = {x, y}
 end
 local size_of_vectors = #attack_vectors.north
 

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -268,7 +268,7 @@ local function send_group(unit_group, force_name, side_target)
 	commands[#commands + 1] = {
 		type = defines.command.attack,
 		target = global.rocket_silo[force_name],
-		distraction = defines.distraction.by_enemy
+		distraction = defines.distraction.by_damage
 	}
 	
 	unit_group.set_command({

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -9,7 +9,7 @@ local vector_radius = 512
 local attack_vectors = {}
 attack_vectors.north = {}
 attack_vectors.south = {}
-for p = 0.3, 0.71, 0.05 do
+for p = 0.3, 0.71, 0.1 do
 	local a = math.pi * p
 	local x = vector_radius * math.cos(a)
 	local y = vector_radius * math.sin(a)
@@ -259,7 +259,7 @@ local function send_group(unit_group, force_name, side_target)
 	
 	local commands = {}	
 	local vector = attack_vectors[force_name][math_random(1, size_of_vectors)]
-	local distance_modifier = math_random(25, 100) * 0.01
+	local distance_modifier = math_random(1, 8) * 0.128
 	
 	local position = {target.x + (vector[1] * distance_modifier), target.y + (vector[2] * distance_modifier)}
 	position = unit_group.surface.find_non_colliding_position("stone-furnace", position, 96, 1)


### PR DESCRIPTION
### Brief description of the changes:
In long games it may take minutes to find a path for the next biter command. This PR should improve that. Make paths from spawners to attack vector low priority and the ones to the silo the highest.
It also changes distraction type when going for the silo. Now biters won't attack players unless they start damaging them.

Second attempt at https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/78

Closes #45 

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.

Start a game go into training mode and debug. Observe paths and improved biter behavior.