### PR TITLE
Limited threshold of biters reviving to 90% chance

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -29,6 +29,9 @@ local function set_biter_endgame_modifiers(force)
 	threshold = math.floor((threshold - 1.0) * 100.0)
 	threshold = threshold / global.max_reanim_thresh * 100
 	threshold = math.floor(threshold)
+	if threshold > 90.0 then
+		threshold = 90.0
+	end
 	global.reanim_chance[force.index] = threshold
 
 	local damage_mod = math.round((global.bb_evolution[force.name] - 1) * 1.0, 3)


### PR DESCRIPTION
### Brief description of the changes:
As it was voted on discord, limited revive chance to 90% for biters.

Vote: https://discord.com/channels/823696400797138974/823771211421974579/876235609499398156

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
