### PR TITLE
Prevent pathfinder crossing river

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -204,6 +204,19 @@ local function on_chunk_generated(event)
 	if event.position.y == 0 and event.position.x == 1 then
 		Terrain.add_holiday_decorations(surface)
 	end
+
+	-- The game pregenerate tiles within a radius of 3 chunks from the generated chunk.
+	-- Bites can use these tiles for pathing.
+	-- This creates a problem that bites pathfinder can cross the river at the edge of the map.
+	-- To prevent this, divide the north and south land by drawing a strip of water on these pregenerated tiles.
+	if event.position.y >= 0 and event.position.y <= 3 then
+		for x = -3, 3 do
+			local chunk_pos = { x = event.position.x + x, y = 0 }
+			if not surface.is_chunk_generated(chunk_pos) then
+				Terrain.draw_water_for_river_ends(surface, chunk_pos)
+			end
+		end
+	end
 end
 
 local function on_entity_cloned(event)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -481,7 +481,13 @@ function Public.draw_spawn_area(surface)
 	surface.regenerate_decorative()
 end
 
-
+function Public.draw_water_for_river_ends(surface, chunk_pos)
+	local left_top_x = chunk_pos.x * 32
+	for x = 0, 31, 1 do
+		local pos = {x = left_top_x + x, y = 1}
+		surface.set_tiles({{name = "deepwater", position = pos}})
+	end
+end
 
 
 local function draw_grid_ore_patch(count, grid, name, surface, size, density)


### PR DESCRIPTION
The game pregenerate tiles within a radius of 3 chunks from the generated chunk.
Bites can use these tiles for pathing.
This creates a problem that bites pathfinder can cross the river at the edge of the map.
To prevent this, divide the north and south land by drawing a strip of water on these pregenerated tiles.

Closes #53 

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
