### PR TITLE
Change text warning to accurately reflect mechanics

### DIFF
--- a/chatbot.lua
+++ b/chatbot.lua
@@ -18,7 +18,7 @@ local brain = {
     },
     [3] = {'Scenario repository for download:', 'https://github.com/1pulse/Factorio-Biter-Battles'},
     [4] = {
-        "If you're not trusted - ask a trusted player or an admin to trust you."
+        "If you're not trusted - ask an admin to trust you."
     },
     [5] = {
         'Need a guide to help learn the server?',

--- a/chatbot.lua
+++ b/chatbot.lua
@@ -18,7 +18,7 @@ local brain = {
     },
     [3] = {'Scenario repository for download:', 'https://github.com/1pulse/Factorio-Biter-Battles'},
     [4] = {
-        "If you're not trusted - ask an admin to trust you."
+        "If you're not trusted and have been playing here for awhile, ask an admin to trust you.  Use the /admins command to see if any are available."
     },
     [5] = {
         'Need a guide to help learn the server?',


### PR DESCRIPTION
### Brief description of the changes:
When the word trust is mentioned, the server indicates to the user that they should ask a trusted player or admin to trust them.  Trusted players however no longer have the ability to trust other players.  I'm assuming this is an admin-only capability.  As such I've modified the warning text to reflect this.

Primarily, I am just learning how to contribute and learn the Biter Battle's development workflow to contribute in a more meaningful way going forward.  Am I doing it right?

### Tested Changes:
- [X] I've tested the changes locally **They have no effect on gameplay**.
- [ ] I've not tested the changes.
