### PR TITLE
Added path to errors from event_core

### DIFF
--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -257,9 +257,12 @@ end
 
 local function on_built_entity(event)
 	if not global.active_special_games["disabled_entities"] then return end
-	local player = game.get_player(event.player_index)
-	local force = player.force
 	local entity = event.created_entity
+	if not entity then return end
+	if not entity.valid then return end
+	
+	local player = game.get_player(event.player_index)
+	local force = player.force	
 	if global.special_games_variables["disabled_entities"][force.name][entity.name] then
 		player.create_local_flying_text({text = "Disabled by special game", position = entity.position})
 		player.get_inventory(defines.inventory.character_main).insert({name = entity.name, count = 1})
@@ -288,8 +291,11 @@ local create_special_games_panel = (function(player, frame)
 end)
 
 local function on_gui_click(event)
-	local player = game.get_player(event.player_index)
 	local element = event.element
+	if not element then return end
+	if not element.valid then return end
+	
+	local player = game.get_player(event.player_index)	
 	if not element.type == "button" then return end
 	local config = element.parent.children[2]
 

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -732,6 +732,7 @@ function Public.deny_construction_bots(event)
 end
 
 function Public.deny_enemy_side_ghosts(event)
+	if not event.created_entity.valid then return end
 	if event.created_entity.type ~= 'entity-ghost' then return end
 	local force = game.get_player(event.player_index).force.name
 	if not robot_build_restriction[force] then return end

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -21,6 +21,7 @@ if not remote.interfaces['interface'] then
     remote.add_interface('interface', interface)
 end ]]
 local pcall = pcall
+local debug_getinfo = debug.getinfo
 local log = log
 local script_on_event = script.on_event
 local script_on_nth_tick = script.on_nth_tick
@@ -45,7 +46,9 @@ else
             local handler = handlers[i]
             local success, error = pcall(handler, event)
             if not success then
-                log(error)
+                local info = debug_getinfo(handler, 'S')
+                --log(string.format('%s in %s:%d' , error, info.short_src, info.linedefined))
+                log({'', '[ERROR] ', error, ' in ', info.short_src, ":", info.linedefined})
             end
         end
     end


### PR DESCRIPTION
 Fixed errors from special_games

### Brief description of the changes:
Added the path to the actual function causing the error to logged line in event_core.
Resulting in more helpful info:

![obraz](https://user-images.githubusercontent.com/92057893/182369692-365f5a82-31f0-49d4-9737-eeeccc5b311b.png)

Fixed errors caused by special_games

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
