### PR TITLE
few commands for WE. no need revert after event end. (i think so :D )

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -259,7 +259,7 @@ function Public.refresh_threat()
 	end
 	global.gui_refresh_delay = game.tick + 5
 end
-
+global.insertcar=false
 function join_team(player, force_name, forced_join)
 	if not player.character then return end
 	if not forced_join then
@@ -331,6 +331,7 @@ function join_team(player, force_name, forced_join)
 	player.insert {name = 'iron-plate', count = 16}
 	player.insert {name = 'burner-mining-drill', count = 10}
 	player.insert {name = 'wood', count = 2}
+	if global.insertcar then player.insert {name = 'car', count = 1} end
 	global.chosen_team[player.name] = force_name
     global.spectator_rejoin_delay[player.name] = game.tick
 	player.spectator = false

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -76,28 +76,38 @@ function Public.initial_setup()
 	end
 end
 
+global.manualmapgen=false
 --Terrain Playground Surface
 function Public.playground_surface()
-	local map_gen_settings = {}
-	local int_max = 2 ^ 31
-	map_gen_settings.seed = math.random(1, int_max)
-	map_gen_settings.water = math.random(15, 65) * 0.01
-	map_gen_settings.starting_area = 2.5
-	map_gen_settings.terrain_segmentation = math.random(30, 40) * 0.1
-	map_gen_settings.cliff_settings = {cliff_elevation_interval = 0, cliff_elevation_0 = 0}
-	map_gen_settings.autoplace_controls = {
-		["coal"] = {frequency = 6.5, size = 0.34, richness = 0.24},
-		["stone"] = {frequency = 6, size = 0.35, richness = 0.25},
-		["copper-ore"] = {frequency = 7, size = 0.32, richness = 0.35},
-		["iron-ore"] = {frequency = 8.5, size = 0.8, richness = 0.23},
-		["uranium-ore"] = {frequency = 2, size = 1, richness = 1},
-		["crude-oil"] = {frequency = 8, size = 1.4, richness = 0.45},
-		["trees"] = {frequency = math.random(8, 28) * 0.1, size = math.random(6, 14) * 0.1, richness = math.random(2, 4) * 0.1},
-		["enemy-base"] = {frequency = 0, size = 0, richness = 0}
-	}
-	local surface = game.create_surface(global.bb_surface_name, map_gen_settings)
-	surface.request_to_generate_chunks({x = 0, y = -256}, 7)
-	surface.force_generate_chunk_requests()
+	if global.manualmapgen
+		then			
+			local int_max = 2 ^ 31
+			global.map_gen_settings.seed = math.random(1, int_max)
+			local surface = game.create_surface(global.bb_surface_name, global.map_gen_settings)
+			surface.request_to_generate_chunks({x = 0, y = -256}, 7)
+			surface.force_generate_chunk_requests()
+		else
+			global.map_gen_settings = {}
+			local int_max = 2 ^ 31
+			global.map_gen_settings.seed = math.random(1, int_max)
+			global.map_gen_settings.water = math.random(15, 65) * 0.01
+			global.map_gen_settings.starting_area = 2.5
+			global.map_gen_settings.terrain_segmentation = math.random(30, 40) * 0.1
+			global.map_gen_settings.cliff_settings = {cliff_elevation_interval = 0, cliff_elevation_0 = 0}
+			global.map_gen_settings.autoplace_controls = {
+				["coal"] = {frequency = 6.5, size = 0.34, richness = 0.24},
+				["stone"] = {frequency = 6, size = 0.35, richness = 0.25},
+				["copper-ore"] = {frequency = 7, size = 0.32, richness = 0.35},
+				["iron-ore"] = {frequency = 8.5, size = 0.8, richness = 0.23},
+				["uranium-ore"] = {frequency = 2, size = 1, richness = 1},
+				["crude-oil"] = {frequency = 8, size = 1.4, richness = 0.45},
+				["trees"] = {frequency = math.random(8, 28) * 0.1, size = math.random(6, 14) * 0.1, richness = math.random(2, 4) * 0.1},
+				["enemy-base"] = {frequency = 0, size = 0, richness = 0}
+			}
+			local surface = game.create_surface(global.bb_surface_name, global.map_gen_settings)
+			surface.request_to_generate_chunks({x = 0, y = -256}, 7)
+			surface.force_generate_chunk_requests()
+	end 
 end
 
 function Public.draw_structures()

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -583,6 +583,7 @@ function Public.generate_spawn_goodies(surface)
 end
 ]]
 
+global.lootmodi=0.02
 function Public.minable_wrecks(event)
 	local entity = event.entity
 	if not entity then return end
@@ -592,7 +593,7 @@ function Public.minable_wrecks(event)
 	local surface = entity.surface
 	local player = game.players[event.player_index]
 	
-	local loot_worth = math_floor(math_abs(entity.position.x * 0.02)) + math_random(16, 32)	
+	local loot_worth = math_floor(math_abs(entity.position.x * global.lootmodi)) + math_random(16, 32)	
 	local blacklist = LootRaffle.get_tech_blacklist(math_abs(entity.position.x * 0.0001) + 0.10)
 	for k, _ in pairs(loot_blacklist) do blacklist[k] = true end
 	local item_stacks = LootRaffle.roll(loot_worth, math_random(1, 3), blacklist)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -383,7 +383,9 @@ local function draw_biter_area(surface, left_top_x, left_top_y)
 	end
 end
 
+global.disablemixedores=false
 local function mixed_ore(surface, left_top_x, left_top_y)
+	if global.disablemixedores then return end
 	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
 	
 	local noise = GetNoise("bb_ore", {x = left_top_x + 16, y = left_top_y + 16}, seed)


### PR DESCRIPTION
default is false. it will work for every new match until u set it back to false.
"/c global.insertcar=true" enable car in starting items
"/c global.disablemixedores=true" disable mixed ores
"/c global.lootmodi=0.02" wrecks loot modifier. rise it to have more loot.
"/c global.manualmapgen=true" allow to overwrite map generation settings.

type this with your tweaks.
"/c
			global.map_gen_settings.water = math.random(15, 65) * 0.01
			global.map_gen_settings.starting_area = 2.5
			global.map_gen_settings.terrain_segmentation = math.random(30, 40) * 0.1
			global.map_gen_settings.cliff_settings = {cliff_elevation_interval = 0, cliff_elevation_0 = 0}
			global.map_gen_settings.autoplace_controls = {
				["coal"] = {frequency = 6.5, size = 0.34, richness = 0.24},
				["stone"] = {frequency = 6, size = 0.35, richness = 0.25},
				["copper-ore"] = {frequency = 7, size = 0.32, richness = 0.35},
				["iron-ore"] = {frequency = 8.5, size = 0.8, richness = 0.23},
				["uranium-ore"] = {frequency = 2, size = 1, richness = 1},
				["crude-oil"] = {frequency = 8, size = 1.4, richness = 0.45},
				["trees"] = {frequency = math.random(8, 28) * 0.1, size = math.random(6, 14) * 0.1, richness = math.random(2, 4) * 0.1},
				["enemy-base"] = {frequency = 0, size = 0, richness = 0}
			}"



### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
