### PR TITLE
Renamed autotag to just East or West for shorter name instead

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -11,8 +11,8 @@ local Team_manager = require "maps.biter_battles_v2.team_manager"
 local Terrain = require "maps.biter_battles_v2.terrain"
 local Session = require 'utils.datastore.session_data'
 local Color = require 'utils.color_presets'
-local autoTagWestOutpost = "[WestOutpost]"
-local autoTagEastOutpost = "[EastOutpost]"
+local autoTagWestOutpost = "[West]"
+local autoTagEastOutpost = "[East]"
 local autoTagDistance = 600
 
 require "maps.biter_battles_v2.sciencelogs_tab"


### PR DESCRIPTION
### Brief description of the changes:
Renamed autotag name to just East or West isntead of East/WestOutpost

Vote link : https://discord.com/channels/823696400797138974/823771211421974579/924224832122540062

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
