### PR TITLE
Fix tags position

### DIFF
--- a/modules/simple_tags.lua
+++ b/modules/simple_tags.lua
@@ -21,14 +21,14 @@ local checks = {
 
 local function get_x_offset(player)
 	local x = 0
-	for _, element in pairs(player.gui.top.children) do
-		if element.name == "simple_tag" then break end		
+	for _, element in pairs(player.gui.top.children) do	
 		local style = element.style
 		for _, v in pairs(checks) do
 			if style[v] then
 				x = x + style[v]
 			end
 		end
+		if element.name == "simple_tag" then break end	
 	end
 	return x
 end


### PR DESCRIPTION
Fix that tag list opens under Tag button.
![bb-tags](https://user-images.githubusercontent.com/88335092/127893398-15a5adb8-4c70-448f-bbc5-23a4e8b3f831.png)


### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
