### PR TITLE
Remove all turrets from target pool

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -149,11 +149,7 @@ local target_entity_types = {
 	["reactor"] = true,
 	["roboport"] = true,
 	["rocket-silo"] = true,
-	["ammo-turret"] = true,
-	["artillery-turret"] = true,
 	["beacon"] = true,
-	["electric-turret"] = true,
-	["fluid-turret"] = true,
 }
 
 local spawn_positions = {}

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -84,8 +84,6 @@ function Public.invert_entity(event)
 	if destination.name == "rocket-silo" then
 		global.rocket_silo[destination.force.name] = destination
 		Functions.add_target_entity(destination)
-	elseif destination.name == "gun-turret" then
-		Functions.add_target_entity(destination)
 	elseif destination.name == "spitter-spawner" or destination.name == 'biter-spawner' then
 		table_insert(global.unit_spawners[destination.force.name], destination)
 	end

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -251,7 +251,6 @@ local function generate_starting_area(pos, distance_to_center, surface)
 						if surface.can_place_entity({name = "gun-turret", position = pos}) then
 							local e = surface.create_entity({name = "gun-turret", position = pos, force = "north"})
 							e.insert({name = "firearm-magazine", count = math_random(2,16)})
-							Functions.add_target_entity(e)
 						end
 					else
 						if math_random(1, 24) == 1 and not is_horizontal_border_river(pos) then


### PR DESCRIPTION
### Brief description of the changes:
Currently target pool in mid and late game is dominated by entities
of turret type. This makes biters behave dumber as they're much more
likely to target turrets next to a wall. As a consequence they throw
themselves at the most well defended part of a wall instead of going
around it and exploiting obvious pathways to a silo.

This change removes turrets of any kind from target pool. In principle
it should make biters act smarter and attack at lower angles. In my
testing on large maps with all kinds of turrets removed from the pool
pathfinder starts prioritizing holes and thin walls.

### Tested Changes:
- [X] I've tested the changes locally or with people.
