### PR TITLE
Add two wood to inventory like in vanilla

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -330,6 +330,7 @@ function join_team(player, force_name, forced_join)
 	player.insert {name = 'iron-gear-wheel', count = 8}
 	player.insert {name = 'iron-plate', count = 16}
 	player.insert {name = 'burner-mining-drill', count = 10}
+	player.insert {name = 'wood', count = 2}
 	global.chosen_team[player.name] = force_name
     global.spectator_rejoin_delay[player.name] = game.tick
 	player.spectator = false


### PR DESCRIPTION
### Brief description of the changes:
Add two wood per suggestion: https://discord.com/channels/823696400797138974/823771211421974579/842809868549357579

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
