### PR TITLE
Cancel crafting queue when going to spectate

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -377,12 +377,8 @@ function spectate(player, forced_join)
 		if global.tournament_mode then player.print("The game is set to tournament mode. Teams can only be changed via team manager.", {r = 0.98, g = 0.66, b = 0.22}) return end
 	end
 	
-	if player.crafting_queue_size > 0 then
-		for i=player.crafting_queue_size, 1,-1 do
-			if player.crafting_queue and player.crafting_queue[i] then
-				player.cancel_crafting(player.crafting_queue[i])
-			end
-		end
+	while player.crafting_queue_size > 0 do
+		player.cancel_crafting(player.crafting_queue[0])
 	end
 	
 	player.teleport(player.surface.find_non_colliding_position("character", {0,0}, 4, 1))

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -378,7 +378,7 @@ function spectate(player, forced_join)
 	end
 	
 	while player.crafting_queue_size > 0 do
-		player.cancel_crafting(player.crafting_queue[0])
+		player.cancel_crafting(player.crafting_queue[1])
 	end
 	
 	player.teleport(player.surface.find_non_colliding_position("character", {0,0}, 4, 1))

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -376,6 +376,15 @@ function spectate(player, forced_join)
 	if not forced_join then
 		if global.tournament_mode then player.print("The game is set to tournament mode. Teams can only be changed via team manager.", {r = 0.98, g = 0.66, b = 0.22}) return end
 	end
+	
+	if player.crafting_queue_size > 0 then
+		for i=player.crafting_queue_size, 1,-1 do
+			if player.crafting_queue and player.crafting_queue[i] then
+				player.cancel_crafting(player.crafting_queue[i])
+			end
+		end
+	end
+	
 	player.teleport(player.surface.find_non_colliding_position("character", {0,0}, 4, 1))
 	player.force = game.forces.spectator
 	player.character.destructible = false

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -378,10 +378,8 @@ function spectate(player, forced_join)
 	end
 	
 	if player.crafting_queue_size > 0 then
-		for i=player.crafting_queue_size, 1,-1 do
-			if player.crafting_queue and player.crafting_queue[i] then
-				player.cancel_crafting(player.crafting_queue[i])
-			end
+		for _, cq in pairs(player.crafting_queue) do
+			player.cancel_crafting(cq)
 		end
 	end
 	

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -378,8 +378,10 @@ function spectate(player, forced_join)
 	end
 	
 	if player.crafting_queue_size > 0 then
-		for _, cq in pairs(player.crafting_queue) do
-			player.cancel_crafting(cq)
+		for i=player.crafting_queue_size, 1,-1 do
+			if player.crafting_queue and player.crafting_queue[i] then
+				player.cancel_crafting(player.crafting_queue[i])
+			end
 		end
 	end
 	


### PR DESCRIPTION
### Brief description of the changes:
Cancel crafting queue when going to spectate

Code talk : 
I went from end to start because otherwise when I deleted the element 1 of the crafting queue, the index changed and the looped crashed because -1 element. Also added a double check for player.crafting_queue because one time, code broke(I didn't go to spectator island) because no condition with just player.crafting_queue[i] so I added another check on player.crafting_queue.

Discord link : https://discord.com/channels/823696400797138974/844719591828881438/889255782917492746


### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
