### PR TITLE
Added infinite spy when white science is thrown

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -217,6 +217,10 @@ local function feed_biters(player, food)
 	set_evo_and_threat(flask_amount, food, biter_force_name)
 	
 	add_stats(player, food, flask_amount ,biter_force_name, evolution_before_feed, threat_before_feed)
+	
+	if (food == "space-science-pack") then
+		global.spy_fish_timeout[player.force.name] = game.tick + 99999999
+	end
 end
 
 return feed_biters


### PR DESCRIPTION
### Brief description of the changes:
Accepted in the discord vote, added infinite spy when you throw white science. I made it as simple as possible (basically, if it's white science that is being sent, just add xxxxxxxx minutes to spy timeout)

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
