### PR TITLE
Always use a standard team name in post-game discord message (and more QoL stuff)

### DIFF
--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -94,8 +94,6 @@ local function on_player_joined_game(event)
 		if not global.difficulty_player_votes[player.name] then
 			if global.bb_settings.only_admins_vote or global.tournament_mode then
 				if player.admin then poll_difficulty(player) end
-			else
-				poll_difficulty(player)
 			end
 		end
 	else

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -433,7 +433,7 @@ function Public.silo_death(event)
         south_evo = math.floor(1000 * global.bb_evolution["south_biters"]) * 0.1
         south_threat = math.floor(global.bb_threat["south_biters"])
 
-		discord_message = "***" .. c .. " has won! ***" .. "\\n" .. 
+		discord_message = "*** Team " .. global.bb_game_won_by_team .. " has won! ***" .. "\\n" ..
 							global.victory_time .. "\\n\\n" .. 
 							"North Evo: " .. north_evo .. "%\\n" ..
                             "North Threat: " .. north_threat .. "\\n\\n" ..

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -184,7 +184,7 @@ function Public.create_main_gui(player)
 		local l = t.add  { type = "label", caption = "Evo:"}
 		--l.style.minimal_width = 25
 		local biter_force = game.forces[gui_value.biter_force]
-		local tooltip = gui_value.t1 .. "\nDamage: " .. (biter_force.get_ammo_damage_modifier("melee") + 1) * 100 .. "%"
+		local tooltip = gui_value.t1 .. "\nDamage: " .. (biter_force.get_ammo_damage_modifier("melee") + 1) * 100 .. "%\nRevive: " .. math.floor(global.reanimate[biter_force.index]/100) .. "%"
 		
 		l.tooltip = tooltip		
 		

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -172,7 +172,7 @@ function Public.tables()
 			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
 		}
 	}
-	global.reanimate = {}
+	global.reanimate = { [6] = 0, [7] = 0} -- 6 and 7 correspond to indices of "north_biters" and "south_biters"
 	global.difficulty_vote_value = 1
 	global.difficulty_vote_index = 4
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -173,6 +173,9 @@ function Public.tables()
 		}
 	}
 	global.reanimate = {}
+	global.difficulty_vote_value = 1
+	global.difficulty_vote_index = 4
+
 	global.difficulty_votes_timeout = 36000
 
 	global.next_attack = "north"

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -9,6 +9,7 @@ local Mirror_terrain = require "maps.biter_battles_v2.mirror_terrain"
 require 'modules.simple_tags'
 local Team_manager = require "maps.biter_battles_v2.team_manager"
 local Terrain = require "maps.biter_battles_v2.terrain"
+local diff_vote = require "maps.biter_battles_v2.difficulty_vote"
 
 require "maps.biter_battles_v2.sciencelogs_tab"
 require 'maps.biter_battles_v2.commands'
@@ -91,7 +92,10 @@ local function on_tick()
 		global.bb_threat["south_biters"] = global.bb_threat["south_biters"] + global.bb_threat_income["south_biters"]
 	end
 
-	if tick % 180 == 0 then Gui.refresh() end
+	if tick % 180 == 0 then
+		Gui.refresh()
+		diff_vote.difficulty_gui()
+	end
 
 	if tick % 300 == 0 then
 		Gui.spy_fish()
@@ -160,4 +164,3 @@ Event.add(defines.events.on_tick, on_tick)
 Event.on_init(on_init)
 
 require "maps.biter_battles_v2.spec_spy"
-require "maps.biter_battles_v2.difficulty_vote"


### PR DESCRIPTION
### Brief description of the changes:
Use the standard team name (`north` or `south`) in post-game discord message.
More stuff:
* reset difficulty when new game starts,
* display revive chance in tooltip (under `Damage:`).

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
