### PR TITLE
Update feeding.lua - buff endgame biters

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -22,7 +22,7 @@ end
 local function set_biter_endgame_modifiers(force)
 	if force.evolution_factor ~= 1 then return end
 	global.reanimate[force.index] = math.floor((global.bb_evolution[force.name] - 1) * 4000)
-	local damage_mod = math.round((global.bb_evolution[force.name] - 1) * 0.50, 3)
+	local damage_mod = math.round((global.bb_evolution[force.name] - 1) * 1.0, 3)
 	force.set_ammo_damage_modifier("melee", damage_mod)
 	force.set_ammo_damage_modifier("biological", damage_mod)
 	force.set_ammo_damage_modifier("artillery-shell", damage_mod)


### PR DESCRIPTION
### Brief description of the changes:
doubling the damage bonus to biters from 100%+ evo

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
