### PR TITLE
Enabled editor and config in spectator

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -99,6 +99,10 @@ function Public.initial_setup()
 		defines.input_action.start_walking,
 		defines.input_action.toggle_show_entity_info,
 		defines.input_action.write_to_console,
+		defines.input_action.map_editor_action,
+		defines.input_action.toggle_map_editor,
+		defines.input_action.change_multiplayer_config,
+		defines.input_action.admin_action,
 	}
 	for _, d in pairs(defs) do p.set_allows_action(d, true) end
 


### PR DESCRIPTION
### Brief description of the changes:
Allows for use of `/editor` and `/config` commands while on the island

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
