### PR TITLE
Remove game.tick check

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -281,9 +281,6 @@ local function on_built_entity(event)
     end
     local tracker = session.get_session_table()
     local trusted = session.get_trusted_table()
-    if game.tick < 1296000 then
-        return
-    end
 
     if event.created_entity.type == 'entity-ghost' then
         local player = game.get_player(event.player_index)

--- a/antigrief.lua
+++ b/antigrief.lua
@@ -186,14 +186,8 @@ local function on_marked_for_deconstruction(event)
         return
     end
 
-    local playtime = player.online_time
-    if tracker[player.name] then
-        playtime = player.online_time + tracker[player.name]
-    end
-    if playtime < 2592000 then
-        event.entity.cancel_deconstruction(game.get_player(event.player_index).force.name)
-        player.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
-    end
+    event.entity.cancel_deconstruction(game.get_player(event.player_index).force.name)
+    player.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
 end
 
 local function on_player_ammo_inventory_changed(event)
@@ -292,15 +286,8 @@ local function on_built_entity(event)
             return
         end
 
-        local playtime = player.online_time
-        if tracker[player.name] then
-            playtime = player.online_time + tracker[player.name]
-        end
-
-        if playtime < 432000 then
-            event.created_entity.destroy()
-            player.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
-        end
+        event.created_entity.destroy()
+        player.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
     end
 end
 


### PR DESCRIPTION
I'm pretty new to this fellas, but I'm not sure I understand why this is here? Anyone can place ghosts if it's before a certain time?  Does this resolve issue #213?

### Brief description of the changes:
There is a check when a player places an entity (ghost or otherwise) for game.tick to be under a certain value.  I don't understand why this is here?  Is this something completely unrelated to issue #213 or does this resolve it?

### Tested Changes:
- [X] I've tested the changes locally with multiple players.  I setup a local server with two players.  One hosting as admin and the other as an untrusted player.  I could not create ghost entities after this change as the untrusted player and I still could as the admin.  Once trusted, the player could place ghosts again.
- [ ] I've not tested the changes.
