### PR TITLE
Fix ghost rotation by spectator

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -99,7 +99,6 @@ function Public.initial_setup()
 		defines.input_action.open_kills_gui,
 		defines.input_action.quick_bar_set_selected_page,
 		defines.input_action.quick_bar_set_slot,
-		defines.input_action.rotate_entity,
 		defines.input_action.set_filter,
 		defines.input_action.set_player_color,
 		defines.input_action.start_walking,


### PR DESCRIPTION
Spectators are able to rotate ghosts. This PR prevent it.

Cons: there will be no more players spinning on the island.