### PR TITLE
Do not allow ghosts on enemy side

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -47,6 +47,7 @@ end
 
 local function on_built_entity(event)
 	Functions.no_turret_creep(event)
+	Terrain.deny_enemy_side_ghosts(event)
 	Functions.add_target_entity(event.created_entity)
 end
 

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -719,4 +719,12 @@ function Public.deny_construction_bots(event)
 	event.created_entity.destroy()
 end
 
+function Public.deny_enemy_side_ghosts(event)
+	if event.created_entity.type ~= 'entity-ghost' then return end
+	local force = game.get_player(event.player_index).force.name
+	if not robot_build_restriction[force] then return end
+	if not robot_build_restriction[force](event.created_entity.position.y) then return end
+	event.created_entity.destroy()
+end
+
 return Public


### PR DESCRIPTION
This PR prohibits placing ghosts on the other side of the river. Sometimes ghosts can interfere with the entities on the enemy side. Especially relevant before the server is updated to version 1.1.49 

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
