### PR TITLE
Perf : No find entities used when defense are built are far from nest

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -315,7 +315,6 @@ function Public.no_turret_creep(event)
 	if posEntity.y > 0 then posEntity.y = (posEntity.y + 100) * -1 end
 	if posEntity.y < 0 then posEntity.y = posEntity.y - 100 end
 	if not Public.is_biter_area(posEntity,false) then
-		game.print('NOPE too far' .. entity.position.y)
 		return
 	end
 	

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -3,6 +3,7 @@ local Muted = require 'utils.muted'
 local Tables = require "maps.biter_battles_v2.tables"
 local Session = require 'utils.datastore.session_data'
 local bb_config = require "maps.biter_battles_v2.config"
+local simplex_noise = require 'utils.simplex_noise'.d2
 local string_sub = string.sub
 local math_random = math.random
 local math_round = math.round
@@ -264,13 +265,44 @@ function Public.init_player(player)
 	game.permissions.get_group("spectator").add_player(player)
 end
 
-local function is_biter_area_no_noise(position)
+function Public.get_noise(name, pos)
+	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
+	local noise_seed_add = 25000
+	if name == 1 then
+		local noise = simplex_noise(pos.x * 0.0042, pos.y * 0.0042, seed)
+		seed = seed + noise_seed_add
+		noise = noise + simplex_noise(pos.x * 0.031, pos.y * 0.031, seed) * 0.08
+		seed  = seed + noise_seed_add
+		noise = noise + simplex_noise(pos.x * 0.1, pos.y * 0.1, seed) * 0.025
+		return noise
+	end
+
+	if name == 2 then
+		local noise = simplex_noise(pos.x * 0.011, pos.y * 0.011, seed)
+		seed = seed + noise_seed_add
+		noise = noise + simplex_noise(pos.x * 0.08, pos.y * 0.08, seed) * 0.2
+		return noise
+	end
+
+	if name == 3 then
+		local noise = simplex_noise(pos.x * 0.005, pos.y * 0.005, seed)
+		noise = noise + simplex_noise(pos.x * 0.02, pos.y * 0.02, seed) * 0.3
+		noise = noise + simplex_noise(pos.x * 0.15, pos.y * 0.15, seed) * 0.025
+		return noise
+	end
+end
+
+function Public.is_biter_area(position,noise_Enabled)
 	local bitera_area_distance = bb_config.bitera_area_distance * -1
 	local biter_area_angle = 0.45
 	local a = bitera_area_distance - (math_abs(position.x) * biter_area_angle)
 	if position.y - 70 > a then return false end
 	if position.y + 70 < a then return true end	
-	if position.y > a then return false end
+	if noise_Enabled then
+		if position.y + (Public.get_noise(3, position) * 64) > a then return false end
+	else
+		if position.y > a then return false end
+	end
 	return true
 end
 
@@ -280,9 +312,10 @@ function Public.no_turret_creep(event)
 	if not no_turret_blacklist[event.created_entity.type] then return end
 	
 	local posEntity = entity.position
-	if posEntity.y > 0 then posEntity.y = (posEntity.y + 140) * -1 end
-	if posEntity.y < 0 then posEntity.y = posEntity.y - 140 end
-	if not is_biter_area_no_noise(posEntity) then
+	if posEntity.y > 0 then posEntity.y = (posEntity.y + 100) * -1 end
+	if posEntity.y < 0 then posEntity.y = posEntity.y - 100 end
+	if not Public.is_biter_area(posEntity,false) then
+		game.print('NOPE too far' .. entity.position.y)
 		return
 	end
 	

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -60,33 +60,6 @@ local function shuffle(tbl)
 	return tbl
 end
 
-local function get_noise(name, pos)
-	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
-	local noise_seed_add = 25000
-	if name == 1 then
-		local noise = simplex_noise(pos.x * 0.0042, pos.y * 0.0042, seed)
-		seed = seed + noise_seed_add
-		noise = noise + simplex_noise(pos.x * 0.031, pos.y * 0.031, seed) * 0.08
-		seed  = seed + noise_seed_add
-		noise = noise + simplex_noise(pos.x * 0.1, pos.y * 0.1, seed) * 0.025
-		return noise
-	end
-
-	if name == 2 then
-		local noise = simplex_noise(pos.x * 0.011, pos.y * 0.011, seed)
-		seed = seed + noise_seed_add
-		noise = noise + simplex_noise(pos.x * 0.08, pos.y * 0.08, seed) * 0.2
-		return noise
-	end
-
-	if name == 3 then
-		local noise = simplex_noise(pos.x * 0.005, pos.y * 0.005, seed)
-		noise = noise + simplex_noise(pos.x * 0.02, pos.y * 0.02, seed) * 0.3
-		noise = noise + simplex_noise(pos.x * 0.15, pos.y * 0.15, seed) * 0.025
-		return noise
-	end
-end
-
 local function create_mirrored_tile_chain(surface, tile, count, straightness)
 	if not surface then return end
 	if not tile then return end
@@ -181,7 +154,7 @@ local river_width_half = math_floor(bb_config.border_river_width * -0.5)
 function is_horizontal_border_river(pos)
 	if pos.y < river_y_1 then return false end
 	if pos.y > river_y_2 then return false end
-	if pos.y >= river_width_half - (math_abs(get_noise(1, pos)) * 4) then return true end
+	if pos.y >= river_width_half - (math_abs(Functions.get_noise(1, pos)) * 4) then return true end
 	return false
 end
 
@@ -196,7 +169,7 @@ local function generate_starting_area(pos, distance_to_center, surface)
 		return
 	end
 
-	local noise = get_noise(2, pos) * noise_multiplier
+	local noise = Functions.get_noise(2, pos) * noise_multiplier
 	local distance_from_spawn_wall = distance_to_center + noise - spawn_wall_radius
 	-- distance_from_spawn_wall is the difference between the distance_to_center (with added noise) 
 	-- and our spawn_wall radius (spawn_wall_radius=116), i.e. how far are we from the ring with radius spawn_wall_radius.
@@ -229,7 +202,7 @@ local function generate_starting_area(pos, distance_to_center, surface)
 	end
 
 	if surface.can_place_entity({name = "wooden-chest", position = pos}) and surface.can_place_entity({name = "coal", position = pos}) then
-		local noise_2 = get_noise(3, pos)
+		local noise_2 = Functions.get_noise(3, pos)
 		if noise_2 < 0.40 then
 			if noise_2 > -0.40 then
 				if distance_from_spawn_wall > -1.75 and distance_from_spawn_wall < 0 then				
@@ -326,19 +299,8 @@ local function generate_extra_worm_turrets(surface, left_top)
 	end
 end
 
-local bitera_area_distance = bb_config.bitera_area_distance * -1
-local biter_area_angle = 0.45
-
-local function is_biter_area(position)
-	local a = bitera_area_distance - (math_abs(position.x) * biter_area_angle)	
-	if position.y - 70 > a then return false end
-	if position.y + 70 < a then return true end	
-	if position.y + (get_noise(3, position) * 64) > a then return false end
-	return true
-end
-
 local function draw_biter_area(surface, left_top_x, left_top_y)
-	if not is_biter_area({x = left_top_x, y = left_top_y - 96}) then return end
+	if not Functions.is_biter_area({x = left_top_x, y = left_top_y - 96},true) then return end
 	
 	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
 		
@@ -349,7 +311,7 @@ local function draw_biter_area(surface, left_top_x, left_top_y)
 	for x = 0, 31, 1 do
 		for y = 0, 31, 1 do
 			local position = {x = left_top_x + x, y = left_top_y + y}
-			if is_biter_area(position) then
+			if Functions.is_biter_area(position,true) then
 				local index = math_floor(GetNoise("bb_biterland", position, seed) * 48) % 7 + 1
 				out_of_map[i] = {name = "out-of-map", position = position}
 				tiles[i] = {name = "dirt-" .. index, position = position}
@@ -364,7 +326,7 @@ local function draw_biter_area(surface, left_top_x, left_top_y)
 	for _ = 1, 4, 1 do
 		local v = chunk_tile_vectors[math_random(1, size_of_chunk_tile_vectors)]
 		local position = {x = left_top_x + v[1], y = left_top_y + v[2]}
-		if is_biter_area(position) and surface.can_place_entity({name = "spitter-spawner", position = position}) then
+		if Functions.is_biter_area(position,true) and surface.can_place_entity({name = "spitter-spawner", position = position}) then
 			local e
 			if math_random(1, 4) == 1 then
 				e = surface.create_entity({name = "spitter-spawner", position = position, force = "north_biters"})
@@ -380,7 +342,7 @@ local function draw_biter_area(surface, left_top_x, left_top_y)
 		local v = chunk_tile_vectors[math_random(1, size_of_chunk_tile_vectors)]
 		local position = {x = left_top_x + v[1], y = left_top_y + v[2]}
 		local worm_turret_name = BiterRaffle.roll("worm", e)
-		if is_biter_area(position) and surface.can_place_entity({name = worm_turret_name, position = position}) then			
+		if Functions.is_biter_area(position,true) and surface.can_place_entity({name = worm_turret_name, position = position}) then			
 			surface.create_entity({name = worm_turret_name, position = position, force = "north_biters"})
 		end
 	end


### PR DESCRIPTION
### Brief description of the changes:
Basically to improve performance : saw in a profiler than find entities is quite heavy when defense are being replaced automatically by bots, The idea was not to do this kind of find entities on 70 radius when it's far from nests.

Function was copied (with noise removed) because I couldn't import terrain from functions (too many c level..).
I did +140 distance to be sure that it's not nearby nests (to avoid any kind of exploit with this change, and anyways even if it's a bit a big number, since barely no ones build defense and have active defenses there, it should be fine, if you want we can reduce the 140 number, just arbitrary but ugh, felt correct enough when testing locally.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
