### PR TITLE
Mirror decoratives to south

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -189,6 +189,7 @@ local function on_area_cloned(event)
 
 	-- Event is fired only for south side.
 	Mirror_terrain.invert_tiles(event)
+	Mirror_terrain.invert_decoratives(event)
 
 	-- Check chunks around southen silo to remove water tiles under stone-path.
 	-- Silo can be removed by picking bricks from under it in a situation where

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -151,4 +151,25 @@ function Public.invert_tiles(event)
 	surface.set_tiles(tiles)
 end
 
+
+function Public.invert_decoratives(event)
+	local surface = event.destination_surface
+	local src_decoratives = surface.find_decoratives_filtered {
+		area = event.source_area
+	}
+
+	local dest_decoratives = {}
+	for i, d in pairs(src_decoratives) do
+		local pos = d.position
+		pos.y = -pos.y - 1
+		dest_decoratives[i] = {
+			amount = d.amount,
+			position = pos,
+			name = d.decorative.name
+		}
+	end
+
+	surface.create_decoratives{check_collision = false, decoratives = dest_decoratives}
+end
+
 return Public


### PR DESCRIPTION
Adds decoratives for the south. In approximately the same places and quantities as in the north 

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
