### PR TITLE
Remove additional teleport during game over phase

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -322,14 +322,12 @@ function Public.server_restart()
 	Init.draw_structures()
         Init.load_spawn()
 
-	local position = {0, 0}
         for _, player in pairs(game.players) do
             Functions.init_player(player)
             for _, e in pairs(player.gui.left.children) do
                 e.destroy()
             end
             Gui.create_main_gui(player)
-	    player.teleport(position, global.bb_surface_name)
         end
         game.reset_time_played()
         global.server_restart_timer = nil


### PR DESCRIPTION
### Brief description of the changes:
Removes additional teleport to fix the issue from the screenshot. The issue is that you cannot move after map reset, since everybody is in the same spot.
![bug](https://user-images.githubusercontent.com/59515242/119187238-626c3580-ba79-11eb-8342-386d9403339c.png)

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
