### PR TITLE
Fix Limited lives desync

### DIFF
--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -295,6 +295,11 @@ local function generate_limited_lives(lives_limit)
 	game.print("Special game Limited lives: " .. special_game_description)
 end
 
+function Public.has_life(player_name)
+	local player_lives = global.special_games_variables["limited_lives"]["player_lives"][player_name]
+	return player_lives == nil or player_lives > 0
+end
+
 local function on_built_entity(event)
 	if not global.active_special_games["disabled_entities"] then return end
 	local entity = event.created_entity

--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -281,10 +281,6 @@ local function generate_limited_lives(lives_limit)
 	global.special_games_variables["limited_lives"] = {
 		lives_limit = lives_limit,
 		player_lives = {},
-		has_life = function (player_name)
-			local player_lives = global.special_games_variables["limited_lives"]["player_lives"][player_name]
-			return player_lives == nil or player_lives > 0
-		end
 	}
 	local special_game_description = table.concat({"Each player has only", lives_limit, ((lives_limit == 1) and "life" or "lives"), "until the end of the game."}, " ")
 	global.special_games_variables["limited_lives"]["text_id"] = rendering.draw_text{

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -339,12 +339,15 @@ function join_team(player, force_name, forced_join, auto_join)
 
 	if global.chosen_team[player.name] then
 		if not forced_join then
-			if global.active_special_games["limited_lives"] and not global.special_games_variables["limited_lives"]['has_life'](player.name) then
-				player.print(
-					"Special game in progress. You have no lives left until the end of the game.",
-					{r = 0.98, g = 0.66, b = 0.22}
-				)
-				return
+			if global.active_special_games["limited_lives"] then
+				local player_lives = global.special_games_variables["limited_lives"]["player_lives"][player.name]
+				if player_lives ~= nil and player_lives <= 0 then
+					player.print(
+						"Special game in progress. You have no lives left until the end of the game.",
+						{r = 0.98, g = 0.66, b = 0.22}
+					)
+					return
+				end
 			end
 			if game.tick - global.spectator_rejoin_delay[player.name] < 3600 then
 				player.print(

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -16,6 +16,7 @@ local math_random = math.random
 local math_abs = math.abs
 require "maps.biter_battles_v2.spec_spy"
 local gui_style = require 'utils.utils'.gui_style
+local has_life = require 'comfy_panel.special_games'.has_life
 local gui_values = {
 		["north"] = {force = "north", biter_force = "north_biters", c1 = bb_config.north_side_team_name, c2 = "JOIN ", n1 = "join_north_button",
 		t1 = "Evolution of north side biters.",
@@ -339,15 +340,12 @@ function join_team(player, force_name, forced_join, auto_join)
 
 	if global.chosen_team[player.name] then
 		if not forced_join then
-			if global.active_special_games["limited_lives"] then
-				local player_lives = global.special_games_variables["limited_lives"]["player_lives"][player.name]
-				if player_lives ~= nil and player_lives <= 0 then
-					player.print(
-						"Special game in progress. You have no lives left until the end of the game.",
-						{r = 0.98, g = 0.66, b = 0.22}
-					)
-					return
-				end
+			if global.active_special_games["limited_lives"] and not has_life(player.name) then
+				player.print(
+					"Special game in progress. You have no lives left until the end of the game.",
+					{r = 0.98, g = 0.66, b = 0.22}
+				)
+				return
 			end
 			if game.tick - global.spectator_rejoin_delay[player.name] < 3600 then
 				player.print(


### PR DESCRIPTION
This fix remove `has_life` function from `global`. According to the lua api  
https://lua-api.factorio.com/latest/Global.html
**_Functions are not allowed in `global`_**

To reproduce the bug:
1. Need a multiplayer at least 2 players.
2. Activate special game Limited lives
3. Spectate
4. Try to join team again. 
5. Desync.

### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
