### PR TITLE
Change GitHub link to this GitHub

### DIFF
--- a/chatbot.lua
+++ b/chatbot.lua
@@ -16,7 +16,7 @@ local brain = {
         'and report it in #support',
         'If you are trusted, you are eligible to run the command /jail <player-name> "reason" and /free'
     },
-    [3] = {'Scenario repository for download:', 'https://github.com/1pulse/Factorio-Biter-Battles'},
+    [3] = {'Scenario repository for download:', 'https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles'},
     [4] = {
         "If you're not trusted and have been playing here for awhile, ask an admin to trust you.  Use the /admins command to see if any are available."
     },


### PR DESCRIPTION
### Brief description of the changes:
Current link does not exist as user has either deleted or privated the repo. This changes the chatbot to provide the correct link.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
