### PR TITLE
Replaced element_style() with gui_style()

### DIFF
--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -10,7 +10,7 @@ draw_map_scores would be a function with the player and the frame as arguments
 
 ]]
 local event = require 'utils.event'
-require 'utils.gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 comfy_panel_tabs = {}
 
 local Public = {}
@@ -66,7 +66,7 @@ local function top_button(player)
         return
     end
     local button = player.gui.top.add({type = 'sprite-button', name = 'comfy_panel_top_button', sprite = 'item/raw-fish'})
-    element_style({element = button, x = 38, y = 38, pad = -2})
+    gui_style(button, {width = 38, height = 38, padding = -2})
 end
 
 local function main_frame(player)

--- a/comfy_panel/poll.lua
+++ b/comfy_panel/poll.lua
@@ -5,7 +5,7 @@ local Game = require 'utils.game'
 local Server = require 'utils.server'
 local Tabs = require 'comfy_panel.main'
 local session = require 'utils.datastore.session_data'
-require 'utils.gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 local Class = {}
 
 local insert = table.insert
@@ -824,14 +824,7 @@ local function player_joined(event)
             sprite = 'item/programmable-speaker',
             tooltip = 'Let your question be heard!'
         }
-        element_style({element = button, x = 38, y = 38, pad = -2})
-        --[[
-        button.style.minimal_width = 38
-        button.style.maximal_width = 38
-        button.style.minimal_height = 38
-        button.style.maximal_height = 38
-        button.style.padding = -2
-        ]]
+        gui_style(button, {width = 38, height = 38, padding = -2})
     end
 end
 

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -3,7 +3,7 @@ local ai = require "maps.biter_battles_v2.ai"
 local event = require 'utils.event'
 local Server = require 'utils.server'
 local Tables = require "maps.biter_battles_v2.tables"
-require 'utils/gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 
 local difficulties = Tables.difficulties
 
@@ -14,7 +14,7 @@ local function difficulty_gui(player)
 	local b = player.gui.top.add { type = "sprite-button", caption = difficulties[global.difficulty_vote_index].name, tooltip = str, name = "difficulty_gui" }
 	b.style.font = "heading-2"
 	b.style.font_color = difficulties[global.difficulty_vote_index].print_color
-	element_style({element = b, x = 114, y = 38, pad = -2})
+	gui_style(b, {width = 114, height = 38, padding = -2})
 end
 
 local function difficulty_gui_all()

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -11,7 +11,7 @@ local math_floor = math.floor
 local table_insert = table.insert
 local table_remove = table.remove
 local string_find = string.find
-require 'utils/gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 
 -- Only add upgrade research balancing logic in this section
 -- All values should be in tables.lua
@@ -407,7 +407,7 @@ function Public.create_map_intro_button(player)
 	local b = player.gui.top.add({type = "sprite-button", caption = "?", name = "map_intro_button", tooltip = "Map Info"})
 	b.style.font_color = {r=0.5, g=0.3, b=0.99}
 	b.style.font = "heading-1"
-	element_style({element = b, x = 38, y = 38, pad = -2})
+	gui_style(b, {width = 38, height = 38, padding = -2})
 end
 
 function Public.show_intro(player)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -14,7 +14,7 @@ local food_names = Tables.gui_foods
 local math_random = math.random
 
 require "maps.biter_battles_v2.spec_spy"
-require 'utils/gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 local gui_values = {
 		["north"] = {force = "north", biter_force = "north_biters", c1 = bb_config.north_side_team_name, c2 = "JOIN ", n1 = "join_north_button",
 		t1 = "Evolution of north side biters.",
@@ -40,8 +40,7 @@ end
 local function create_sprite_button(player)
 	if player.gui.top["bb_toggle_button"] then return end
 	local button = player.gui.top.add({type = "sprite-button", name = "bb_toggle_button", sprite = "entity/big-biter"})
-	button.style.font = "default-bold"
-	element_style({element = button, x= 38, y = 38, pad = -2})
+	gui_style(button, {width = 38, height = 38, padding = -2, font = "default-bold"})
 end
 
 local function clock(frame)
@@ -151,23 +150,11 @@ function Public.create_main_gui(player)
 		frame.add { type = "table", name = "biter_battle_table", column_count = 4 }
 		local t = frame.biter_battle_table
 		for food_name, tooltip in pairs(food_names) do
-			local s = t.add { type = "sprite-button", name = food_name, sprite = "item/" .. food_name }
-			s.tooltip = tooltip
-			s.style.minimal_height = 41
-			s.style.minimal_width = 41
-			s.style.top_padding = 0
-			s.style.left_padding = 0
-			s.style.right_padding = 0
-			s.style.bottom_padding = 0
+			local s = t.add { type = "sprite-button", name = food_name, sprite = "item/" .. food_name, tooltip = tooltip}
+			gui_style(s, {minimal_height = 41, minimal_width = 41, padding = 0})
 		end
 		local s = t.add { type = "sprite-button", name = "send_all", caption = "All", tooltip = "LMB - low to high, RMB - high to low"}
-		s.style.minimal_height = 41
-		s.style.minimal_width = 41
-		s.style.top_padding = 0
-		s.style.left_padding = 0
-		s.style.right_padding = 0
-		s.style.bottom_padding = 0
-		s.style.font_color = {r = 0.9, g = 0.9, b = 0.9}
+		gui_style(s, {minimal_height = 41, minimal_width = 41, padding = 0, font_color = {r = 0.9, g = 0.9, b = 0.9}})
 		frame.add{type="line"}
 	end
 	
@@ -187,11 +174,7 @@ function Public.create_main_gui(player)
 		local c = gui_value.c1
 		if global.tm_custom_name[gui_value.force] then c = global.tm_custom_name[gui_value.force] end
 		local l = t.add  { type = "label", caption = c}
-		l.style.font = "default-bold"
-		l.style.font_color = gui_value.color1
-		l.style.single_line = false
-		l.style.maximal_width = 102
-
+		gui_style(l, {font = "default-bold", font_color = gui_value.color1, single_line = false, maximal_width = 102})
 		-- Number of players
 		local l = t.add  { type = "label", caption = " - "}
 		local c = #game.forces[gui_value.force].connected_players .. " Player"

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -1,6 +1,6 @@
 local Public = {}
 local Server = require 'utils.server'
-require 'utils.gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 local forces = {
 	{name = "north", color = {r = 0, g = 0, b = 200}},
 	{name = "spectator", color = {r = 111, g = 111, b = 111}},
@@ -99,7 +99,7 @@ function Public.draw_top_toggle_button(player)
 	local button = player.gui.top.add({type = "sprite-button", name = "team_manager_toggle_button", caption = "Team Manager", tooltip = tooltip})
 	button.style.font = "heading-2"
 	button.style.font_color = {r = 0.88, g = 0.55, b = 0.11}
-	element_style({element = button, x = 114, y = 38, pad = -2})
+	gui_style(button, {width = 114, height = 38, padding = -2})
 end
 
 local function draw_manager_gui(player)

--- a/modules/simple_tags.lua
+++ b/modules/simple_tags.lua
@@ -1,7 +1,7 @@
 --Adds a small gui to quick select an icon tag for your character - mewmew
 
 local Event = require 'utils.event'
-require 'utils.gui_styles'
+local gui_style = require 'utils.utils'.gui_style
 local icons = {
 	{"[img=item/electric-mining-drill]", "item/electric-mining-drill", "Miner"},
 	{"[img=item/stone-furnace]", "item/stone-furnace", "Smeltery"},
@@ -38,7 +38,7 @@ local function draw_top_gui(player)
 	local button = player.gui.top.add({type = "sprite-button", name = "simple_tag", caption = "Tag"})
 	button.style.font = "heading-2"
 	button.style.font_color = {212, 212, 212}
-	element_style({element = button, x = 38, y = 38, pad = -2})
+	gui_style(button, {width = 38, height = 38, padding = -2})
 end
 
 local function draw_screen_gui(player)
@@ -59,7 +59,7 @@ local function draw_screen_gui(player)
 	
 	for _, v in pairs(icons) do
 		local button = frame.add({type = "sprite-button", name = v[1], sprite = v[2], tooltip = v[3]})
-		element_style({element = button, x = 38, y = 38, pad = -2})
+		gui_style(button, {width = 38, height = 38, padding = -2})
 	end
 	
 	local tag = player.tag

--- a/utils/gui_styles.lua
+++ b/utils/gui_styles.lua
@@ -1,8 +1,0 @@
-function element_style(options)
-	local element = options.element
-	element.style.width = options.x
-	element.style.height = options.y
-	element.style.padding = options.pad
-end
-
-

--- a/utils/utils.lua
+++ b/utils/utils.lua
@@ -128,4 +128,10 @@ Module.format_time = function(ticks)
     return table.concat(result, ' ')
 end
 
+Module.gui_style = function(element, attributes)
+    for attribute, value in pairs(attributes) do
+        element.style[attribute] = value
+    end
+end
+
 return Module


### PR DESCRIPTION
### Brief description of the changes:
Replaced not-so-useful `element_style()` from `utils.gui_styles` with `gui_style()` in `utils.utils`.
The goal is to cut down number of lines needed to format a gui element.
Possible downsides: tiny performance impact related to the `for` loop.

This PR was created to break #324 into smaller, more managable chunks
### Tested Changes:
- [x] I've tested the changes locally ~~or with people~~.
- [ ] I've not tested the changes.
