### PR TITLE
Limit the max of biters revive chance to 95% instead of 90%

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -29,8 +29,8 @@ local function set_biter_endgame_modifiers(force)
 	threshold = math.floor((threshold - 1.0) * 100.0)
 	threshold = threshold / global.max_reanim_thresh * 100
 	threshold = math.floor(threshold)
-	if threshold > 90.0 then
-		threshold = 90.0
+	if threshold > 95.0 then
+		threshold = 95.0
 	end
 	global.reanim_chance[force.index] = threshold
 


### PR DESCRIPTION
### Brief description of the changes:
Limit biters revive chance to 95% instead of 90% (think it was a typo in todo list, that's why the mistake..?)

Vote : https://discord.com/channels/823696400797138974/823771211421974579/876235609499398156

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
