### PR TITLE
fix-mutagen-log: ammo-damage-modifier for laser-turrets is not valid,…

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -26,7 +26,7 @@ local function set_biter_endgame_modifiers(force)
 	force.set_ammo_damage_modifier("biological", damage_mod)
 	force.set_ammo_damage_modifier("artillery-shell", damage_mod)
 	force.set_ammo_damage_modifier("flamethrower", damage_mod)
-	force.set_ammo_damage_modifier("laser-turret", damage_mod)
+	force.set_turret_attack_modifier("laser-turret", damage_mod)
 
 	global.reanimate[force.index] = math.floor((global.bb_evolution[force.name] - 1) * 4000)
 end


### PR DESCRIPTION
… causing function to fail and mutagen logs to fail past 100%

### Brief description of the changes:
---Fill in---

### Tested Changes:
- [ x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
