### PR TITLE
Allow freed players to participate in jail votes

### DIFF
--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -254,11 +254,6 @@ local validate_args = function(data)
         return false
     end
 
-    if votefree[player.name] and not player.admin then
-        Utils.print_to(player, 'You are currently being investigated since you have griefed.')
-        return false
-    end
-
     if jailed[player.name] and not player.admin then
         Utils.print_to(player, 'You are jailed, you can´t run this command.')
         return false


### PR DESCRIPTION
### Brief description of the changes:
As discussed in discord #support, untrusted players should be barred
from jail voting through the existing "trusted" check. Freed and
trusted players should be able to jail vote.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
