### PR TITLE
Fix threat boss issue going negative too often (waves were oversized) and frozen boss bug and added boss announce

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -149,8 +149,8 @@ local function generate_boss_units_around_spawner(spawner, force_name, side_targ
 		max_group_size_biters_force = bb_config.max_group_size_south
 	end
 
-	local threat = global.bb_threat[biter_force_name] / 10
-
+	local threat = global.bb_threat[biter_force_name] / 10 / 2 -- divide by 2 since 2 waves are spawned, one normal and one boss
+	
 	local max_unit_count = math.floor(global.bb_threat[biter_force_name] * 0.25) + math_random(6,12)
 	if max_unit_count > max_group_size_biters_force then max_unit_count = max_group_size_biters_force end
 	
@@ -178,9 +178,9 @@ local function generate_boss_units_around_spawner(spawner, force_name, side_targ
 				game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. force_name .. "...")
 				global.biter_spawn_unseen[force_name][unit_name] = false
 			end
+			if threat + threat_values[biter.name] * 20 * health_buff_equivalent_revive < 0 then break end
 		end
 	end
-	
 	if global.bb_debug then game.print(get_active_biter_count(biter_force_name) .. " active units for " .. biter_force_name) end
 
 	return valid_biters
@@ -197,6 +197,11 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	local max_group_size_biters_force = bb_config.max_group_size_north
 	if biter_force_name == 'south_biters' then
 		max_group_size_biters_force = bb_config.max_group_size_south
+	end
+	
+	
+	if max_group_size_biters_force ~= bb_config.max_group_size_initial then
+		threat = threat / 2 -- divide by 2 since 2 waves are spawned, one normal and one boss 
 	end
 	
 	local unit_count = 0

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -193,15 +193,17 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	-- Half threat goes to normal biters, half threat goes for bosses, to get half bosses and half normal biters
 	local threat = global.bb_threat[biter_force_name] / 10
 	local threat_for_normal_biters = threat
+	
+	local max_group_size_biters_force = global.max_group_size_north
+	if biter_force_name == 'south_biters' then
+		max_group_size_biters_force = global.max_group_size_south
+	end
+	
 	if max_group_size_biters_force ~= global.max_group_size_initial then
 		threat_for_normal_biters = threat_for_normal_biters / 2
 	end
 	local threat_for_boss_biters = threat  / 2
 
-	local max_group_size_biters_force = global.max_group_size_north
-	if biter_force_name == 'south_biters' then
-		max_group_size_biters_force = global.max_group_size_south
-	end
 	
 	local unit_count = 0
 	local max_unit_count = math.floor(global.bb_threat[biter_force_name] * 0.25) + math_random(6,12)

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -200,31 +200,11 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 		threat_for_normal_biters = threat_for_normal_biters / 2
 	end
 	local threat_for_boss_biters = threat  / 2
-
-	
-	local unit_count = 0
 	local max_unit_count = math.floor(global.bb_threat[biter_force_name] * 0.25) + math_random(6,12)
 	if max_unit_count > max_group_size_biters_force then max_unit_count = max_group_size_biters_force end
 
-	--Collect biters around spawners
-	if math_random(1, 2) == 1 then
-		local biters = spawner.surface.find_enemy_units(spawner.position, 96, force_name)
-		if biters[1] then
-			for _, biter in pairs(biters) do
-				if unit_count >= max_unit_count then break end
-				if biter.force.name == biter_force_name then
-					i = i + 1
-					valid_biters[i] = biter
-					unit_count = unit_count + 1
-					threat_for_normal_biters = threat_for_normal_biters - threat_values[biter.name]
-				end
-				if threat_for_normal_biters < 0 then break end
-			end
-		end
-	end
-
 	--Manual spawning of units
-	spawn_biters(true,max_unit_count - unit_count,spawner,threat_for_normal_biters,biter_force_name,max_unit_count,valid_biters,force_name)
+	spawn_biters(true,max_unit_count,spawner,threat_for_normal_biters,biter_force_name,max_unit_count,valid_biters,force_name)
 	
 	--Manual spawning of boss units
 	if max_group_size_biters_force ~= global.max_group_size_initial then

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -193,14 +193,14 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	-- Half threat goes to normal biters, half threat goes for bosses, to get half bosses and half normal biters
 	local threat = global.bb_threat[biter_force_name] / 10
 	local threat_for_normal_biters = threat
-	if max_group_size_biters_force ~= bb_config.max_group_size_initial then
+	if max_group_size_biters_force ~= global.max_group_size_initial then
 		threat_for_normal_biters = threat_for_normal_biters / 2
 	end
 	local threat_for_boss_biters = threat  / 2
 
-	local max_group_size_biters_force = bb_config.max_group_size_north
+	local max_group_size_biters_force = global.max_group_size_north
 	if biter_force_name == 'south_biters' then
-		max_group_size_biters_force = bb_config.max_group_size_south
+		max_group_size_biters_force = global.max_group_size_south
 	end
 	
 	local unit_count = 0
@@ -228,8 +228,8 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	spawn_biters(true,max_unit_count - unit_count,spawner,threat_for_normal_biters,biter_force_name,max_unit_count,valid_biters,force_name)
 	
 	--Manual spawning of boss units
-	if max_group_size_biters_force ~= bb_config.max_group_size_initial then
-		spawn_biters(false,math.ceil((bb_config.max_group_size_initial - max_group_size_biters_force)/20),spawner,threat_for_boss_biters,biter_force_name,max_unit_count,valid_biters,force_name)
+	if max_group_size_biters_force ~= global.max_group_size_initial then
+		spawn_biters(false,math.ceil((global.max_group_size_initial - max_group_size_biters_force)/20),spawner,threat_for_boss_biters,biter_force_name,max_unit_count,valid_biters,force_name)
 	end
 
 	if global.bb_debug then game.print(get_active_biter_count(biter_force_name) .. " active units for " .. biter_force_name) end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -138,6 +138,52 @@ local function get_random_spawner(biter_force_name)
 	end
 end
 
+local function spawn_biters(isItnormalBiters, maxLoopIteration,spawner,biter_threat,biter_force_name,max_unit_count,valid_biters,force_name)
+	local roll_type = unit_type_raffle[math_random(1, size_of_unit_type_raffle)]
+	local boss_biter_force_name = biter_force_name .. "_boss"
+	-- *1.5 because we add 50% health bonus as it's just one unit.  
+	-- *20 because one boss is equal of 20 biters in theory
+	-- formula because 90% revive chance is 1/(1-0.9) = 10, which means biters needs to be killed 10 times, so *10 . easy fast-check : 50% revive is 2 biters worth, formula matches. 0% revive -> 1 biter worth
+	local health_buff_equivalent_revive = 1.0/(1.0-global.reanim_chance[game.forces[biter_force_name].index]/100)
+	local health_factor = bb_config.health_multiplier_boss*health_buff_equivalent_revive
+	local i = #valid_biters
+	for _ = 1, maxLoopIteration, 1 do
+		local unit_name = BiterRaffle.roll(roll_type, global.bb_evolution[biter_force_name])
+		if isItnormalBiters and biter_threat < 0 then break end
+		if not isItnormalBiters and biter_threat - threat_values[unit_name] * 20 * health_buff_equivalent_revive < 0 then break end -- Do not add a biter if it will make the threat goes negative when all the biters of wave were killed
+		local position = spawner.surface.find_non_colliding_position(unit_name, spawner.position, 128, 2)
+		if not position then break end
+		local biter
+
+		if isItnormalBiters then
+			biter = spawner.surface.create_entity({name = unit_name, force = biter_force_name, position = position})
+		else
+			biter = spawner.surface.create_entity({name = unit_name, force = boss_biter_force_name, position = position})
+		end
+		if isItnormalBiters then
+			biter_threat = biter_threat - threat_values[biter.name]
+		else
+			biter_threat = biter_threat - threat_values[biter.name] * 20 * health_buff_equivalent_revive -- 20 because boss is 20 biters equivalent with health buff included
+		end
+		i = i + 1
+		valid_biters[i] = biter
+		if not isItnormalBiters then
+			BossUnit.add_boss_unit(biter, health_factor, 0.55)	
+		end
+		
+		--Announce New Spawn
+		if(isItnormalBiters and global.biter_spawn_unseen[force_name][unit_name]) then
+			game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. force_name .. "...")
+			global.biter_spawn_unseen[force_name][unit_name] = false
+		end
+		if(not isItnormalBiters and global.biter_spawn_unseen[boss_biter_force_name][unit_name]) then
+			game.print("A " .. unit_name:gsub("-", " ") .. " boss was spotted far away on team " .. force_name .. "...")
+			global.biter_spawn_unseen[boss_biter_force_name][unit_name] = false
+		end
+	end
+end
+
+
 local function select_units_around_spawner(spawner, force_name, side_target)
 	local biter_force_name = spawner.force.name
 
@@ -179,53 +225,11 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	end
 
 	--Manual spawning of units
-	local roll_type = unit_type_raffle[math_random(1, size_of_unit_type_raffle)]
-	for _ = 1, max_unit_count - unit_count, 1 do
-		if threat_for_normal_biters < 0 then break end
-		local unit_name = BiterRaffle.roll(roll_type, global.bb_evolution[biter_force_name])
-		local position = spawner.surface.find_non_colliding_position(unit_name, spawner.position, 128, 2)
-		if not position then break end
-		local biter = spawner.surface.create_entity({name = unit_name, force = biter_force_name, position = position})
-		threat_for_normal_biters = threat_for_normal_biters - threat_values[biter.name]
-		i = i + 1
-		valid_biters[i] = biter
-		--Announce New Spawn
-		if(global.biter_spawn_unseen[force_name][unit_name]) then
-			game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. force_name .. "...")
-			global.biter_spawn_unseen[force_name][unit_name] = false
-		end
-	end
-
-	--Boss units
-	local boss_biter_force_name = biter_force_name .. "_boss"
-	max_unit_count = math.floor(global.bb_threat[biter_force_name] * 0.25) + math_random(6,12)
-	if max_unit_count > max_group_size_biters_force then max_unit_count = max_group_size_biters_force end
-	
-	-- *1.5 because we add 50% health bonus as it's just one unit.  
-	-- *20 because one boss is equal of 20 biters in theory
-	-- formula because 90% revive chance is 1/(1-0.9) = 10, which means biters needs to be killed 10 times, so *10 . easy fast-check : 50% revive is 2 biters worth, formula matches. 0% revive -> 1 biter worth
-	local health_buff_equivalent_revive = 1.0/(1.0-global.reanim_chance[game.forces[biter_force_name].index]/100)
-	local health_factor = bb_config.health_multiplier_boss*health_buff_equivalent_revive
+	spawn_biters(true,max_unit_count - unit_count,spawner,threat_for_normal_biters,biter_force_name,max_unit_count,valid_biters,force_name)
 	
 	--Manual spawning of boss units
-	roll_type = unit_type_raffle[math_random(1, size_of_unit_type_raffle)]
 	if max_group_size_biters_force ~= bb_config.max_group_size_initial then
-		for _ = 1, math.ceil((bb_config.max_group_size_initial - max_group_size_biters_force)/20), 1 do
-			local unit_name = BiterRaffle.roll(roll_type, global.bb_evolution[biter_force_name])
-			if threat_for_boss_biters - threat_values[unit_name] * 20 * health_buff_equivalent_revive < 0 then break end -- Do not add a biter if it will make the threat goes negative when all the biters of wave were killed
-			local position = spawner.surface.find_non_colliding_position(unit_name, spawner.position, 128, 2)
-			if not position then break end
-			local biter = spawner.surface.create_entity({name = unit_name, force = boss_biter_force_name, position = position})
-			threat_for_boss_biters = threat_for_boss_biters - threat_values[biter.name] * 20 * health_buff_equivalent_revive -- 20 because boss is 20 biters equivalent with health buff included
-			i = i + 1
-			valid_biters[i] = biter
-			BossUnit.add_boss_unit(biter, health_factor, 0.55)
-			--Announce New Spawn
-			if(global.biter_spawn_unseen[boss_biter_force_name][unit_name]) then
-				game.print("A " .. unit_name:gsub("-", " ") .. " boss was spotted far away on team " .. force_name .. "...")
-				global.biter_spawn_unseen[boss_biter_force_name][unit_name] = false
-			end
-		end
+		spawn_biters(false,math.ceil((bb_config.max_group_size_initial - max_group_size_biters_force)/20),spawner,threat_for_boss_biters,biter_force_name,max_unit_count,valid_biters,force_name)
 	end
 
 	if global.bb_debug then game.print(get_active_biter_count(biter_force_name) .. " active units for " .. biter_force_name) end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -194,10 +194,7 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	local threat = global.bb_threat[biter_force_name] / 10
 	local threat_for_normal_biters = threat
 	
-	local max_group_size_biters_force = global.max_group_size_north
-	if biter_force_name == 'south_biters' then
-		max_group_size_biters_force = global.max_group_size_south
-	end
+	local max_group_size_biters_force = global.max_group_size[biter_force_name]
 	
 	if max_group_size_biters_force ~= global.max_group_size_initial then
 		threat_for_normal_biters = threat_for_normal_biters / 2

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -144,7 +144,7 @@ local function select_units_around_spawner(spawner, force_name, side_target)
 	local valid_biters = {}
 	local i = 0
 
-	-- Half threat goes to normal biters, half threat goes for bosses, to get half bosses and half normal bosses
+	-- Half threat goes to normal biters, half threat goes for bosses, to get half bosses and half normal biters
 	local threat = global.bb_threat[biter_force_name] / 10
 	local threat_for_normal_biters = threat
 	if max_group_size_biters_force ~= bb_config.max_group_size_initial then

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -178,7 +178,7 @@ local function generate_boss_units_around_spawner(spawner, force_name, side_targ
 				game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. force_name .. "...")
 				global.biter_spawn_unseen[force_name][unit_name] = false
 			end
-			if threat + threat_values[biter.name] * 20 * health_buff_equivalent_revive < 0 then break end
+			if threat - threat_values[biter.name] * 20 * health_buff_equivalent_revive < 0 then break end
 		end
 	end
 	if global.bb_debug then game.print(get_active_biter_count(biter_force_name) .. " active units for " .. biter_force_name) end

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -11,9 +11,6 @@ local bb_config = {
 	["random_scrap"] = true,							--Generate harvestable scrap around worms randomly?
 
 	--BITER SETTINGS--
-	["max_group_size_initial"] = 300,							--Maximum unit group size for all biters at start, just used as a reference, doesnt change initial group size.
-	["max_group_size_north"] = 300,							--Maximum unit group size for north biters.
-	["max_group_size_south"] = 300,							--Maximum unit group size for south biters.
 	["biter_timeout"] = 162000,						--Time it takes in ticks for an attacking unit to be deleted. This prevents permanent stuck units.
 	["bitera_area_distance"] = 512,					--Distance to the biter area.
 	

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -218,33 +218,13 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 		update_boss_modifiers(biter_force_name, 2,1)
 	end
 	if evo > 3.3 then -- 330% evo => 3.3
-		if biter_force_name == "north_biters" and global.max_group_size_north ~= 50 then
-			global.max_group_size_north = 50
-		end
-		if biter_force_name == "south_biters" and global.max_group_size_south ~= 50 then
-			global.max_group_size_south = 50
-		end
+		global.max_group_size[biter_force_name] = 50
 	elseif evo > 2.3 then
-		if biter_force_name == "north_biters" and global.max_group_size_north ~= 75 then
-			global.max_group_size_north = 75
-		end
-		if biter_force_name == "south_biters" and global.max_group_size_south ~= 75 then
-			global.max_group_size_south = 75
-		end
+		global.max_group_size[biter_force_name] = 75
 	elseif evo > 1.3 then  
-		if biter_force_name == "north_biters" and global.max_group_size_north ~= 100 then
-			global.max_group_size_north = 100
-		end
-		if biter_force_name == "south_biters" and global.max_group_size_south ~= 100 then
-			global.max_group_size_south = 100
-		end
+		global.max_group_size[biter_force_name] = 100
 	elseif evo > 0.7 then 
-		if biter_force_name == "north_biters" and global.max_group_size_north ~= 200 then
-			global.max_group_size_north = 200
-		end
-		if biter_force_name == "south_biters" and global.max_group_size_south ~= 200 then
-			global.max_group_size_south = 200
-		end
+		global.max_group_size[biter_force_name] = 200
 	end
 	
 	-- Adjust threat for revive

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -218,32 +218,32 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 		update_boss_modifiers(biter_force_name, 2,1)
 	end
 	if evo > 3.3 then -- 330% evo => 3.3
-		if biter_force_name == "north_biters" and bb_config.max_group_size_north ~= 50 then
-			bb_config.max_group_size_north = 50
+		if biter_force_name == "north_biters" and global.max_group_size_north ~= 50 then
+			global.max_group_size_north = 50
 		end
-		if biter_force_name == "south_biters" and bb_config.max_group_size_south ~= 50 then
-			bb_config.max_group_size_south = 50
+		if biter_force_name == "south_biters" and global.max_group_size_south ~= 50 then
+			global.max_group_size_south = 50
 		end
 	elseif evo > 2.3 then
-		if biter_force_name == "north_biters" and bb_config.max_group_size_north ~= 75 then
-			bb_config.max_group_size_north = 75
+		if biter_force_name == "north_biters" and global.max_group_size_north ~= 75 then
+			global.max_group_size_north = 75
 		end
-		if biter_force_name == "south_biters" and bb_config.max_group_size_south ~= 75 then
-			bb_config.max_group_size_south = 75
+		if biter_force_name == "south_biters" and global.max_group_size_south ~= 75 then
+			global.max_group_size_south = 75
 		end
 	elseif evo > 1.3 then  
-		if biter_force_name == "north_biters" and bb_config.max_group_size_north ~= 100 then
-			bb_config.max_group_size_north = 100
+		if biter_force_name == "north_biters" and global.max_group_size_north ~= 100 then
+			global.max_group_size_north = 100
 		end
-		if biter_force_name == "south_biters" and bb_config.max_group_size_south ~= 100 then
-			bb_config.max_group_size_south = 100
+		if biter_force_name == "south_biters" and global.max_group_size_south ~= 100 then
+			global.max_group_size_south = 100
 		end
 	elseif evo > 0.7 then 
-		if biter_force_name == "north_biters" and bb_config.max_group_size_north ~= 200 then
-			bb_config.max_group_size_north = 200
+		if biter_force_name == "north_biters" and global.max_group_size_north ~= 200 then
+			global.max_group_size_north = 200
 		end
-		if biter_force_name == "south_biters" and bb_config.max_group_size_south ~= 200 then
-			bb_config.max_group_size_south = 200
+		if biter_force_name == "south_biters" and global.max_group_size_south ~= 200 then
+			global.max_group_size_south = 200
 		end
 	end
 	

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -2,7 +2,6 @@ local bb_config = require "maps.biter_battles_v2.config"
 local Functions = require "maps.biter_battles_v2.functions"
 local Server = require 'utils.server'
 
-local Profiler = require 'utils.profiler'
 local tables = require "maps.biter_battles_v2.tables"
 local food_values = tables.food_values
 local force_translation = tables.force_translation

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -372,6 +372,12 @@ local function freeze_all_biters(surface)
     for _, e in pairs(surface.find_entities_filtered({force = "south_biters"})) do
         e.active = false
     end
+    for _, e in pairs(surface.find_entities_filtered({force = "north_biters_boss"})) do
+        e.active = false
+    end
+    for _, e in pairs(surface.find_entities_filtered({force = "south_biters_boss"})) do
+        e.active = false
+    end
 end
 
 local function biter_killed_the_silo(event)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -167,7 +167,6 @@ function Public.draw_structures()
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
 	Terrain.draw_spawn_circle(surface)
-	game.surfaces[global.bb_surface_name].create_entity({name="flying-text",position={-4,-13},text="Experimental version: Boss biters",color = {r = 0, g = 1, b = 0, a = 0.5},text_align="right"}).active=false
 	--Terrain.generate_spawn_goodies(surface)
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -210,8 +210,9 @@ function Public.tables()
 	global.special_games_variables = {}
 	global.player_data_afk = {}
 	global.max_group_size_initial = 300							--Maximum unit group size for all biters at start, just used as a reference, doesnt change initial group size.
-	global.max_group_size_north = 300							--Maximum unit group size for north biters.
-	global.max_group_size_south = 300							--Maximum unit group size for south biters.
+	global.max_group_size = {}
+	global.max_group_size["north_biters"] = 300							--Maximum unit group size for north biters.
+	global.max_group_size["south_biters"] = 300							--Maximum unit group size for south biters.
 	global.biter_spawn_unseen = {
 		["north"] = {
 			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -209,9 +209,9 @@ function Public.tables()
 	global.active_special_games = {}
 	global.special_games_variables = {}
 	global.player_data_afk = {}
-	global.max_group_size_initial = 300,							--Maximum unit group size for all biters at start, just used as a reference, doesnt change initial group size.
-	global.max_group_size_north = 300,							--Maximum unit group size for north biters.
-	global.max_group_size_south = 300,							--Maximum unit group size for south biters.
+	global.max_group_size_initial = 300							--Maximum unit group size for all biters at start, just used as a reference, doesnt change initial group size.
+	global.max_group_size_north = 300							--Maximum unit group size for north biters.
+	global.max_group_size_south = 300							--Maximum unit group size for south biters.
 	global.biter_spawn_unseen = {
 		["north"] = {
 			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -213,6 +213,12 @@ function Public.tables()
 		},
 		["south"] = {
 			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
+		},
+		["north_biters_boss"] = {
+			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
+		},
+		["south_biters_boss"] = {
+			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true
 		}
 	}
 	global.difficulty_vote_value = 1

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -209,6 +209,9 @@ function Public.tables()
 	global.active_special_games = {}
 	global.special_games_variables = {}
 	global.player_data_afk = {}
+	global.max_group_size_initial = 300,							--Maximum unit group size for all biters at start, just used as a reference, doesnt change initial group size.
+	global.max_group_size_north = 300,							--Maximum unit group size for north biters.
+	global.max_group_size_south = 300,							--Maximum unit group size for south biters.
 	global.biter_spawn_unseen = {
 		["north"] = {
 			["medium-spitter"] = true, ["medium-biter"] = true, ["big-spitter"] = true, ["big-biter"] = true, ["behemoth-spitter"] = true, ["behemoth-biter"] = true


### PR DESCRIPTION
### Brief description of the changes:
Check here for details : https://discord.com/channels/823696400797138974/984991352909611040
But the summary is that with bosses, you spawn one more wave when a normal biter wave is being, issue is that threat is local for boss wave spawning and normal biters wave boss, to fix that issue, divide by 2 threat (normal biters get half of threat, boss get half of threat), so now, you don't spawn too many biters anymore, which stops the negative threat issue happening too often.

Second thing is that the loop for threat : Another issue is that the check for threat is done at the beginning of loop when spawning biters, not end.
Imagine you have a 5K wave threat to spawn. You spawn bosses, you are at 4950 threat wave, a new boss could cost for example 1k threat to spawn. Still in the loop, threat is < 5000, so it spawns a boss, you re at 5950 total, the loop check threat, too much threat , it stops. But you still end up with a wave of 5950 instead of 5k max . So at end of loop do this kind of calcul  : if threat - newThreatBiter  < 0 then stop the loop of spawning. This issue is also the case for normal biters, but since they are worth not much, it doesn't show as much as a boss biter

Tested it with 1K on normal white science (~42k threat) and tested it by sending 1k purple once in a while, a lot better now threat wise

==
Also fixed boss biters that were not frozen because they have difference force and these boss forces were not frozen


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
