### PR TITLE
Fix revive buff not applying

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -26,7 +26,6 @@ local function set_biter_endgame_modifiers(force)
 	force.set_ammo_damage_modifier("biological", damage_mod)
 	force.set_ammo_damage_modifier("artillery-shell", damage_mod)
 	force.set_ammo_damage_modifier("flamethrower", damage_mod)
-	force.set_ammo_damage_modifier("laser-turret", damage_mod)
 
 	global.reanimate[force.index] = math.floor((global.bb_evolution[force.name] - 1) * 4000)
 end


### PR DESCRIPTION
`global.reanimate` table wasn't updated, because code failed in the previous line.

Log excerpt:
```
.factorio/temp/currently-playing/utils/event_core.lua:48: Unknown ammo-category name: laser-turret
```

This fix was inspired by @maksiu1000 in PR #150.