### PR TITLE
Add a window that tells players the number of flasks to get to each next level

### DIFF
--- a/maps/biter_battles_v2/biter_raffle.lua
+++ b/maps/biter_battles_v2/biter_raffle.lua
@@ -1,21 +1,38 @@
 local Public = {}
 local math_random = math.random
 local math_floor = math.floor
+local Tables = require "maps.biter_battles_v2.tables"
+
+local function linear_biter_function(x, slope, x_intercept)
+	-- x_intercept == evo when this biter starts appearing
+	-- (or dissapearing for small-biters)
+	return slope *(x - x_intercept)
+end
+
+local function initial_medium_biter_function(level, slope, x_intercept)
+end
 
 local function get_raffle_table(level, name)
+	-- thresholds
+	local small_thr = Tables.biter_mutagen_thresholds["small"]
+	local medium_thr = Tables.biter_mutagen_thresholds["medium"]
+	local big_thr = Tables.biter_mutagen_thresholds["big"]
+	local behemoth_thr = Tables.biter_mutagen_thresholds["behemoth"]
+
 	local raffle = {
-		["small-" .. name] = 1000 - level * 1.75,		
-		["medium-" .. name] = -250 + level * 1.5,
-		["big-" .. name] = 0,		
+		["small-" .. name] = linear_biter_function(level, Tables.biter_mutagen_initial_slopes["small"], 1000/1.75),
+		["medium-" .. name] = initial_medium_biter_function(level, 1.5, medium_thr),
+		["big-" .. name] = 0,
 		["behemoth-" .. name] = 0,
 	}
 	
-	if level > 500 then
-		raffle["medium-" .. name] = 500 - (level - 500)
-		raffle["big-" .. name] = (level - 500) * 2
+	if level > big_thr then
+		raffle["medium-" .. name] = big_thr - (level - big_thr)
+		raffle["big-" .. name] = linear_biter_function(level, Tables.biter_mutagen_initial_slopes["big"], big_thr)
 	end
-	if level > 900 then
-		raffle["behemoth-" .. name] = (level - 900) * 8
+
+	if level > behemoth_thr then
+		raffle["behemoth-" .. name] = linear_biter_function(level, Tables.biter_mutagen_initial_slopes["behemoth"], behemoth_thr)
 	end
 	for k, _ in pairs(raffle) do
 		if raffle[k] < 0 then raffle[k] = 0 end
@@ -41,15 +58,15 @@ local function get_biter_name(evolution_factor)
 	return roll(evolution_factor, "biter")
 end
 
-local function get_spitter_name(evolution_factor)	
-	return roll(evolution_factor, "spitter")	
+local function get_spitter_name(evolution_factor)
+	return roll(evolution_factor, "spitter")
 end
 
 local function get_worm_raffle_table(level)
 	local raffle = {
-		["small-worm-turret"] = 1000 - level * 1.75,		
-		["medium-worm-turret"] = level,		
-		["big-worm-turret"] = 0,		
+		["small-worm-turret"] = 1000 - level * 1.75,
+		["medium-worm-turret"] = level,
+		["big-worm-turret"] = 0,
 		["behemoth-worm-turret"] = 0,
 	}
 	

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -5,7 +5,7 @@ local bb_config = require "maps.biter_battles_v2.config"
 local bb_diff = require "maps.biter_battles_v2.difficulty_vote"
 local event = require 'utils.event'
 local Functions = require "maps.biter_battles_v2.functions"
-local feed_the_biters = require "maps.biter_battles_v2.feeding"
+local Feeding = require "maps.biter_battles_v2.feeding"
 local Tables = require "maps.biter_battles_v2.tables"
 
 local wait_messages = Tables.wait_messages
@@ -471,7 +471,7 @@ local function on_gui_click(event)
 
 	if name == "raw-fish" then Functions.spy_fish(player, event) return end
 
-	if food_names[name] then feed_the_biters(player, name) return end
+	if food_names[name] then Feeding.feed_biters(player, name) return end
 
 	if name == "bb_leave_spectate" then join_team(player, global.chosen_team[player.name])	end
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -7,6 +7,7 @@ local Gui = require "maps.biter_battles_v2.gui"
 local Init = require "maps.biter_battles_v2.init"
 local Mirror_terrain = require "maps.biter_battles_v2.mirror_terrain"
 require 'modules.simple_tags'
+require 'modules.simple_stats'
 local Team_manager = require "maps.biter_battles_v2.team_manager"
 local Terrain = require "maps.biter_battles_v2.terrain"
 local Session = require 'utils.datastore.session_data'

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -147,6 +147,22 @@ Public.difficulties = {
 	[7] = {name = "Fun and Fast", str = "500%", value = 5, color = {r=0.55, g=0.00, b=0.00}, print_color = {r=0.9, g=0.0, b=0.00}}
 }
 
+Public.biter_mutagen_initial_slopes = {
+	["small"] = -1.75,
+	["medium"] = 1.5,
+	["big"] = 2,
+	["behemoth"] = 8,
+}
+
+-- Minimum mutagen to see each biter size
+Public.biter_mutagen_thresholds = {
+	["small"] = 0,
+	["medium"] = 250/Public.biter_mutagen_initial_slopes["medium"],
+	["big"] = 500,
+	["behemoth"] = 900,
+}
+
+
 Public.forces_list = { "all teams", "north", "south" }
 Public.science_list = { "all science", "very high tier (space, utility, production)", "high tier (space, utility, production, chemical)", "mid+ tier (space, utility, production, chemical, military)","space","utility","production","chemical","military", "logistic", "automation" }
 Public.evofilter_list = { "all evo jump", "no 0 evo jump", "10+ only","5+ only","4+ only","3+ only","2+ only","1+ only" }

--- a/modules/simple_stats.lua
+++ b/modules/simple_stats.lua
@@ -5,33 +5,6 @@ local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local Feeding = require "maps.biter_battles_v2.feeding"
 local Tables = require "maps.biter_battles_v2.tables"
 require 'utils.gui_styles'
-local icons = {
-
-	{"[img=item/chemical-science-pack]", "item/chemical-science-pack", "Science"},
-	{"[img=item/locomotive]", "item/locomotive", "Trainman"},	
-	{"[img=fluid/crude-oil]", "fluid/crude-oil", "Oil processing"},	
-	{"[img=item/submachine-gun]", "item/submachine-gun", "Trooper"},
-	{"[img=item/stone-wall]", "item/stone-wall", "Fortifications"},
-	{"[img=item/repair-pack]", "item/repair-pack", "Support"},	
-}
-
-local checks = {
-	"minimal_width", "left_margin", "right_margin"
-}
-
-local function get_x_offset(player)
-	local x = 0
-	for _, element in pairs(player.gui.top.children) do
-		if element.name == "simple_stats" then break end
-		local style = element.style
-		for _, v in pairs(checks) do
-			if style[v] then
-				x = x + style[v]
-			end
-		end
-	end
-	return x
-end
 
 local function draw_top_gui(player)
 	if player.gui.top.simple_stats then return end
@@ -54,7 +27,6 @@ local function get_upcoming_biter_tier_list_from_current_evo(evo)
 	end
 	return biters_tiers
 end
-
 
 local function calculate_needed_food(biter_force_name, current_threshold, current_evo, current_evo_factor, food_value, player)
 	local evo = current_evo
@@ -95,49 +67,17 @@ local function add_biter_puberty_thresholds_for_team(t, team, player)
 		t.add({type="sprite", sprite="entity/"..v.."-biter"})
 		for kk, vv in pairs(Tables.food_values) do
 			local needed = calculate_needed_food(biter_force_name, c_threshold, current_evo, current_evo_factor, vv.value*global.difficulty_vote_value, player)
-			--player.print("k "..kk.." current_evo "..current_evo.." y val "..vv.value.." thresh "..c_threshold)
 			t.add({type="label", caption=string.format("%7d", needed)})
 		end
 	end
 	for _=1,8 do t.add({type="label", caption= ""}) end
-	--t.add({type="label", caption= ""})
-
-	--local l = t.add({ type="label", caption = "Current evolution: " .. tostring(global.bb_evolution[biter_id])})
-	--for _=1,6 do t.add({type="label", caption= ""}) end
 end
 
 local function add_biter_puberty_thresholds_to_table(t, player)
-	player.print("north "..global.bb_evolution["north_biters"])
-	player.print("south "..global.bb_evolution["south_biters"])
 	for _, x in pairs({"north", "south"}) do
 		add_biter_puberty_thresholds_for_team(t, x, player)
 	end
---Number of Flasks to reach the next biter tier for " .. player.force.name
-
-
-
---Number of Flasks to reach next biter tier
---
---team id, red sci icon, green sci icon, etc
---small, 
---med,
---large, 
---.. global.bb_evolution[biter_force_name]+10*3.0
 end
-
-function dump(o)
-   if type(o) == 'table' then
-      local s = '{ '
-      for k,v in pairs(o) do
-         if type(k) ~= 'number' then k = '"'..k..'"' end
-         s = s .. '['..k..'] = ' .. dump(v) .. ','
-      end
-      return s .. '} '
-   else
-      return tostring(o)
-   end
-end
-
 
 local function draw_screen_gui(player)
 	local frame = player.gui.screen.simple_stats_frame
@@ -155,19 +95,6 @@ local function draw_screen_gui(player)
 	frame.location = {x = 3, y = 39 * player.display_scale}
 	frame.style.padding = -2
 	add_biter_puberty_thresholds_to_table(t, player)
-
---	local l = t.add  { type = "label", caption = "banana Players "}
---	l.style.font_color = { r=0.22, g=0.88, b=0.22}
-----	frame.style.maximal_width = 42
---	local l2 = t.add  { type = "label", caption = "strawberry players"}
---	l2.style.font_color = { r=0.88, g=0.88, b=0.22}
---	local l3 = t.add  { type = "label", caption = "liquid players"}
---	l3.style.font_color = { r=0.88, g=0.88, b=0.22}
---	local unit_name = BiterRaffle.roll("spitter", global.bb_evolution["north"])
---	local l4 = t.add  { type = "label", caption = unit_name}
---	l4.style.font_color = { r=0.88, g=0.88, b=0.22}
---	local l5 = t.add  { type = "label", caption = global.bb_evolution["north"]}
---	l5.style.font_color = { r=0.88, g=0.88, b=0.22}
 end
 
 local function on_player_joined_game(event)

--- a/modules/simple_stats.lua
+++ b/modules/simple_stats.lua
@@ -1,0 +1,206 @@
+--Adds a small gui to quick select an icon tag for your character - mewmew
+
+local Event = require 'utils.event'
+local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
+local Feeding = require "maps.biter_battles_v2.feeding"
+local Tables = require "maps.biter_battles_v2.tables"
+require 'utils.gui_styles'
+local icons = {
+
+	{"[img=item/chemical-science-pack]", "item/chemical-science-pack", "Science"},
+	{"[img=item/locomotive]", "item/locomotive", "Trainman"},	
+	{"[img=fluid/crude-oil]", "fluid/crude-oil", "Oil processing"},	
+	{"[img=item/submachine-gun]", "item/submachine-gun", "Trooper"},
+	{"[img=item/stone-wall]", "item/stone-wall", "Fortifications"},
+	{"[img=item/repair-pack]", "item/repair-pack", "Support"},	
+}
+
+local checks = {
+	"minimal_width", "left_margin", "right_margin"
+}
+
+local function get_x_offset(player)
+	local x = 0
+	for _, element in pairs(player.gui.top.children) do
+		if element.name == "simple_stats" then break end
+		local style = element.style
+		for _, v in pairs(checks) do
+			if style[v] then
+				x = x + style[v]
+			end
+		end
+	end
+	return x
+end
+
+local function draw_top_gui(player)
+	if player.gui.top.simple_stats then return end
+	local button = player.gui.top.add({type = "sprite-button", name = "simple_stats", caption = "Stats"})
+	button.style.font = "heading-2"
+	button.style.font_color = {212, 212, 212}
+	element_style({element = button, x = 38, y = 38, pad = -2})
+end
+
+local function get_upcoming_biter_tier_list_from_current_evo(evo)
+	local biters_tiers = {}
+	if evo < Tables.biter_mutagen_thresholds["medium"] then
+		table.insert(biters_tiers, "medium")
+	end
+	if evo < Tables.biter_mutagen_thresholds["big"] then
+		table.insert(biters_tiers, "big")
+	end
+	if evo < Tables.biter_mutagen_thresholds["behemoth"] then
+		table.insert(biters_tiers, "behemoth")
+	end
+	return biters_tiers
+end
+
+
+local function calculate_needed_food(biter_force_name, current_threshold, current_evo, current_evo_factor, food_value, player)
+	local evo = current_evo
+	local evo_factor = current_evo_factor
+	local count = 0
+	while (evo*1000 < current_threshold) do
+		local e2 = Feeding.calculate_e2(evo_factor)
+		local evo_gain = Feeding.evo_gain_from_one_flask(food_value, e2)
+		evo = evo + evo_gain
+		evo_factor = Feeding.get_new_evo_factor_from_evolution(evo)
+		count = count + 1
+	end
+	return count
+end
+
+local function add_biter_puberty_thresholds_for_team(t, team, player)
+	local biter_force_name = team.."_biters"
+	local current_evo = global.bb_evolution[biter_force_name]
+	local current_evo_factor = game.forces[biter_force_name].evolution_factor
+	local upcoming_biter_list = get_upcoming_biter_tier_list_from_current_evo(current_evo)
+	if #upcoming_biter_list == 0 then
+		return
+	end
+
+	local l = t.add({ type="label", caption = team })
+	for _=1,7 do t.add({type="label", caption= ""}) end
+
+	local l = t.add({ type="label", caption = "Evo: " .. tostring(global.bb_evolution[biter_force_name]*100)})
+	for _=1,7 do t.add({type="label", caption= ""}) end
+
+	t.add({type="label", caption= ""})
+	for k, v in pairs(Tables.food_values) do
+		t.add({type="sprite", sprite="item/"..k})
+	end
+
+	for _, v in ipairs(upcoming_biter_list) do
+		local c_threshold = Tables.biter_mutagen_thresholds[v]
+		t.add({type="sprite", sprite="entity/"..v.."-biter"})
+		for kk, vv in pairs(Tables.food_values) do
+			local needed = calculate_needed_food(biter_force_name, c_threshold, current_evo, current_evo_factor, vv.value*global.difficulty_vote_value, player)
+			--player.print("k "..kk.." current_evo "..current_evo.." y val "..vv.value.." thresh "..c_threshold)
+			t.add({type="label", caption=string.format("%7d", needed)})
+		end
+	end
+	for _=1,8 do t.add({type="label", caption= ""}) end
+	--t.add({type="label", caption= ""})
+
+	--local l = t.add({ type="label", caption = "Current evolution: " .. tostring(global.bb_evolution[biter_id])})
+	--for _=1,6 do t.add({type="label", caption= ""}) end
+end
+
+local function add_biter_puberty_thresholds_to_table(t, player)
+	player.print("north "..global.bb_evolution["north_biters"])
+	player.print("south "..global.bb_evolution["south_biters"])
+	for _, x in pairs({"north", "south"}) do
+		add_biter_puberty_thresholds_for_team(t, x, player)
+	end
+--Number of Flasks to reach the next biter tier for " .. player.force.name
+
+
+
+--Number of Flasks to reach next biter tier
+--
+--team id, red sci icon, green sci icon, etc
+--small, 
+--med,
+--large, 
+--.. global.bb_evolution[biter_force_name]+10*3.0
+end
+
+function dump(o)
+   if type(o) == 'table' then
+      local s = '{ '
+      for k,v in pairs(o) do
+         if type(k) ~= 'number' then k = '"'..k..'"' end
+         s = s .. '['..k..'] = ' .. dump(v) .. ','
+      end
+      return s .. '} '
+   else
+      return tostring(o)
+   end
+end
+
+
+local function draw_screen_gui(player)
+	local frame = player.gui.screen.simple_stats_frame
+	if player.gui.screen.simple_stats_frame then
+		frame.destroy()
+		return
+	end
+	
+	local frame = player.gui.screen.add({
+		type = "frame",
+		name = "simple_stats_frame",
+		direction = "vertical",
+	})
+	local t = frame.add { type = "table", column_count = 8 }
+	frame.location = {x = 3, y = 39 * player.display_scale}
+	frame.style.padding = -2
+	add_biter_puberty_thresholds_to_table(t, player)
+
+--	local l = t.add  { type = "label", caption = "banana Players "}
+--	l.style.font_color = { r=0.22, g=0.88, b=0.22}
+----	frame.style.maximal_width = 42
+--	local l2 = t.add  { type = "label", caption = "strawberry players"}
+--	l2.style.font_color = { r=0.88, g=0.88, b=0.22}
+--	local l3 = t.add  { type = "label", caption = "liquid players"}
+--	l3.style.font_color = { r=0.88, g=0.88, b=0.22}
+--	local unit_name = BiterRaffle.roll("spitter", global.bb_evolution["north"])
+--	local l4 = t.add  { type = "label", caption = unit_name}
+--	l4.style.font_color = { r=0.88, g=0.88, b=0.22}
+--	local l5 = t.add  { type = "label", caption = global.bb_evolution["north"]}
+--	l5.style.font_color = { r=0.88, g=0.88, b=0.22}
+end
+
+local function on_player_joined_game(event)
+	local player = game.players[event.player_index]
+	draw_top_gui(player)
+end
+
+local function on_gui_click(event)
+	local element = event.element
+	if not element then return end
+	if not element.valid then return end
+	
+	local name = element.name
+	if name == "simple_stats" then
+		local player = game.players[event.player_index]
+		draw_screen_gui(player)
+		return
+	end
+	
+	local parent = element.parent
+	if not parent then return end
+	if not parent.valid then return end
+	if not parent.name then return end
+	if parent.name ~= "simple_stats_frame" then return end	
+	
+	local player = game.players[event.player_index]	
+	local selected_tag = element.name
+	
+	if player.tag == selected_tag then
+		selected_tag = "" end
+	player.tag = selected_tag
+	parent.destroy()
+end
+
+Event.add(defines.events.on_gui_click, on_gui_click)
+Event.add(defines.events.on_player_joined_game, on_player_joined_game)

--- a/modules/simple_tags.lua
+++ b/modules/simple_tags.lua
@@ -46,7 +46,7 @@ local function draw_screen_gui(player)
 	if player.gui.screen.simple_tag_frame then
 		frame.destroy()
 		return
-	end		
+	end
 	
 	local frame = player.gui.screen.add({
 		type = "frame",
@@ -68,7 +68,7 @@ local function draw_screen_gui(player)
 	local clear_tag_element = frame[tag]
 	if not clear_tag_element then return end
 	clear_tag_element.sprite = "utility/close_white"
-	clear_tag_element.tooltip = "Clear Tag"	
+	clear_tag_element.tooltip = "Clear Tag"
 end
 
 local function on_player_joined_game(event)


### PR DESCRIPTION
### Brief description of the changes:
This PR provides a window that lets you know how many of each flask you need to add to get to the next biter level.

required:
- significant modification of biter_raffle.lua
  - this made it easier to set when each biter tier appears (previously it was pretty obfuscated)
- split out some of the feeding code so we could access it in a different file
- add biter probabilities to tables
- remove a lot of weird whitespace/tabs
- all relevant code is in the simple_stats file, it's based off of the simple_tags module


Notes:
This code should NOT be merged.  it's just for historical purposes.
I think the functionality is interesting, useful, and makes the game easier for new players.
however - `calculate_needed_food` is way too slow (10+ seconds on ITYTD).  i'm not sure if it's possible to make it faster without modifying the way diminishing returns are calculated

example:
![image](https://user-images.githubusercontent.com/87399868/143201064-b2734338-73f7-4fca-b9e9-c77bd7abaea1.png)

I also have a jupyter notebook that might be helpful for people. it helps plot evolution per flasks

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/XVhc6A/Factorio-Biter-Battles/plot-in-binder-flaskadditions?labpath=biter-battles-plotting.ipynb)
![image](https://user-images.githubusercontent.com/87399868/143203480-e690f960-c5a8-4381-a79b-3406fb48a851.png)


### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
