### PR TITLE
Fix silo grief (mirroring)

### DIFF
--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -81,7 +81,7 @@ function Public.invert_entity(event)
 		destination.force = "south_biters"
 	end
 
-	if destination.name == "rocket-silo" then
+	if destination.name == "rocket-silo" and destination.position.y > -150 and destination.position.y < 150 and destination.position.x > -100 and destination.position.x < 100 then
 		global.rocket_silo[destination.force.name] = destination
 		Functions.add_target_entity(destination)
 	elseif destination.name == "gun-turret" then

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -81,7 +81,7 @@ function Public.invert_entity(event)
 		destination.force = "south_biters"
 	end
 
-	if destination.name == "rocket-silo" and destination.position.y > -150 and destination.position.y < 150 and destination.position.x > -100 and destination.position.x < 100 then
+	if destination.name == "rocket-silo" and math.abs(destination.position.y) < 150 and math.abs(destination.position.x) < 100 then
 		global.rocket_silo[destination.force.name] = destination
 		Functions.add_target_entity(destination)
 	elseif destination.name == "gun-turret" then


### PR DESCRIPTION
### Brief description of the changes:
Fix silo grief (mirroring exploit, which changes the global.rocket_silo variable, breaking bb)
I've chosen the most simple way to fix it (feel free if you have a better idea but silo is generated only on this coord (	local pos = {x = -32 + math_random(0, 64), y = -72} // 	local mirror_position = {x = pos.x * -1, y = pos.y * -1} ) 

So I'm just using that to restrict when to update this variable. I couldn't do position.y == 72 because sometimes it's 71.5 or something (which broke bb because != 72), even saw a y=82. That's why I'm doing a large range (anyways chunk this close is already made at game start so no exploit to do with this range I think).

### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
