### PR TITLE
add parameters for spawn ore in tables.lua

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -103,7 +103,8 @@ end
 function Public.draw_structures()
 	local surface = game.surfaces[global.bb_surface_name]
 	Terrain.draw_spawn_area(surface)
-	Terrain.generate_additional_spawn_ore(surface)
+	Terrain.clear_ore_in_main(surface)
+	Terrain.generate_spawn_ore(surface)
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
 	Terrain.draw_spawn_circle(surface)

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -94,6 +94,18 @@ Public.food_long_to_short = {
 	["utility-science-pack"] = {short_name= "utility", indexScience = 6},
 	["space-science-pack"] = {short_name= "space", indexScience = 7}
 }
+
+Public.spawn_ore = { 
+	--size is size of the patches. default 20. recomended range 0 to 50.  
+	--density is the density of the ore. default 3000. recomended range from 0 to no limit. 
+	--big/small_patches is amout of big/small patches that will be drawn.
+	--recomended range 0 to 21. if more, they will be drawn on top of each other.
+	["iron-ore"] = {size = 23, density = 3000, big_patches = 2, small_patches = 1},
+	["copper-ore"] = {size = 21, density = 3000, big_patches = 1, small_patches = 2},
+	["coal"] = {size = 22, density = 3000, big_patches = 1, small_patches = 2},
+	["stone"] = {size = 22, density = 3000, big_patches = 1, small_patches = 2}
+}
+
 Public.forces_list = { "all teams", "north", "south" }
 Public.science_list = { "all science", "very high tier (space, utility, production)", "high tier (space, utility, production, chemical)", "mid+ tier (space, utility, production, chemical, military)","space","utility","production","chemical","military", "logistic", "automation" }
 Public.evofilter_list = { "all evo jump", "no 0 evo jump", "10+ only","5+ only","4+ only","3+ only","2+ only","1+ only" }

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -99,7 +99,7 @@ Public.spawn_ore = {
 	--size is size of the patches. default 20. recomended range 0 to 50.  
 	--density is the density of the ore. default 3000. recomended range from 0 to no limit. 
 	--big/small_patches is amout of big/small patches that will be drawn.
-	--recomended range 0 to 21. if more, they will be drawn on top of each other.
+	--recomended range 0 to 21. warning sum off big and small patches cant be higher than 21
 	["iron-ore"] = {size = 23, density = 3000, big_patches = 2, small_patches = 1},
 	["copper-ore"] = {size = 21, density = 3000, big_patches = 1, small_patches = 2},
 	["coal"] = {size = 22, density = 3000, big_patches = 1, small_patches = 2},

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -490,20 +490,6 @@ function Public.clear_ore_in_main(surface)
 	end
 end
 
-function premutate_table(tableA)
-	local tableB = {}
-	local rn
-	local index = table.maxn(tableA)
-
-	for i, v in ipairs(tableA) do		
-		repeat
-			rn = math_random(1, index)
-		until(tableB[rn] == nil)
-		tableB[rn] = v
-	end
-	return tableB
-end
-
 function generate_oref(grid,count,ore,surface,size)	
 	for i = 1, count, 1 do		
 		local idx = math.random(1, #grid)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -488,6 +488,20 @@ function Public.clear_ore_in_main(surface)
 	end
 end
 
+function premutate_table(tableA)
+	local tableB = {}
+	local rn
+	local index = table.maxn(tableA)
+
+	for i, v in ipairs(tableA) do		
+		repeat
+			rn = math_random(1, index)
+		until(tableB[rn] == nil)
+		tableB[rn] = v
+	end
+	return tableB
+end
+
 function Public.generate_additional_spawn_ore(surface)
 	local r = 130
 	local area = {{r * -1, r * -1}, {r, 0}}

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -563,28 +563,6 @@ function Public.generate_spawn_ore(surface)
 	end
 end
 
-function Public.generate_additional_spawn_ore(surface)
-	local r = 130
-	local area = {{r * -1, r * -1}, {r, 0}}
-	local ores = {}
-	ores["iron-ore"] = surface.count_entities_filtered({name = "iron-ore", area = area})
-	ores["copper-ore"] = surface.count_entities_filtered({name = "copper-ore", area = area})
-	ores["coal"] = surface.count_entities_filtered({name = "coal", area = area})
-	ores["stone"] = surface.count_entities_filtered({name = "stone", area = area})
-	for ore, ore_count in pairs(ores) do
-		if ore_count < 1000 or ore_count == nil then
-			local pos = {}
-			for _ = 1, 32, 1 do
-				pos = {x = -96 + math_random(0, 192), y = -20 - math_random(0, 96)}
-				if surface.can_place_entity({name = "coal", position = pos, amount = 1}) then
-					break
-				end
-			end
-			draw_noise_ore_patch(pos, ore, surface, math_random(18, 24), math_random(1500, 2000))
-		end
-	end
-end
-
 function Public.generate_additional_rocks(surface)
 	local r = 130
 	if surface.count_entities_filtered({type = "simple-entity", area = {{r * -1, r * -1}, {r, 0}}}) >= 12 then return end		

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -504,6 +504,15 @@ function premutate_table(tableA)
 	return tableB
 end
 
+function generate_oref(grid,count,ore,surface,size)	
+	for i = 1, count, 1 do		
+		local idx = math.random(1, #grid)
+		local pos = grid[idx]
+		table.remove(grid, idx)
+		draw_noise_ore_patch(pos, ore, surface, size, spawn_ore[ore].density)
+	end
+end
+
 function Public.generate_spawn_ore(surface)
 
 	local y

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -3,7 +3,9 @@ local LootRaffle = require "functions.loot_raffle"
 local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local bb_config = require "maps.biter_battles_v2.config"
 local Functions = require "maps.biter_battles_v2.functions"
+local tables = require "maps.biter_battles_v2.tables"
 
+local spawn_ore = tables.spawn_ore
 local table_insert = table.insert
 local math_floor = math.floor
 local math_random = math.random
@@ -500,6 +502,65 @@ function premutate_table(tableA)
 		tableB[rn] = v
 	end
 	return tableB
+end
+
+function Public.generate_spawn_ore(surface)
+
+	local y
+	local x
+	local pos
+	local grid = {
+		{x = -69, y = -38},
+		{x = -46, y = -38},
+		{x = -23, y = -38},
+		{x = 0, y = -45},
+		{x = 23, y = -38},
+		{x = 46, y = -38},
+		{x = 69, y = -38},
+		{x = -80, y = -63},
+		{x = -46, y = -63},
+		{x = -23, y = -68},
+		{x = 0, y = -78},
+		{x = 23, y = -68},
+		{x = 46, y = -63},
+		{x = 80, y = -63},
+		{x = -69, y = -88},
+		{x = -46, y = -88},
+		{x = -23, y = -100},
+		{x = 0, y = -118},
+		{x = 23, y = -100},
+		{x = 46, y = -88},
+		{x = 69, y = -88}
+	}
+	grid = premutate_table(grid)
+	grid_index = 1
+	local gridmax = table.maxn(grid)
+
+	for ore, k in pairs(spawn_ore) do 		       
+		for i = 1, spawn_ore[ore].big_patches, 1 do
+			pos = {
+				x = grid[grid_index].x + math_random(-5, 5),
+				y = grid[grid_index].y + math_random(-8, 8)
+			}            
+			draw_noise_ore_patch(pos, ore, surface, spawn_ore[ore].size, spawn_ore[ore].density)  
+			grid_index = grid_index + 1
+			if grid_index > gridmax then
+				grid_index = 1
+			end
+		end
+
+		for i = 1 ,spawn_ore[ore].small_patches, 1 do
+			pos = {
+				x = grid[grid_index].x + math_random(-5, 5),
+				y = grid[grid_index].y + math_random(-8, 8)				
+			}         
+			draw_noise_ore_patch(pos, ore, surface, spawn_ore[ore].size / 2.5, spawn_ore[ore].density)  
+			grid_index = grid_index + 1
+			if  grid_index > gridmax then
+				grid_index = 1
+			end
+		end  		      
+	end
 end
 
 function Public.generate_additional_spawn_ore(surface)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -514,61 +514,24 @@ function generate_oref(grid,count,ore,surface,size)
 end
 
 function Public.generate_spawn_ore(surface)
-
 	local y
 	local x
-	local pos
-	local grid = {
-		{x = -69, y = -38},
-		{x = -46, y = -38},
-		{x = -23, y = -38},
-		{x = 0, y = -45},
-		{x = 23, y = -38},
-		{x = 46, y = -38},
-		{x = 69, y = -38},
-		{x = -80, y = -63},
-		{x = -46, y = -63},
-		{x = -23, y = -68},
-		{x = 0, y = -78},
-		{x = 23, y = -68},
-		{x = 46, y = -63},
-		{x = 80, y = -63},
-		{x = -69, y = -88},
-		{x = -46, y = -88},
-		{x = -23, y = -100},
-		{x = 0, y = -118},
-		{x = 23, y = -100},
-		{x = 46, y = -88},
-		{x = 69, y = -88}
-	}
-	grid = premutate_table(grid)
-	grid_index = 1
-	local gridmax = table.maxn(grid)
-
-	for ore, k in pairs(spawn_ore) do 		       
-		for i = 1, spawn_ore[ore].big_patches, 1 do
-			pos = {
-				x = grid[grid_index].x + math_random(-5, 5),
-				y = grid[grid_index].y + math_random(-8, 8)
-			}            
-			draw_noise_ore_patch(pos, ore, surface, spawn_ore[ore].size, spawn_ore[ore].density)  
-			grid_index = grid_index + 1
-			if grid_index > gridmax then
-				grid_index = 1
+	local grid = {}	
+		for x = -2, 2, 1 do
+			for y = -1, -3, -1 do	
+				local f = 0 
+				if x == 0 then 
+					f = -12 
+				end		
+				 grid[#grid + 1] = {
+					 x = x * 32 + math.random(-12, 12),
+					 y = y * 32 + math.random(-24, -1) + f
+				 }	
 			end
 		end
-
-		for i = 1 ,spawn_ore[ore].small_patches, 1 do
-			pos = {
-				x = grid[grid_index].x + math_random(-5, 5),
-				y = grid[grid_index].y + math_random(-8, 8)				
-			}         
-			draw_noise_ore_patch(pos, ore, surface, spawn_ore[ore].size / 2.5, spawn_ore[ore].density)  
-			grid_index = grid_index + 1
-			if  grid_index > gridmax then
-				grid_index = 1
-			end
-		end  		      
+	for ore, k in pairs(spawn_ore) do 
+		generate_oref(grid,spawn_ore[ore].big_patches,ore,surface,spawn_ore[ore].size)
+		generate_oref(grid,spawn_ore[ore].small_patches,ore,surface,spawn_ore[ore].size/2)
 	end
 end
 

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -478,6 +478,16 @@ function Public.draw_spawn_area(surface)
 	surface.regenerate_decorative()
 end
 
+function Public.clear_ore_in_main(surface)
+	local filter = surface.find_entities_filtered{
+		area = {{-150, -150}, {150, 0}},
+		type = "resource"
+	}
+	for _, entity in pairs(filter) do
+		entity.destroy() 
+	end
+end
+
 function Public.generate_additional_spawn_ore(surface)
 	local r = 130
 	local area = {{r * -1, r * -1}, {r, 0}}


### PR DESCRIPTION
Brief description of the changes:
parameters that can be changed.
size = 23, density = 3000, big_patches = 2, small_patches = 1

functions added:
generate_spawn_ore
premutate_table
clear_ore_in_main

deleted: generate_additional_spawn_ore

### Tested Changes:
- [x] I've tested the changes locally or with people.
