### PR TITLE
Whitelist wall, offshore-pump and boiler for entity mining logs

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -42,6 +42,12 @@ local this = {
     explosive_threshold = 16
 }
 
+this.whitelist_types = {
+    ['wall'] = true,
+    ['offshore-pump'] = true,
+    ['boiler'] = true,
+}
+
 local blacklisted_types = {
     ['transport-belt'] = true,
     ['wall'] = true,


### PR DESCRIPTION
### Brief description of the changes:
Whitelist wall, offshore-pump and boiler for entity mining logs. The whitelist was previously empty kekw.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
