### PR TITLE
Added auto-shouting after game ending

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -4,6 +4,8 @@ local Init = require "maps.biter_battles_v2.init"
 local Score = require "comfy_panel.score"
 local Server = require 'utils.server'
 local Special_games = require 'comfy_panel.special_games'
+local Event = require 'utils.event'
+local Tables = require 'maps.biter_battles_v2.tables'
 
 local math_random = math.random
 
@@ -474,4 +476,16 @@ function Public.silo_death(event)
     end
 end
 
+local function chat_with_everyone(event)
+    if not global.server_restart_timer then return end
+    if not event.message then return end
+    local player = game.get_player(event.player_index)
+    if not player or not player.valid then return end
+    local enemy = Tables.enemy_team_of[player.force.name]
+    if not enemy then return end
+    local message = player.name .."[auto-shout]: " .. event.message
+    game.forces[enemy].print(message, player.chat_color)
+end
+
+Event.add(defines.events.on_console_chat, chat_with_everyone)
 return Public


### PR DESCRIPTION
### Brief description of the changes:
As voted, every message after silo's destruction is visible for everyone

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
