### PR TITLE
Improvement to map generation performance

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -128,7 +128,7 @@ Public.send_near_biters_to_silo = function()
 	if not global.rocket_silo["north"] then return end
 	if not global.rocket_silo["south"] then return end
 
-	game.surfaces["biter_battles"].set_multi_command({
+	game.surfaces[global.bb_surface_name].set_multi_command({
 		command={
 			type=defines.command.attack,
 			target=global.rocket_silo["north"],
@@ -139,7 +139,7 @@ Public.send_near_biters_to_silo = function()
 		unit_search_distance = 64
 		})
 
-	game.surfaces["biter_battles"].set_multi_command({
+	game.surfaces[global.bb_surface_name].set_multi_command({
 		command={
 			type=defines.command.attack,
 			target=global.rocket_silo["south"],
@@ -363,7 +363,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 end
 
 Public.pre_main_attack = function()
-	local surface = game.surfaces["biter_battles"]
+	local surface = game.surfaces[global.bb_surface_name]
 	local force_name = global.next_attack
 
 	if not global.training_mode or (global.training_mode and #game.forces[force_name].connected_players > 0) then
@@ -379,7 +379,7 @@ end
 
 Public.perform_main_attack = function()
 	if global.main_attack_wave_amount > 0 then
-		local surface = game.surfaces["biter_battles"]
+		local surface = game.surfaces[global.bb_surface_name]
 		local force_name = global.next_attack
 		local biter_force_name = force_name .. "_biters"
 

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -249,7 +249,7 @@ function Public.init_player(player)
 	player.spectator = true
 	player.force = game.forces.spectator
 	
-	local surface = game.surfaces.biter_battles
+	local surface = game.surfaces[global.bb_surface_name]
 	local p = spawn_positions[math_random(1, size_of_spawn_positions)]
 	if surface.is_chunk_generated({0,0}) then
 		player.teleport(surface.find_non_colliding_position("character", p, 4, 0.5), surface)

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -287,14 +287,6 @@ local enemy_team_of = {["north"] = "south", ["south"] = "north"}
 function Public.server_restart()
     if not global.server_restart_timer then return end
     global.server_restart_timer = global.server_restart_timer - 5
-    if global.server_restart_timer == 10 then
-        game.delete_surface(game.surfaces.bb_source)
-        return
-    end
-    if global.server_restart_timer == 5 then
-        Init.source_surface()
-        return
-    end
 
     if global.server_restart_timer == 0 then
         if global.restart then
@@ -323,20 +315,26 @@ function Public.server_restart()
         local message = 'Map is restarting! '
         Server.to_discord_bold(table.concat {'*** ', message, ' ***'})
 
+	local prev_surface = global.bb_surface_name
         Init.tables()
-        Init.forces()
+	Init.playground_surface()
+	Init.forces()
+	Init.draw_structures()
         Init.load_spawn()
+
+	local position = {0, 0}
         for _, player in pairs(game.players) do
             Functions.init_player(player)
             for _, e in pairs(player.gui.left.children) do
                 e.destroy()
             end
             Gui.create_main_gui(player)
+	    player.teleport(position, global.bb_surface_name)
         end
-        game.surfaces[global.bb_surface_name].clear(true)
         game.reset_time_played()
         global.server_restart_timer = nil
         game.speed = 1
+	game.delete_surface(prev_surface)
         return
     end
     if global.server_restart_timer % 30 == 0 then

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -287,7 +287,6 @@ local enemy_team_of = {["north"] = "south", ["south"] = "north"}
 function Public.server_restart()
     if not global.server_restart_timer then return end
     global.server_restart_timer = global.server_restart_timer - 5
-    if global.server_restart_timer == 150 then return end
     if global.server_restart_timer == 10 then
         game.delete_surface(game.surfaces.bb_source)
         return

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -25,7 +25,7 @@ end
 function Public.reveal_map()
     for _, f in pairs({"north", "south", "player", "spectator"}) do
         local r = 768
-        game.forces[f].chart(game.surfaces["biter_battles"],
+        game.forces[f].chart(game.surfaces[global.bb_surface_name],
                              {{r * -1, r * -1}, {r, r}})
     end
 end
@@ -333,7 +333,7 @@ function Public.server_restart()
             end
             Gui.create_main_gui(player)
         end
-        game.surfaces.biter_battles.clear(true)
+        game.surfaces[global.bb_surface_name].clear(true)
         game.reset_time_played()
         global.server_restart_timer = nil
         game.speed = 1

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -381,7 +381,7 @@ function Public.spy_fish()
 	for _, f in pairs(spy_forces) do
 		if global.spy_fish_timeout[f[1]] - game.tick > 0 then
 			local r = 96
-			local surface = game.surfaces["biter_battles"]
+			local surface = game.surfaces[global.bb_surface_name]
 			for _, player in pairs(game.forces[f[2]].connected_players) do
 				game.forces[f[1]].chart(surface, {{player.position.x - r, player.position.y - r}, {player.position.x + r, player.position.y + r}})
 			end

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -74,34 +74,10 @@ function Public.initial_setup()
 	for chunk in surface.get_chunks() do
 		surface.delete_chunk({chunk.x, chunk.y})
 	end
-
-	--Playground Surface
-	local map_gen_settings = {
-		["water"] = 0,
-		["starting_area"] = 1,
-		["cliff_settings"] = {cliff_elevation_interval = 0, cliff_elevation_0 = 0},
-		["default_enable_all_autoplace_controls"] = false,
-		["autoplace_settings"] = {
-			["entity"] = {treat_missing_as_default = false},
-			["tile"] = {treat_missing_as_default = false},
-			["decorative"] = {treat_missing_as_default = false},
-		},
-		autoplace_controls = {
-			["coal"] = {frequency = 0, size = 0, richness = 0},
-			["stone"] = {frequency = 0, size = 0, richness = 0},
-			["copper-ore"] = {frequency = 0, size = 0, richness = 0},
-			["iron-ore"] = {frequency = 0, size = 0, richness = 0},
-			["uranium-ore"] = {frequency = 0, size = 0, richness = 0},
-			["crude-oil"] = {frequency = 0, size = 0, richness = 0},
-			["trees"] = {frequency = 0, size = 0, richness = 0},
-			["enemy-base"] = {frequency = 0, size = 0, richness = 0}
-		},
-	}
-	local surface = game.create_surface(global.bb_surface_name, map_gen_settings)
 end
 
---Terrain Source Surface
-function Public.source_surface()
+--Terrain Playground Surface
+function Public.playground_surface()
 	local map_gen_settings = {}
 	local int_max = 2 ^ 31
 	map_gen_settings.seed = math.random(1, int_max)
@@ -119,10 +95,13 @@ function Public.source_surface()
 		["trees"] = {frequency = math.random(8, 28) * 0.1, size = math.random(6, 14) * 0.1, richness = math.random(2, 4) * 0.1},
 		["enemy-base"] = {frequency = 0, size = 0, richness = 0}
 	}
-	local surface = game.create_surface("bb_source", map_gen_settings)
+	local surface = game.create_surface(global.bb_surface_name, map_gen_settings)
 	surface.request_to_generate_chunks({x = 0, y = -256}, 8)
 	surface.force_generate_chunk_requests()
+end
 
+function Public.draw_structures()
+	local surface = game.surfaces[global.bb_surface_name]
 	Terrain.draw_spawn_area(surface)
 	Terrain.generate_additional_spawn_ore(surface)
 	Terrain.generate_additional_rocks(surface)
@@ -138,7 +117,13 @@ function Public.tables()
 	global.science_logs_total_north = nil
 	global.science_logs_total_south = nil
 	-- Name of main BB surface within game.surfaces
-	global.bb_surface_name = "bb0"
+	-- We hot-swap here between 2 surfaces.
+	if global.bb_surface_name == 'bb0' then
+		global.bb_surface_name = "bb1"
+	else
+		global.bb_surface_name = "bb0"
+	end
+
 	global.active_biters = {}
 	global.bb_evolution = {}
 	global.bb_game_won_by_team = nil

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -97,7 +97,7 @@ function Public.initial_setup()
 			["enemy-base"] = {frequency = 0, size = 0, richness = 0}
 		},
 	}
-	local surface = game.create_surface("biter_battles", map_gen_settings)
+	local surface = game.create_surface(global.bb_surface_name, map_gen_settings)
 end
 
 --Terrain Source Surface
@@ -137,6 +137,8 @@ function Public.tables()
 	global.science_logs_text = nil
 	global.science_logs_total_north = nil
 	global.science_logs_total_south = nil
+	-- Name of main BB surface within game.surfaces
+	global.bb_surface_name = "bb0"
 	global.active_biters = {}
 	global.bb_evolution = {}
 	global.bb_game_won_by_team = nil
@@ -181,7 +183,7 @@ function Public.tables()
 end
 
 function Public.load_spawn()
-	local surface = game.surfaces["biter_battles"]
+	local surface = game.surfaces[global.bb_surface_name]
 	surface.request_to_generate_chunks({x = 0, y = 0}, 1)
 	surface.force_generate_chunk_requests()
 
@@ -213,7 +215,7 @@ function Public.forces()
 		end
 	end
 
-	local surface = game.surfaces["biter_battles"]
+	local surface = game.surfaces[global.bb_surface_name]
 
 	local f = game.forces["north"]
 	f.set_spawn_position({0, -44}, surface)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -103,7 +103,8 @@ end
 --Terrain Source Surface
 function Public.source_surface()
 	local map_gen_settings = {}
-	map_gen_settings.seed = math.random(1, 99999999)
+	local int_max = 2 ^ 31
+	map_gen_settings.seed = math.random(1, int_max)
 	map_gen_settings.water = math.random(15, 65) * 0.01
 	map_gen_settings.starting_area = 2.5
 	map_gen_settings.terrain_segmentation = math.random(30, 40) * 0.1

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -136,8 +136,9 @@ end
 local function on_init()
 	Init.tables()
 	Init.initial_setup()
-	Init.forces()	
-	Init.source_surface()
+	Init.playground_surface()
+	Init.forces()
+	Init.draw_structures()
 	Init.load_spawn()
 end
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -15,7 +15,7 @@ require 'maps.biter_battles_v2.commands'
 require "modules.spawners_contain_biters"
 
 local function on_player_joined_game(event)
-	local surface = game.surfaces["biter_battles"]
+	local surface = game.surfaces[global.bb_surface_name]
 	local player = game.players[event.player_index]
 	if player.online_time == 0 or player.force.name == "player" then
 		Functions.init_player(player)

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -118,7 +118,7 @@ local function process_entity(surface, entity, force_name)
 end
 
 local function copy_chunk(chunk)
-	local target_surface = game.surfaces.biter_battles
+	local target_surface = game.surfaces[global.bb_surface_name]
 	
 	local source_surface = game.surfaces.bb_source
 	local source_chunk_position = {chunk[1][1], chunk[1][2]}
@@ -169,7 +169,7 @@ local function copy_chunk(chunk)
 end
 
 local function mirror_chunk(chunk)
-	local target_surface = game.surfaces.biter_battles
+	local target_surface = game.surfaces[global.bb_surface_name]
 	
 	local source_surface = game.surfaces.bb_source
 	local source_chunk_position = {chunk[1][1], chunk[1][2] * -1 - 1}
@@ -209,7 +209,7 @@ local function mirror_chunk(chunk)
 end
 
 local function reveal_chunk(chunk)
-	local surface = game.surfaces.biter_battles
+	local surface = game.surfaces[global.bb_surface_name]
 	local chunk_position = chunk[1]
 	for _, force_name in pairs({"north", "south"}) do
 		local force = game.forces[force_name]
@@ -221,7 +221,7 @@ end
 
 function Public.add_chunk(event)
 	local surface = event.surface
-	if surface.name ~= "biter_battles" then return end
+	if surface.name ~= global.bb_surface_name then return end
 	local left_top = event.area.left_top	
 	local terrain_gen = global.terrain_gen
 	

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -425,7 +425,7 @@ function Public.generate(event)
 	local left_top_x = left_top.x
 	local left_top_y = left_top.y
 	
-	if surface.name == "biter_battles" then
+	if surface.name == global.bb_surface_name then
 		local tiles = {}
 		if math_abs(left_top_x) > 64 or math_abs(left_top_y) > 64 then
 			for k, v in pairs(loading_chunk_vectors) do tiles[k] = {name = "out-of-map", position = {left_top_x + v[1], left_top_y + v[2]}} end

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -410,7 +410,7 @@ local function mixed_ore(surface, left_top_x, left_top_y)
 	end
 	
 	if left_top_y == -32 and math_abs(left_top_x) <= 32 then
-		for _, e in pairs(surface.find_entities_filtered({area = {{-12, -12},{12, 12}}})) do e.destroy() end
+		for _, e in pairs(surface.find_entities_filtered({name = 'character', invert = true, area = {{-12, -12},{12, 12}}})) do e.destroy() end
 	end
 end
 

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -2,6 +2,7 @@ local Public = {}
 local LootRaffle = require "functions.loot_raffle"
 local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local bb_config = require "maps.biter_battles_v2.config"
+local Functions = require "maps.biter_battles_v2.functions"
 
 local table_insert = table.insert
 local math_floor = math.floor
@@ -57,7 +58,7 @@ local function shuffle(tbl)
 end
 
 local function get_noise(name, pos)
-	local seed = game.surfaces["bb_source"].map_gen_settings.seed
+	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
 	local noise_seed_add = 25000
 	if name == 1 then
 		local noise = simplex_noise(pos.x * 0.0042, pos.y * 0.0042, seed)
@@ -141,7 +142,7 @@ local function draw_noise_ore_patch(position, name, surface, radius, richness)
 	if not surface then return end
 	if not radius then return end
 	if not richness then return end
-	local seed = game.surfaces["bb_source"].map_gen_settings.seed
+	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
 	local noise_seed_add = 25000
 	local richness_part = richness / radius
 	for y = radius * -3, radius * 3, 1 do
@@ -229,29 +230,26 @@ local function generate_starting_area(pos, distance_to_center, surface)
 		if noise_2 < 0.40 then
 			if noise_2 > -0.40 then
 				if distance_from_spawn_wall > -1.75 and distance_from_spawn_wall < 0 then				
-					local e = surface.create_entity({name = "stone-wall", position = pos, force = "neutral"})
-					e.active = false
+					local e = surface.create_entity({name = "stone-wall", position = pos, force = "north"})
 				end
 			else
 				if distance_from_spawn_wall > -1.95 and distance_from_spawn_wall < 0 then				
-					local e = surface.create_entity({name = "stone-wall", position = pos, force = "neutral"})
-					e.active = false
+					local e = surface.create_entity({name = "stone-wall", position = pos, force = "north"})
 
 				elseif distance_from_spawn_wall > 0 and distance_from_spawn_wall < 4.5 then
 						local name = "wooden-chest"
 						local r_max = math_floor(math.abs(distance_from_spawn_wall)) + 2
 						if math_random(1,3) == 1 and not is_horizontal_border_river(pos) then name = name .. "-remnants" end
 						if math_random(1,r_max) == 1 then 
-							local e = surface.create_entity({name = name, position = pos, force = "neutral"})
-							e.active = false
+							local e = surface.create_entity({name = name, position = pos, force = "north"})
 						end
 
 				elseif distance_from_spawn_wall > -6 and distance_from_spawn_wall < -3 then
 					if math_random(1, 16) == 1 then
 						if surface.can_place_entity({name = "gun-turret", position = pos}) then
-							local e = surface.create_entity({name = "gun-turret", position = pos, force = "neutral"})
+							local e = surface.create_entity({name = "gun-turret", position = pos, force = "north"})
 							e.insert({name = "firearm-magazine", count = math_random(2,16)})
-							e.active = false
+							Functions.add_target_entity(e)
 						end
 					else
 						if math_random(1, 24) == 1 and not is_horizontal_border_river(pos) then
@@ -276,7 +274,6 @@ local function generate_river(surface, left_top_x, left_top_y)
 				surface.set_tiles({{name = "deepwater", position = pos}})
 				if math_random(1, 64) == 1 then 
 					local e = surface.create_entity({name = "fish", position = pos}) 
-					e.active = false
 				end
 			end
 		end
@@ -310,8 +307,7 @@ local function generate_extra_worm_turrets(surface, left_top)
 		local v = chunk_tile_vectors[math_random(1, size_of_chunk_tile_vectors)]
 		local position = surface.find_non_colliding_position(worm_turret_name, {left_top.x + v[1], left_top.y + v[2]}, 8, 1)
 		if position then
-			local worm = surface.create_entity({name = worm_turret_name, position = position, force = "enemy"})
-			worm.active = false
+			local worm = surface.create_entity({name = worm_turret_name, position = position, force = "north_biters"})
 			
 			-- add some scrap			
 			for _ = 1, math_random(0, 4), 1 do
@@ -321,7 +317,6 @@ local function generate_extra_worm_turrets(surface, left_top)
 				position = surface.find_non_colliding_position(name, position, 16, 1)									
 				if position then
 					local e = surface.create_entity({name = name, position = position, force = "neutral"})
-					e.active = false
 				end
 			end		
 		end
@@ -342,7 +337,7 @@ end
 local function draw_biter_area(surface, left_top_x, left_top_y)
 	if not is_biter_area({x = left_top_x, y = left_top_y - 96}) then return end
 	
-	local seed = game.surfaces["bb_source"].map_gen_settings.seed
+	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
 		
 	local out_of_map = {}
 	local tiles = {}
@@ -367,13 +362,13 @@ local function draw_biter_area(surface, left_top_x, left_top_y)
 		local v = chunk_tile_vectors[math_random(1, size_of_chunk_tile_vectors)]
 		local position = {x = left_top_x + v[1], y = left_top_y + v[2]}
 		if is_biter_area(position) and surface.can_place_entity({name = "spitter-spawner", position = position}) then
+			local e
 			if math_random(1, 4) == 1 then
-				local e = surface.create_entity({name = "spitter-spawner", position = position, force = "enemy"})
-				e.active = false
+				e = surface.create_entity({name = "spitter-spawner", position = position, force = "north_biters"})
 			else
-				local e = surface.create_entity({name = "biter-spawner", position = position, force = "enemy"})
-				e.active = false
+				e = surface.create_entity({name = "biter-spawner", position = position, force = "north_biters"})
 			end
+			table.insert(global.unit_spawners[e.force.name], e)
 		end
 	end
 
@@ -383,13 +378,13 @@ local function draw_biter_area(surface, left_top_x, left_top_y)
 		local position = {x = left_top_x + v[1], y = left_top_y + v[2]}
 		local worm_turret_name = BiterRaffle.roll("worm", e)
 		if is_biter_area(position) and surface.can_place_entity({name = worm_turret_name, position = position}) then			
-			surface.create_entity({name = worm_turret_name, position = position, force = "enemy"})			
+			surface.create_entity({name = worm_turret_name, position = position, force = "north_biters"})
 		end
 	end
 end
 
 local function mixed_ore(surface, left_top_x, left_top_y)
-	local seed = game.surfaces["bb_source"].map_gen_settings.seed
+	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
 	
 	local noise = GetNoise("bb_ore", {x = left_top_x + 16, y = left_top_y + 16}, seed)
 
@@ -425,32 +420,24 @@ function Public.generate(event)
 	local left_top_x = left_top.x
 	local left_top_y = left_top.y
 	
-	if surface.name == global.bb_surface_name then
+	if surface.name ~= global.bb_surface_name then return end
+	if left_top_y >= 0 then
 		local tiles = {}
 		if math_abs(left_top_x) > 64 or math_abs(left_top_y) > 64 then
 			for k, v in pairs(loading_chunk_vectors) do tiles[k] = {name = "out-of-map", position = {left_top_x + v[1], left_top_y + v[2]}} end
 		end
 		surface.set_tiles(tiles, false)
+
+		local objects = surface.find_entities(event.area)
+		for _, object in pairs(objects) do
+			if object.name ~= 'character' then
+				object.destroy()
+			end
+		end
+
 		return
 	end
 
-	if surface.name ~= "bb_source" then return end
-
-	if left_top_y == 0 then
-		local tiles = {}
-		local i = 0
-		for x = 0, 31, 1 do
-			for y = 0, 31, 1 do
-				i = i + 1
-				tiles[i] = {name = "out-of-map", position = {left_top_x + x, left_top_y + y}}
-			end
-		end
-		surface.set_tiles(tiles, false)
-		return 
-	end
-	
-	if left_top_y > 0 then return end
-	
 	mixed_ore(surface, left_top_x, left_top_y)
 	generate_river(surface, left_top_x, left_top_y)
 	draw_biter_area(surface, left_top_x, left_top_y)		
@@ -488,7 +475,6 @@ function Public.draw_spawn_circle(surface)
 		if tiles[i].name == "deepwater" then
 			if math_random(1, 48) == 1 then 
 				local e = surface.create_entity({name = "fish", position = tiles[i].position})
-				e.active = false
 			end
 		end
 	end
@@ -548,21 +534,22 @@ end
 function Public.generate_silo(surface)
 	local pos = {x = -32 + math_random(0, 64), y = -72}
 	local mirror_position = {x = pos.x * -1, y = pos.y * -1}
-	
+
 	for _, t in pairs(surface.find_tiles_filtered({area = {{pos.x - 6, pos.y - 6},{pos.x + 6, pos.y + 6}}, name = {"water", "deepwater"}})) do
 		surface.set_tiles({{name = get_replacement_tile(surface, t.position), position = t.position}})
 	end
 	for _, t in pairs(surface.find_tiles_filtered({area = {{mirror_position.x - 6, mirror_position.y - 6},{mirror_position.x + 6, mirror_position.y + 6}}, name = {"water", "deepwater"}})) do
 		surface.set_tiles({{name = get_replacement_tile(surface, t.position), position = t.position}})
 	end
-	
+
 	local silo = surface.create_entity({
 		name = "rocket-silo",
 		position = pos,
-		force = "neutral"
+		force = "north"
 	})
 	silo.minable = false
-	silo.active = false
+	global.rocket_silo[silo.force.name] = silo
+	Functions.add_target_entity(global.rocket_silo[silo.force.name])
 
 	for _ = 1, 32, 1 do
 		create_mirrored_tile_chain(surface, {name = "stone-path", position = silo.position}, 32, 10)
@@ -574,12 +561,10 @@ function Public.generate_silo(surface)
 			entity.destroy()
 		end
 	end
-	local turret1 = surface.create_entity({name = "gun-turret", position = {x=pos.x, y=pos.y-5}, force = "neutral"})
+	local turret1 = surface.create_entity({name = "gun-turret", position = {x=pos.x, y=pos.y-5}, force = "north"})
 	turret1.insert({name = "firearm-magazine", count = 10})
-	turret1.active = false
-	local turret2 = surface.create_entity({name = "gun-turret", position = {x=pos.x+2, y=pos.y-5}, force = "neutral"})
+	local turret2 = surface.create_entity({name = "gun-turret", position = {x=pos.x+2, y=pos.y-5}, force = "north"})
 	turret2.insert({name = "firearm-magazine", count = 10})
-	turret2.active = false
 end
 --[[
 function Public.generate_spawn_goodies(surface)


### PR DESCRIPTION
### Brief description of the changes:
Among small bugs that this series fixes I changed core mechanics of how map chunks are generated and cloned. These commits aim to get rid of "bb_source" surface thus cutting amount of operations at runtime by half. If these changes are applied we're looking at near instant chunk generation for north side and 2x as fast mirroring for south side.

With this series of changes I prepare the scenario for further performance improvements of map generation. The goal is to move from tick driven to event driven chunk replication in order to optimize performance further.

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.

I did what I could to test everything locally, but I did not perform any multiplayer tests.
