### PR TITLE
Update/prevent landfilling by untrusted user

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -1,6 +1,7 @@
 local Server = require 'utils.server'
 local Muted = require 'utils.muted'
 local Tables = require "maps.biter_battles_v2.tables"
+local Session = require 'utils.datastore.session_data'
 local string_sub = string.sub
 local math_random = math.random
 local math_round = math.round
@@ -296,6 +297,18 @@ function Public.no_turret_creep(event)
 	})
 	
 	entity.destroy()
+end
+
+function Public.no_landfill_by_untrusted_user(event)
+	local entity = event.created_entity
+	if not entity.valid or not event.player_index or entity.name ~= "tile-ghost" or entity.ghost_name ~= "landfill" then return end
+	local player = game.players[event.player_index]
+	local trusted = Session.get_trusted_table()
+	if not trusted[player.name] then
+		player.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
+		entity.destroy()
+		return
+	end
 end
 
 --Share chat with spectator force

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -46,6 +46,7 @@ local function on_console_chat(event)
 end
 
 local function on_built_entity(event)
+	Functions.no_landfill_by_untrusted_user(event)
 	Functions.no_turret_creep(event)
 	Functions.add_target_entity(event.created_entity)
 end

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -121,7 +121,9 @@ end
 
 local function on_player_built_tile(event)
 	local player = game.players[event.player_index]
-	Terrain.restrict_landfill(player.surface, player, event.tiles)
+	if event.item ~= nil and event.item.name == "landfill" then
+		Terrain.restrict_landfill(player.surface, player, event.tiles)
+	end
 end
 
 local function on_player_mined_entity(event)

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -124,11 +124,6 @@ local function on_player_built_tile(event)
 	Terrain.restrict_landfill(player.surface, player, event.tiles)
 end
 
-local function on_player_built_tile(event)
-	local player = game.players[event.player_index]
-	Terrain.restrict_landfill(player.surface, player, event.tiles)
-end
-
 local function on_player_mined_entity(event)
 	Terrain.minable_wrecks(event)
 end

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -693,7 +693,7 @@ function Public.restrict_landfill(surface, user, tiles)
 		local trusted = session.get_trusted_table()
 		if is_horizontal_border_river(check_position) or distance_to_center < spawn_circle_size then
 			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)
-	    elseif not trusted[user.name] then
+	    elseif user ~= nil and not trusted[user.name] then
 			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)
 			user.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
 		end
@@ -701,7 +701,7 @@ function Public.restrict_landfill(surface, user, tiles)
 end
 
 function Public.deny_bot_landfill(event)
-    Public.restrict_landfill(event.robot.surface, event.robot.associated_player, event.tiles)
+    Public.restrict_landfill(event.robot.surface, nil, event.tiles)
 end
 
 --Construction Robot Restriction

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -706,7 +706,9 @@ function Public.restrict_landfill(surface, user, tiles)
 end
 
 function Public.deny_bot_landfill(event)
-    Public.restrict_landfill(event.robot.surface, nil, event.tiles)
+	if event.item ~= nil and event.item.name == "landfill" then
+		Public.restrict_landfill(event.robot.surface, nil, event.tiles)
+	end
 end
 
 --Construction Robot Restriction

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -4,6 +4,7 @@ local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local bb_config = require "maps.biter_battles_v2.config"
 local Functions = require "maps.biter_battles_v2.functions"
 local tables = require "maps.biter_battles_v2.tables"
+local session = require 'utils.datastore.session_data'
 
 local spawn_ore = tables.spawn_ore
 local table_insert = table.insert
@@ -684,19 +685,23 @@ function Public.minable_wrecks(event)
 end
 
 --Landfill Restriction
-function Public.restrict_landfill(surface, inventory, tiles)
+function Public.restrict_landfill(surface, user, tiles)
 	for _, t in pairs(tiles) do
 		local distance_to_center = math_sqrt(t.position.x ^ 2 + t.position.y ^ 2)
 		local check_position = t.position
 		if check_position.y > 0 then check_position = {x = check_position.x * -1, y = (check_position.y * -1) - 1} end
+		local trusted = session.get_trusted_table()
 		if is_horizontal_border_river(check_position) or distance_to_center < spawn_circle_size then
 			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)
+	    elseif not trusted[user.name] then
+			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)
+			user.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
 		end
 	end
 end
 
 function Public.deny_bot_landfill(event)
-    Public.restrict_landfill(event.robot.surface, event.robot.get_inventory(defines.inventory.robot_cargo), event.tiles)
+    Public.restrict_landfill(event.robot.surface, event.robot.associated_player, event.tiles)
 end
 
 --Construction Robot Restriction

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -693,8 +693,13 @@ function Public.restrict_landfill(surface, user, tiles)
 		local trusted = session.get_trusted_table()
 		if is_horizontal_border_river(check_position) or distance_to_center < spawn_circle_size then
 			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)
+			if user ~= nil then
+				user.print('You can not landfill the river', {r = 0.22, g = 0.99, b = 0.99})
+				user.insert({name = "landfill", count = 1})	
+			end
 	    elseif user ~= nil and not trusted[user.name] then
 			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)
+			user.insert({name = "landfill", count = 1})	
 			user.print('You have not grown accustomed to this technology yet.', {r = 0.22, g = 0.99, b = 0.99})
 		end
 	end


### PR DESCRIPTION
### Brief description of the changes:
-Removed duplicate function on_player_built_tile (weird there were twice the same method)
-Added just a print for user to know they can't landfill the river and it's refunded (no more scenario is bugged, my landfilled disappeared, an admin stole/trolled me)
-And the main goal of this PR is to prevent untrusted to use landfill by hand manually, or by bots.

Discord vote : https://discord.com/channels/823696400797138974/844719591828881438/889255782917492746

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
