### PR TITLE
Improve biter performance

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -114,10 +114,6 @@ end
 Public.destroy_inactive_biters = function()
 	local biter_force_name = global.next_attack .. "_biters"
 
-	for _, group in pairs(global.unit_groups) do
-		set_active_biters(group)
-	end
-
 	for unit_number, biter in pairs(global.active_biters[biter_force_name]) do
 		if is_biter_inactive(biter, unit_number, biter_force_name) then
 			global.active_biters[biter_force_name][unit_number] = nil
@@ -360,8 +356,6 @@ local function create_attack_group(surface, force_name, biter_force_name)
 	for _, unit in pairs(units) do unit_group.add_member(unit) end
 
 	send_group(unit_group, force_name, side_target)
-
-	global.unit_groups[unit_group.group_number] = unit_group
 end
 
 Public.pre_main_attack = function()

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -143,14 +143,7 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	local valid_biters = {}
 	local i = 0
 
-	local threat = global.bb_threat[biter_force_name] * math_random(8, 32) * 0.01
-
-	--threat modifier for outposts
-	local m = math_abs(side_target.position.x) - 512
-	if m < 0 then m = 0 end
-	m = 1 - m * 0.001
-	if m < 0.5 then m = 0.5 end
-	threat = threat * m
+	local threat = global.bb_threat[biter_force_name] / 10
 
 	local unit_count = 0
 	local max_unit_count = math.floor(global.bb_threat[biter_force_name] * 0.25) + math_random(6,12)

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -151,7 +151,7 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 
 	--Collect biters around spawners
 	if math_random(1, 2) == 1 then
-		local biters = spawner.surface.find_enemy_units(spawner.position, 160, force_name)
+		local biters = spawner.surface.find_enemy_units(spawner.position, 96, force_name)
 		if biters[1] then
 			for _, biter in pairs(biters) do
 				if unit_count >= max_unit_count then break end
@@ -245,7 +245,7 @@ local function get_unit_group_position(spawner)
 	else
 		p = {x = spawner.position.x, y = spawner.position.y - 4}
 	end
-	p = spawner.surface.find_non_colliding_position("electric-furnace", p, 512, 1)
+	p = spawner.surface.find_non_colliding_position("electric-furnace", p, 256, 1)
 	if not p then
 		if global.bb_debug then game.print("No unit_group_position found for team " .. spawner.force.name) end
 		return

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -93,7 +93,7 @@ local function is_biter_inactive(biter, unit_number, biter_force_name)
 end
 
 Public.send_near_biters_to_silo = function()
-	if game.tick < 108000 then return end
+	if game.ticks_played < 108000 then return end
 	if not global.rocket_silo["north"] then return end
 	if not global.rocket_silo["south"] then return end
 

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -209,9 +209,9 @@ local function send_group(unit_group, force_name, side_target)
 	if position then
 		if math.abs(position.y) < math.abs(unit_group.position.y) then
 			commands[#commands + 1] = {
-				type = defines.command.attack_area,
+				type = defines.command.go_to_location,
 				destination = position,
-				radius = 16,
+				radius = 32,
 				distraction = defines.distraction.by_enemy
 			}
 		end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -227,7 +227,7 @@ local function send_group(unit_group, force_name, side_target)
 	commands[#commands + 1] = {
 		type = defines.command.attack,
 		target = global.rocket_silo[force_name],
-		distraction = defines.distraction.by_enemy
+		distraction = defines.distraction.by_damage
 	}
 
 	unit_group.set_command({

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -11,7 +11,6 @@ local bb_config = {
 	["random_scrap"] = true,							--Generate harvestable scrap around worms randomly?
 
 	--BITER SETTINGS--
-	["max_active_biters"] = 2048,					--Maximum total amount of attacking units per side.
 	["max_group_size"] = 420,							--Maximum unit group size.
 	["biter_timeout"] = 162000,						--Time it takes in ticks for an attacking unit to be deleted. This prevents permanent stuck units.
 	["bitera_area_distance"] = 512					--Distance to the biter area.

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -11,7 +11,7 @@ local bb_config = {
 	["random_scrap"] = true,							--Generate harvestable scrap around worms randomly?
 
 	--BITER SETTINGS--
-	["max_group_size"] = 420,							--Maximum unit group size.
+	["max_group_size"] = 300,							--Maximum unit group size.
 	["biter_timeout"] = 162000,						--Time it takes in ticks for an attacking unit to be deleted. This prevents permanent stuck units.
 	["bitera_area_distance"] = 512					--Distance to the biter area.
 }

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -145,7 +145,6 @@ function Public.tables()
 	global.target_entities = {}
 	global.tm_custom_name = {}
 	global.total_passive_feed_redpotion = 0
-	global.unit_groups = {}
 	global.unit_spawners = {}
 	global.unit_spawners.north_biters = {}
 	global.unit_spawners.south_biters = {}

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -127,7 +127,6 @@ function Public.tables()
 		global.bb_surface_name = "bb0"
 	end
 
-	global.active_biters = {}
 	global.bb_evolution = {}
 	global.bb_game_won_by_team = nil
 	global.bb_threat = {}
@@ -293,7 +292,6 @@ function Public.forces()
 		game.forces[force.name].research_queue_enabled = true
 		global.target_entities[force.index] = {}
 		global.spy_fish_timeout[force.name] = 0
-		global.active_biters[force.name] = {}
 		global.bb_evolution[force.name] = 0
 		global.reanim_chance[force.index] = 0
 		global.bb_threat_income[force.name] = 0

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -70,7 +70,6 @@ end
 
 local tick_minute_functions = {
 	[300 * 1] = Ai.raise_evo,
-	[300 * 2] = Ai.destroy_inactive_biters,
 	[300 * 3 + 30 * 0] = Ai.pre_main_attack,		-- setup for main_attack
 	[300 * 3 + 30 * 1] = Ai.perform_main_attack,	-- call perform_main_attack 7 times on different ticks
 	[300 * 3 + 30 * 2] = Ai.perform_main_attack,	-- some of these might do nothing (if there are no wave left)
@@ -81,7 +80,6 @@ local tick_minute_functions = {
 	[300 * 3 + 30 * 7] = Ai.perform_main_attack,
 	[300 * 3 + 30 * 8] = Ai.post_main_attack,
 	[300 * 4] = Ai.send_near_biters_to_silo,
-	[300 * 5] = Ai.wake_up_sleepy_groups,
 }
 
 local function on_tick()


### PR DESCRIPTION
### Brief description of the changes:
* Remove `global` variables to reduce memory footprint and improve performance
* Fix behavior of some parts due to wrong tick source
* Stop biters from chasing players when they should focus on destroying a silo
* Stop biters from destroying everything in the area that is 99% of a time empty
* Make surface searches smaller to decrease lag spikes

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.

It was tested in a public game almost a year ago. Most likely needs retesting.