### PR TITLE
Add support for configurable spawn area ore patches

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -104,7 +104,8 @@ end
 function Public.draw_structures()
 	local surface = game.surfaces[global.bb_surface_name]
 	Terrain.draw_spawn_area(surface)
-	Terrain.generate_additional_spawn_ore(surface)
+	Terrain.clear_ore_in_main(surface)
+	Terrain.generate_spawn_ore(surface)
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
 	Terrain.draw_spawn_circle(surface)

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -94,6 +94,48 @@ Public.food_long_to_short = {
 	["utility-science-pack"] = {short_name= "utility", indexScience = 6},
 	["space-science-pack"] = {short_name= "space", indexScience = 7}
 }
+
+-- This array contains parameters for spawn area ore patches.
+-- These are non-standard units and they do not map to values used in factorio
+-- map generation. They are only used internally by scenario logic.
+Public.spawn_ore = {
+	-- Value "size" is a parameter used as coefficient for simplex noise
+	-- function that is applied to shape of an ore patch. You can think of it
+	-- as size of a patch on average. Recomended range is from 1 up to 50.
+
+	-- Value "density" controls the amount of resource in a single tile.
+	-- The center of an ore patch contains specified amount and is decreased
+	-- proportionally to distance from center of the patch.
+
+	-- Value "big_patches" and "small_patches" represents a number of an ore
+	-- patches of given type. The "density" is applied with the same rule
+	-- regardless of the patch size.
+	["iron-ore"] = {
+		size = 23,
+		density = 3000,
+		big_patches = 2,
+		small_patches = 1
+	},
+	["copper-ore"] = {
+		size = 21,
+		density = 3000,
+		big_patches = 1,
+		small_patches = 2
+	},
+	["coal"] = {
+		size = 22,
+		density = 3000,
+		big_patches = 1,
+		small_patches = 2
+	},
+	["stone"] = {
+		size = 22,
+		density = 3000,
+		big_patches = 1,
+		small_patches = 2
+	}
+}
+
 Public.forces_list = { "all teams", "north", "south" }
 Public.science_list = { "all science", "very high tier (space, utility, production)", "high tier (space, utility, production, chemical)", "mid+ tier (space, utility, production, chemical, military)","space","utility","production","chemical","military", "logistic", "automation" }
 Public.evofilter_list = { "all evo jump", "no 0 evo jump", "10+ only","5+ only","4+ only","3+ only","2+ only","1+ only" }

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -112,7 +112,7 @@ Public.spawn_ore = {
 	-- regardless of the patch size.
 	["iron-ore"] = {
 		size = 23,
-		density = 3000,
+		density = 3500,
 		big_patches = 2,
 		small_patches = 1
 	},
@@ -124,15 +124,15 @@ Public.spawn_ore = {
 	},
 	["coal"] = {
 		size = 22,
-		density = 3000,
+		density = 2500,
 		big_patches = 1,
-		small_patches = 2
+		small_patches = 1
 	},
 	["stone"] = {
-		size = 22,
-		density = 3000,
+		size = 20,
+		density = 2000,
 		big_patches = 1,
-		small_patches = 2
+		small_patches = 0
 	}
 }
 

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -480,27 +480,6 @@ function Public.draw_spawn_area(surface)
 	surface.regenerate_decorative()
 end
 
-function Public.generate_additional_spawn_ore(surface)
-	local r = 130
-	local area = {{r * -1, r * -1}, {r, 0}}
-	local ores = {}
-	ores["iron-ore"] = surface.count_entities_filtered({name = "iron-ore", area = area})
-	ores["copper-ore"] = surface.count_entities_filtered({name = "copper-ore", area = area})
-	ores["coal"] = surface.count_entities_filtered({name = "coal", area = area})
-	ores["stone"] = surface.count_entities_filtered({name = "stone", area = area})
-	for ore, ore_count in pairs(ores) do
-		if ore_count < 1000 or ore_count == nil then
-			local pos = {}
-			for _ = 1, 32, 1 do
-				pos = {x = -96 + math_random(0, 192), y = -20 - math_random(0, 96)}
-				if surface.can_place_entity({name = "coal", position = pos, amount = 1}) then
-					break
-				end
-			end
-			draw_noise_ore_patch(pos, ore, surface, math_random(18, 24), math_random(1500, 2000))
-		end
-	end
-end
 
 
 


### PR DESCRIPTION
### Brief description of the changes:
Continuation of: https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/175
Max requested help from me to properly rebase and apply my remarks to commits.
I took the liberty to simplify further some code areas and write additional code comments.

This change brings configurable spawn area ores system. As a consequence of this change all starting area ores are erased and ores specified within `tables.lua` script are drawn. It makes this change functional and ore density, amount of patches will differ. That's why I applied additional balancing patch.

### Tested Changes:
- [X] I've tested the changes locally or with people.
