### PR TITLE
Fix difficulty GUI lag spikes

### DIFF
--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -7,16 +7,14 @@ require 'utils/gui_styles'
 
 local difficulties = Tables.difficulties
 
-local function difficulty_gui()
+local function difficulty_gui(player)
 	local value = math.floor(global.difficulty_vote_value*100)
-	for _, player in pairs(game.connected_players) do
-		if player.gui.top["difficulty_gui"] then player.gui.top["difficulty_gui"].destroy() end
-		local str = table.concat({"Global map difficulty is ", difficulties[global.difficulty_vote_index].name, ". Mutagen has ", value, "% effectiveness."})
-		local b = player.gui.top.add { type = "sprite-button", caption = difficulties[global.difficulty_vote_index].name, tooltip = str, name = "difficulty_gui" }
-		b.style.font = "heading-2"
-		b.style.font_color = difficulties[global.difficulty_vote_index].print_color
-		element_style({element = b, x = 114, y = 38, pad = -2})		
-	end
+	if player.gui.top["difficulty_gui"] then player.gui.top["difficulty_gui"].destroy() end
+	local str = table.concat({"Global map difficulty is ", difficulties[global.difficulty_vote_index].name, ". Mutagen has ", value, "% effectiveness."})
+	local b = player.gui.top.add { type = "sprite-button", caption = difficulties[global.difficulty_vote_index].name, tooltip = str, name = "difficulty_gui" }
+	b.style.font = "heading-2"
+	b.style.font_color = difficulties[global.difficulty_vote_index].print_color
+	element_style({element = b, x = 114, y = 38, pad = -2})
 end
 
 local function poll_difficulty(player)

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -17,6 +17,12 @@ local function difficulty_gui(player)
 	element_style({element = b, x = 114, y = 38, pad = -2})
 end
 
+local function difficulty_gui_all()
+	for _, player in pairs(game.connected_players) do
+		difficulty_gui(player)
+	end
+end
+
 local function poll_difficulty(player)
 	if player.gui.center["difficulty_poll"] then player.gui.center["difficulty_poll"].destroy() return end
 	
@@ -91,7 +97,7 @@ local function on_player_joined_game(event)
 		if player.gui.center["difficulty_poll"] then player.gui.center["difficulty_poll"].destroy() end
 	end
 	
-	difficulty_gui()
+	difficulty_gui_all()
 end
 
 local function on_player_left_game(event)
@@ -122,7 +128,7 @@ local function on_gui_click(event)
 			game.print(player.name .. " has voted for " .. difficulties[i].name .. " difficulty!", difficulties[i].print_color)
 			global.difficulty_player_votes[player.name] = i
 			set_difficulty()
-			difficulty_gui()				
+			difficulty_gui(player)
 		end
 		event.element.parent.destroy()
 		return
@@ -146,7 +152,7 @@ local function on_gui_click(event)
 	game.print(player.name .. " has voted for " .. difficulties[i].name .. " difficulty!", difficulties[i].print_color)
 	global.difficulty_player_votes[player.name] = i
 	set_difficulty()
-	difficulty_gui()	
+	difficulty_gui_all()
 	event.element.parent.destroy()
 end
 	
@@ -157,5 +163,6 @@ event.add(defines.events.on_player_joined_game, on_player_joined_game)
 local Public = {}
 Public.difficulties = difficulties
 Public.difficulty_gui = difficulty_gui
+Public.difficulty_gui_all = difficulty_gui_all
 
 return Public

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -237,7 +237,7 @@ function Public.create_main_gui(player)
 	end
 
 	-- Difficulty mutagen effectivness update
-	bb_diff.difficulty_gui()
+	bb_diff.difficulty_gui(player)
 
 	-- Action frame
 	local t = frame.add  { type = "table", column_count = 2 }

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -92,12 +92,12 @@ local function on_tick()
 		global.bb_threat["south_biters"] = global.bb_threat["south_biters"] + global.bb_threat_income["south_biters"]
 	end
 
-	if tick % 180 == 0 then
+	if (tick+5) % 180 == 0 then
 		Gui.refresh()
 		diff_vote.difficulty_gui_all()
 	end
 
-	if tick % 300 == 0 then
+	if (tick+11) % 300 == 0 then
 		Gui.spy_fish()
 
 		if global.bb_game_won_by_team then

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -94,7 +94,7 @@ local function on_tick()
 
 	if tick % 180 == 0 then
 		Gui.refresh()
-		diff_vote.difficulty_gui()
+		diff_vote.difficulty_gui_all()
 	end
 
 	if tick % 300 == 0 then


### PR DESCRIPTION
### Brief description of the changes:
`difficulty_gui` was called for each player and then it refreshed GUI for each player again causing quadratic increase in number of operations with number of players present in the game.

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
