### PR TITLE
Remove vehicle from silo

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -203,6 +203,24 @@ local function on_area_cloned(event)
 	end
 end
 
+local function on_rocket_launch_ordered(event)
+	local vehicles = {
+		["car"] = true,
+		["tank"] = true,
+		["locomotive"] = true,
+		["cargo-wagon"] = true,
+		["fluid-wagon"] = true,
+		["spidertron"] = true,
+	}
+	local inventory = event.rocket.get_inventory(defines.inventory.fuel)
+	local contents = inventory.get_contents()
+	for name, _ in pairs(contents) do
+		if vehicles[name] then
+			inventory.clear()
+		end
+	end
+end
+
 local function clear_corpses(cmd)
 	local player = game.player
         local trusted = Session.get_trusted_table()
@@ -259,6 +277,7 @@ local function on_init()
 end
 
 local Event = require 'utils.event'
+Event.add(defines.events.on_rocket_launch_ordered, on_rocket_launch_ordered)
 Event.add(defines.events.on_area_cloned, on_area_cloned)
 Event.add(defines.events.on_research_finished, Ai.unlock_satellite)			--free silo space tech
 Event.add(defines.events.on_post_entity_died, Ai.schedule_reanimate)


### PR DESCRIPTION
Remove a vehicle from rocket silo before launching the rocket to prevent the player from riding it.  A more humane alternative than #204 
### Tested Changes:
- [X] I've tested the changes locally.
- [ ] I've not tested the changes.
