### PR TITLE
Removed auto research of silo

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -337,19 +337,6 @@ Public.post_main_attack = function()
 	end
 end
 
---By Maksiu1000 skip the last two tech
-Public.unlock_satellite = function(event)
-    -- Skip unrelated events
-    if event.research.name ~= 'speed-module-3' then
-        return
-    end
-    local force = event.research.force
-    if not force.technologies['rocket-silo'].researched then
-        force.technologies['rocket-silo'].researched=true
-        force.technologies['space-science-pack'].researched=true
-    end
-end
-
 Public.raise_evo = function()
 	if global.freeze_players then return end
 	if not global.training_mode and (#game.forces.north.connected_players == 0 or #game.forces.south.connected_players == 0) then return end

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -312,10 +312,17 @@ local function on_init()
 	Init.load_spawn()
 end
 
+--By Maksiu1000 skip the last tech
+local unlock_satellite = function(event)
+    if event.research.name == 'rocket-silo' then
+		event.research.force.technologies['space-science-pack'].researched = true
+    end
+end
+
 local Event = require 'utils.event'
 Event.add(defines.events.on_rocket_launch_ordered, on_rocket_launch_ordered)
 Event.add(defines.events.on_area_cloned, on_area_cloned)
-Event.add(defines.events.on_research_finished, Ai.unlock_satellite)			--free silo space tech
+Event.add(defines.events.on_research_finished, unlock_satellite)			--free silo space tech
 Event.add(defines.events.on_post_entity_died, Ai.schedule_reanimate)
 Event.add_event_filter(defines.events.on_post_entity_died, {
 	filter = "type",


### PR DESCRIPTION
### Brief description of the changes:
Rocket silo is no longer automatically unlocked after speed module 3
Space sci is automatically unlocked after rocket silo
Moved the function to main.lua so that ai.lua is just about controling biters

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
