### PR TITLE
Fix evo reset when admins change difficulty

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -463,7 +463,7 @@ end
 
 Public.reset_evo = function()
 	-- Shouldn't reset evo if any of the teams fed. Feeding is blocked when voting is in progress.
-	if game.ticks_played >= 7200 then return end
+	if game.ticks_played >= global.difficulty_votes_timeout then return end
 
 	local amount = global.total_passive_feed_redpotion
 	if amount < 1 then return end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -462,6 +462,9 @@ Public.raise_evo = function()
 end
 
 Public.reset_evo = function()
+	-- Shouldn't reset evo if any of the teams fed. Feeding is blocked when voting is in progress.
+	if game.ticks_played >= 7200 then return end
+
 	local amount = global.total_passive_feed_redpotion
 	if amount < 1 then return end
 	global.total_passive_feed_redpotion = 0


### PR DESCRIPTION
Evo reset was introduced to readjust evo/threat increase when vote is still in progress and neither team can feed. It was broken, because it ignored feeds from both teams (evo was reset to values from passive feed only).

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
