### PR TITLE
Disabled mines temporarily until better fix is found

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -266,6 +266,7 @@ function Public.forces()
 		game.forces[force.name].technologies["artillery-shell-speed-1"].enabled = false
 		game.forces[force.name].technologies["atomic-bomb"].enabled = false
 		game.forces[force.name].technologies["cliff-explosives"].enabled = false
+		game.forces[force.name].technologies["land-mine"].enabled = false
 		game.forces[force.name].research_queue_enabled = true
 		global.target_entities[force.index] = {}
 		global.spy_fish_timeout[force.name] = 0


### PR DESCRIPTION
This is the command that guppy_face is running manually to disable mines. This will make sure guppy_face can go to sleep :P
Note: this is a temporary fix, should be replaced with proper fix to limit mines:

Suggested fixes were:

- Mines expire after a certain time
- Limit on amount of mines to be placed
- Mines are only active for a portion of time

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
