### PR TITLE
Add more threat to compensate revive

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -179,6 +179,8 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 			game.forces[biter_force_name].evolution_factor = global.bb_evolution[biter_force_name]
 		else
 			game.forces[biter_force_name].evolution_factor = 1
+			-- Adjust threat for revive
+			food_value = food_value * (1 / (1.001 - global.reanim_chance[biter_force_name]))
 		end
 		
 		--ADD INSTANT THREAT

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -167,32 +167,42 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	local instant_threat_player_count_modifier = get_instant_threat_player_count_modifier()
 	
 	local food_value = food_values[food].value * global.difficulty_vote_value
+
+	local evo = global.bb_evolution[biter_force_name]
+	local biter_evo = game.forces[biter_force_name].evolution_factor
+	local threat = global.bb_threat[biter_force_name]
+	local pre_threat = threat
 	
 	for _ = 1, flask_amount, 1 do
 		---SET EVOLUTION
-		local e2 = (game.forces[biter_force_name].evolution_factor * 100) + 1
+		local e2 = (biter_evo * 100) + 1
 		local diminishing_modifier = (1 / (10 ^ (e2 * 0.015))) / (e2 * 0.5)
 		local evo_gain = (food_value * diminishing_modifier)
-		global.bb_evolution[biter_force_name] = global.bb_evolution[biter_force_name] + evo_gain
-		global.bb_evolution[biter_force_name] = math_round(global.bb_evolution[biter_force_name], decimals)
-		if global.bb_evolution[biter_force_name] <= 1 then
-			game.forces[biter_force_name].evolution_factor = global.bb_evolution[biter_force_name]
+		evo = evo + evo_gain
+		if evo <= 1 then
+			biter_evo = evo
 		else
-			game.forces[biter_force_name].evolution_factor = 1
-			-- Adjust threat for revive
-			food_value = food_value * (1 / (1.001 - global.reanim_chance[biter_force_name]))
+			biter_evo = 1
 		end
 		
 		--ADD INSTANT THREAT
 		local diminishing_modifier = 1 / (0.2 + (e2 * 0.016))
-		global.bb_threat[biter_force_name] = global.bb_threat[biter_force_name] + (food_value * instant_threat_player_count_modifier * diminishing_modifier)
-		global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name], decimals)		
+		threat = threat + (food_value * instant_threat_player_count_modifier * diminishing_modifier)
 	end
+	evo = math_round(evo, decimals)
 	
 	--SET THREAT INCOME
-	global.bb_threat_income[biter_force_name] = global.bb_evolution[biter_force_name] * 25
+	global.bb_threat_income[biter_force_name] = evo * 25
 	
+	game.forces[biter_force_name].evolution_factor = biter_evo
+	global.bb_evolution[biter_force_name] = evo
 	set_biter_endgame_modifiers(game.forces[biter_force_name])
+	-- Adjust threat for revive
+	if not global.reanim_chance[biter_force_name] then
+		global.bb_threat[biter_force_name] = math_round(threat, decimals)
+	else
+		global.bb_threat[biter_force_name] = math_round(threat + (threat - pre_threat) * (1 / (1.001 - global.reanim_chance[biter_force_name])), decimals)
+	end
 end
 
 local function feed_biters(player, food)	

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -201,7 +201,7 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	if not global.reanim_chance[biter_force_name] then
 		global.bb_threat[biter_force_name] = math_round(threat, decimals)
 	else
-		global.bb_threat[biter_force_name] = math_round(threat + (threat - pre_threat) * (1 / (1.001 - global.reanim_chance[biter_force_name])), decimals)
+		global.bb_threat[biter_force_name] = math_round(threat + (threat - pre_threat) * (100 / (100.001 - global.reanim_chance[biter_force_name])), decimals)
 	end
 end
 

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -170,8 +170,7 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 
 	local evo = global.bb_evolution[biter_force_name]
 	local biter_evo = game.forces[biter_force_name].evolution_factor
-	local threat = global.bb_threat[biter_force_name]
-	local pre_threat = threat
+	local threat = 0.0
 	
 	for _ = 1, flask_amount, 1 do
 		---SET EVOLUTION
@@ -198,11 +197,10 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	global.bb_evolution[biter_force_name] = evo
 	set_biter_endgame_modifiers(game.forces[biter_force_name])
 	-- Adjust threat for revive
-	if not global.reanim_chance[biter_force_name] then
-		global.bb_threat[biter_force_name] = math_round(threat, decimals)
-	else
-		global.bb_threat[biter_force_name] = math_round(threat + (threat - pre_threat) * (100 / (100.001 - global.reanim_chance[biter_force_name])), decimals)
+	if global.reanim_chance[biter_force_name] ~= nil then
+		threat = threat * (100 / (100.001 - global.reanim_chance[biter_force_name]))
 	end
+	global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name] + threat, decimals)
 end
 
 local function feed_biters(player, food)	

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -197,8 +197,10 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	global.bb_evolution[biter_force_name] = evo
 	set_biter_endgame_modifiers(game.forces[biter_force_name])
 	-- Adjust threat for revive
-	if global.reanim_chance[biter_force_name] ~= nil then
-		threat = threat * (100 / (100.001 - global.reanim_chance[biter_force_name]))
+	local force_index = game.forces[biter_force_name].index
+	local reanim_chance = global.reanim_chance[force_index]
+	if reanim_chance ~= nil and reanim_chance > 0 then
+		threat = threat * (100 / (100.001 - reanim_chance))
 	end
 	global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name] + threat, decimals)
 end


### PR DESCRIPTION
### Brief description of the changes:
Reviving biters should be worth more threat than a regular ones. We attempted reducing subtracted threat when they revive, but it didn't work (most likely a rounding error). This PR tries to increase threat income by multiplying it by expected number of biter lives. It should mitigate the issue that in the worse case caused negative threat without threat farming.

This PR can also slightly improve performance of `set_evo_and_threat` function by moving references to global variables out of loop that iterated over each flask separately.

### Tested Changes:
- [X] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
