### PR TITLE
Top gui visual cleanup

### DIFF
--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -68,7 +68,9 @@ local function top_button(player)
     local button =
         player.gui.top.add({type = 'sprite-button', name = 'comfy_panel_top_button', sprite = 'item/raw-fish'})
     button.style.minimal_height = 38
+    button.style.maximal_height = 38
     button.style.minimal_width = 38
+    button.style.maximal_width = 38
     button.style.padding = -2
 end
 

--- a/comfy_panel/poll.lua
+++ b/comfy_panel/poll.lua
@@ -826,12 +826,17 @@ local function player_joined(event)
             update_poll_viewer(data)
         end
     else
-        player.gui.top.add {
+        local button = player.gui.top.add {
             type = 'sprite-button',
             name = main_button_name,
             sprite = 'item/programmable-speaker',
             tooltip = 'Let your question be heard!'
         }
+        button.style.minimal_width = 38
+        button.style.maximal_width = 38
+        button.style.minimal_height = 38
+        button.style.maximal_height = 38
+        button.style.padding = -2
     end
 end
 

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -15,7 +15,9 @@ local function difficulty_gui()
 		b.style.font = "heading-2"
 		b.style.font_color = difficulties[global.difficulty_vote_index].print_color
 		b.style.minimal_height = 38
+		b.style.maximal_height = 38
 		b.style.minimal_width = 96
+		b.style.padding = -2
 	end
 end
 

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -387,11 +387,10 @@ function Public.create_map_intro_button(player)
 	b.style.font_color = {r=0.5, g=0.3, b=0.99}
 	b.style.font = "heading-1"
 	b.style.minimal_height = 38
+	b.style.maximal_height = 38
 	b.style.minimal_width = 38
-	b.style.top_padding = 1
-	b.style.left_padding = 1
-	b.style.right_padding = 1
-	b.style.bottom_padding = 1
+	b.style.maximal_width = 38
+	b.style.padding = -2
 end
 
 function Public.show_intro(player)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -42,7 +42,9 @@ local function create_sprite_button(player)
 	local button = player.gui.top.add({type = "sprite-button", name = "bb_toggle_button", sprite = "entity/big-biter"})
 	button.style.font = "default-bold"
 	button.style.minimal_height = 38
+	button.style.maximal_height = 38
 	button.style.minimal_width = 38
+	button.style.maximal_width = 38
 	button.style.padding = -1
 end
 

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -100,11 +100,9 @@ function Public.draw_top_toggle_button(player)
 	button.style.font = "heading-2"
 	button.style.font_color = {r = 0.88, g = 0.55, b = 0.11}
 	button.style.minimal_height = 38
+	button.style.maximal_height = 38
 	button.style.minimal_width = 120
-	button.style.top_padding = 2
-	button.style.left_padding = 0
-	button.style.right_padding = 0
-	button.style.bottom_padding = 2
+	button.style.padding = -2
 end
 
 local function draw_manager_gui(player)

--- a/modules/simple_tags.lua
+++ b/modules/simple_tags.lua
@@ -39,7 +39,9 @@ local function draw_top_gui(player)
 	button.style.font = "heading-2"
 	button.style.font_color = {212, 212, 212}
 	button.style.minimal_height = 38
+	button.style.maximal_height = 38
 	button.style.minimal_width = 38
+	button.style.maximal_width = 38
 	button.style.padding = -2
 end
 
@@ -55,14 +57,17 @@ local function draw_screen_gui(player)
 		name = "simple_tag_frame",
 		direction = "vertical",
 	})	
-	frame.location = {x = get_x_offset(player), y = 39}
-	frame.style.padding = -1	
+	frame.location = {x = get_x_offset(player) * player.display_scale - 2, y = 39 * player.display_scale}
+	frame.style.padding = -2
+	frame.style.maximal_width = 42
 	
 	for _, v in pairs(icons) do
 		local button = frame.add({type = "sprite-button", name = v[1], sprite = v[2], tooltip = v[3]})
 		button.style.minimal_height = 38
+		button.style.maximal_height = 38
 		button.style.minimal_width = 38
-		button.style.padding = -1
+		button.style.maximal_width = 38
+		button.style.padding = -2
 	end
 	
 	local tag = player.tag


### PR DESCRIPTION
### Brief description of the changes:

- All buttons from top menu are now 38x38 (or _x38)
- Tags drop-list now drops in the right place, and works with custom gui scale.

### Tested Changes:
- [X] I've tested the changes locally.
- [ ] I've not tested the changes.
