### PR TITLE
add parameters for spawn ore in tables.lua

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -103,7 +103,8 @@ end
 function Public.draw_structures()
 	local surface = game.surfaces[global.bb_surface_name]
 	Terrain.draw_spawn_area(surface)
-	Terrain.generate_additional_spawn_ore(surface)
+	Terrain.clear_ore_in_main(surface)
+	Terrain.generate_spawn_ore(surface)
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
 	Terrain.draw_spawn_circle(surface)

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -94,6 +94,13 @@ Public.food_long_to_short = {
 	["utility-science-pack"] = {short_name= "utility", indexScience = 6},
 	["space-science-pack"] = {short_name= "space", indexScience = 7}
 }
+
+Public.spawn_ore = { --max 21 patches total
+	["iron-ore"] =      {size = 23, density = 3000, big_patches = 2, small_patches = 1},
+	["copper-ore"] =    {size = 21, density = 3000, big_patches = 1, small_patches = 2},
+	["coal"] =          {size = 22, density = 3000, big_patches = 1, small_patches = 2},
+	["stone"] =         {size = 22, density = 3000, big_patches = 1, small_patches = 1}
+}
 Public.forces_list = { "all teams", "north", "south" }
 Public.science_list = { "all science", "very high tier (space, utility, production)", "high tier (space, utility, production, chemical)", "mid+ tier (space, utility, production, chemical, military)","space","utility","production","chemical","military", "logistic", "automation" }
 Public.evofilter_list = { "all evo jump", "no 0 evo jump", "10+ only","5+ only","4+ only","3+ only","2+ only","1+ only" }

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -482,27 +482,7 @@ function Public.clear_ore_in_main(surface)
 	for _, entity in pairs(game.surfaces[global.bb_surface_name].find_entities_filtered{area = area, type = "resource"}) do
 		entity.destroy() end
 end
-function Public.generate_additional_spawn_ore(surface)
-	local r = 130
-	local area = {{r * -1, r * -1}, {r, 0}}
-	local ores = {}
-	ores["iron-ore"] = surface.count_entities_filtered({name = "iron-ore", area = area})
-	ores["copper-ore"] = surface.count_entities_filtered({name = "copper-ore", area = area})
-	ores["coal"] = surface.count_entities_filtered({name = "coal", area = area})
-	ores["stone"] = surface.count_entities_filtered({name = "stone", area = area})
-	for ore, ore_count in pairs(ores) do
-		if ore_count < 1000 or ore_count == nil then
-			local pos = {}
-			for _ = 1, 32, 1 do
-				pos = {x = -96 + math_random(0, 192), y = -20 - math_random(0, 96)}
-				if surface.can_place_entity({name = "coal", position = pos, amount = 1}) then
-					break
-				end
-			end
-			draw_noise_ore_patch(pos, ore, surface, math_random(18, 24), math_random(1500, 2000))
-		end
-	end
-end
+
 
 function Public.generate_additional_rocks(surface)
 	local r = 130

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -3,7 +3,9 @@ local LootRaffle = require "functions.loot_raffle"
 local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local bb_config = require "maps.biter_battles_v2.config"
 local Functions = require "maps.biter_battles_v2.functions"
+local tables = require "maps.biter_battles_v2.tables"
 
+local spawn_ore = tables.spawn_ore
 local table_insert = table.insert
 local math_floor = math.floor
 local math_random = math.random
@@ -483,6 +485,44 @@ function Public.clear_ore_in_main(surface)
 		entity.destroy() end
 end
 
+function Public.generate_spawn_ore(surface)
+	local area = { x = 160, y = 80 }
+	local y = 30
+	local x = -area.x/2
+	local grid_index = 1
+	local grid = {}
+	local sqy=(area.y-30)/3
+	local sqx=(area.x)/7
+	for i = 1 ,3 ,1 do
+		y = y + sqy/2
+		if i >1 then y = y + sqy end
+		for j = 1, 7, 1 do
+			x = x + sqx/2
+			if j >1 then x = x + sqx/2 end
+			grid[grid_index] = { x = math.floor( x + 0.5 ), y = - math.floor( y + 0.5 ) }            
+			grid_index = grid_index + 1
+		end
+		x = -area.x/2
+	end
+	grid = premutate_table(grid)
+	grid_index = 1
+	for ore, k in pairs(spawn_ore) do        
+		for i = 1 ,spawn_ore[ore].big_patches, 1 do
+			local ingy = grid[grid_index].y + math_floor((math_random(0,sqy)-sqy/2))
+			local ingx = grid[grid_index].x + math_floor((math_random(0,sqx)-sqx/2))
+			local pos = {x = ingx, y = ingy}          
+			draw_noise_ore_patch(pos, ore, surface, spawn_ore[ore].size, spawn_ore[ore].density)  
+			grid_index = grid_index + 1
+		end
+		for i = 1 ,spawn_ore[ore].small_patches, 1 do
+			local ingy = grid[grid_index].y + math_floor((math_random(0,sqy)-sqy/2))
+			local ingx = grid[grid_index].x + math_floor((math_random(0,sqx)-sqy/2))
+			local pos = {x = ingx, y = ingy}          
+			draw_noise_ore_patch(pos, ore, surface, spawn_ore[ore].size/2.5, spawn_ore[ore].density)  
+			grid_index = grid_index + 1
+		end        
+	end
+end
 
 function Public.generate_additional_rocks(surface)
 	local r = 130

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -477,7 +477,11 @@ function Public.draw_spawn_area(surface)
 	surface.destroy_decoratives({})
 	surface.regenerate_decorative()
 end
-
+function Public.clear_ore_in_main(surface)
+	local area = {{-150, -150}, {150, 0}}	
+	for _, entity in pairs(game.surfaces[global.bb_surface_name].find_entities_filtered{area = area, type = "resource"}) do
+		entity.destroy() end
+end
 function Public.generate_additional_spawn_ore(surface)
 	local r = 130
 	local area = {{r * -1, r * -1}, {r, 0}}

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -485,6 +485,25 @@ function Public.clear_ore_in_main(surface)
 		entity.destroy() end
 end
 
+function premutate_table(tableA)
+    local tableB = {}
+    local state
+    local rn
+    local index = 0
+    for i, v in ipairs(tableA) do index = index + 1 end
+    for i, v in ipairs(tableA) do 
+        state = true
+        while(state) do
+            rn = math_random(1,index)
+            if tableB[rn] == nil then
+                tableB[rn] = v
+                state = false
+            end    
+        end
+    end
+    return tableB
+    end
+
 function Public.generate_spawn_ore(surface)
 	local area = { x = 160, y = 80 }
 	local y = 30


### PR DESCRIPTION
### Brief description of the changes:
parameters that can be changed. 
size = 23, density = 3000, big_patches = 2, small_patches = 1

functions added:
generate_spawn_ore
premutate_table
clear_ore_in_main

deleted: generate_additional_spawn_ore

### Tested Changes:
- [x] I've tested the changes locally or with people.

