### PR TITLE
Fix spectator in vehicle

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -404,15 +404,7 @@ function spectate(player, forced_join, stored_position)
 		player.cancel_crafting(player.crafting_queue[1])
 	end
 	
-	local vehicle = player.vehicle
-	if vehicle then
-		if vehicle.get_driver() == player.character then
-			vehicle.set_driver(nil) 
-		end
-		if vehicle.get_passenger() == player.character then
-			vehicle.set_passenger(nil) 
-		end
-	end
+	player.driving = false
 
 	if stored_position then
         local p_data = get_player_data(player)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -404,6 +404,16 @@ function spectate(player, forced_join, stored_position)
 		player.cancel_crafting(player.crafting_queue[1])
 	end
 	
+	local vehicle = player.vehicle
+	if vehicle then
+		if vehicle.get_driver() == player.character then
+			vehicle.set_driver(nil) 
+		end
+		if vehicle.get_passenger() == player.character then
+			vehicle.set_passenger(nil) 
+		end
+	end
+
 	if stored_position then
         local p_data = get_player_data(player)
         p_data.position = player.position


### PR DESCRIPTION
When you switch to spectator mode while in a car or other vehicle, the character does not teleport to the island but stay as spectator in the vehicle. This PR changes so that the player is teleported to the island even if they are in a vehicle.

Fixes #293

### Tested Changes:
- [x] I've tested the changes locally without people.
- [ ] I've not tested the changes.
