### PR TITLE
Revert "Disabled mines temporarily until better fix is found"

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -278,7 +278,6 @@ function Public.forces()
 		game.forces[force.name].technologies["artillery-shell-speed-1"].enabled = false
 		game.forces[force.name].technologies["atomic-bomb"].enabled = false
 		game.forces[force.name].technologies["cliff-explosives"].enabled = false
-		game.forces[force.name].technologies["land-mine"].enabled = false
 		game.forces[force.name].research_queue_enabled = true
 		global.target_entities[force.index] = {}
 		global.spy_fish_timeout[force.name] = 0


### PR DESCRIPTION
Reverts Factorio-Biter-Battles/Factorio-Biter-Battles#126

Mines were limited in #140 but the mine research was not enabled.
This fixes that :)