### PR TITLE
Special event shared evo and throws

### DIFF
--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -274,6 +274,7 @@ end
 
 local function generate_shared_science_throw()
 		game.print("[SPECIAL GAMES] All science throws are shared (if you send, both team gets +threat and +evo !)", Color.cyan)
+		game.print("[SPECIAL GAMES] Evo and threat and threat income were reset to same value for both teams !", Color.cyan)
 		global.active_special_games["shared_science_throw"] = true
 		if not global.special_games_variables["shared_science_throw"] then
 			global.special_games_variables["shared_science_throw"] = {}
@@ -291,6 +292,18 @@ local function generate_shared_science_throw()
 			alignment = "center",
 			scale_with_zoom = false
 		}
+		local maxEvoFactor = math.max(game.forces["north_biters"].evolution_factor,game.forces["south_biters"].evolution_factor)
+		game.forces["north_biters"].evolution_factor = maxEvoFactor
+		game.forces["south_biters"].evolution_factor = maxEvoFactor
+		local maxBbEvo = math.max(global.bb_evolution["north_biters"],global.bb_evolution["south_biters"])
+		global.bb_evolution["north_biters"] = maxBbEvo
+		global.bb_evolution["south_biters"] = maxBbEvo
+		local maxThreatIncome = math.max(global.bb_threat_income["north_biters"],global.bb_threat_income["south_biters"])
+		global.bb_threat_income["north_biters"] = maxThreatIncome
+		global.bb_threat_income["south_biters"] = maxThreatIncome
+		local maxThreat = math.max(global.bb_threat["north_biters"],global.bb_threat["south_biters"])
+		global.bb_threat["north_biters"] = maxThreat
+		global.bb_threat["south_biters"] = maxThreat
 end
 
 local function generate_limited_lives(lives_limit)

--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -84,6 +84,13 @@ local valid_special_games = {
 		button = {name = "disabled_entities_apply", type = "button", caption = "Apply"}
 	},
 
+	shared_science_throw = {
+		name = {type = "label", caption = "Shared throws of science", tooltip = "Science throws are shared between both teams"},
+		config = {
+		},
+		button = {name = "shared_science_throw_apply", type = "button", caption = "Apply"}
+	},
+
 	limited_lives = {
 		name = {type = "label", caption = "Limited lives", tooltip = "Limits the number of player lives per game"},
 		config = {
@@ -265,6 +272,27 @@ local function generate_disabled_entities(team, eq)
 	global.active_special_games["disabled_entities"] = true
 end
 
+local function generate_shared_science_throw()
+		game.print("[SPECIAL GAMES] All science throws are shared (if you send, both team gets +threat and +evo !)", Color.cyan)
+		global.active_special_games["shared_science_throw"] = true
+		if not global.special_games_variables["shared_science_throw"] then
+			global.special_games_variables["shared_science_throw"] = {}
+		end
+		if global.special_games_variables["shared_science_throw"]["text_id"] then
+			rendering.destroy(global.special_games_variables["shared_science_throw"]["text_id"])
+		end
+		local special_game_description = "All science throws are shared (if you send, both teams gets +threat and +evo)"
+		global.special_games_variables["shared_science_throw"]["text_id"] = rendering.draw_text{
+			text = special_game_description,
+			surface = game.surfaces[global.bb_surface_name],
+			target = {-0,12},
+			color = Color.warning,
+			scale = 3,
+			alignment = "center",
+			scale_with_zoom = false
+		}
+end
+
 local function generate_limited_lives(lives_limit)
 	if global.special_games_variables["limited_lives"] then
 		rendering.destroy(global.special_games_variables["limited_lives"]["text_id"])
@@ -429,6 +457,8 @@ local function on_gui_click(event)
 			config["eq7"].elem_value
 		}
 		generate_disabled_entities(team, eq)
+	elseif element.name == "shared_science_throw_confirm" then
+		generate_shared_science_throw()
 
 	elseif element.name == "limited_lives_confirm" then
 		local lives_limit = tonumber(config["lives_limit"].text)

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -238,7 +238,7 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 		local enemyBitersForceName = enemy_team_of[force_translation[biter_force_name]] .. "_biters"
 		game.forces[enemyBitersForceName].evolution_factor = game.forces[biter_force_name].evolution_factor
 		global.bb_evolution[enemyBitersForceName] = global.bb_evolution[biter_force_name]
-		global.bb_threat_income[enemyBitersForceName] = evo * 25
+		global.bb_threat_income[enemyBitersForceName] = global.bb_threat_income[biter_force_name]
 		global.bb_threat[enemyBitersForceName] = math_round(global.bb_threat[enemyBitersForceName] + threat, decimals)
 	end
 end

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -239,7 +239,7 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 		game.forces[enemyBitersForceName].evolution_factor = game.forces[biter_force_name].evolution_factor
 		global.bb_evolution[enemyBitersForceName] = global.bb_evolution[biter_force_name]
 		global.bb_threat_income[enemyBitersForceName] = evo * 25
-		global.bb_threat[enemyBitersForceName] = global.bb_threat[enemyBitersForceName] + threat
+		global.bb_threat[enemyBitersForceName] = math_round(global.bb_threat[enemyBitersForceName] + threat, decimals)
 	end
 end
 

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -233,6 +233,22 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 		threat = threat * (100 / (100.001 - reanim_chance))
 	end
 	global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name] + threat, decimals)
+	
+	if global.active_special_games["shared_science_throw"] then
+		local enemyBitersForceName = ""
+		if biter_force_name == "south_biters" then
+			enemyBitersForceName = "north_biters"
+		else
+			enemyBitersForceName = "south_biters"
+		end
+		local maxEvo = math.max(game.forces["north_biters"].evolution_factor,game.forces["south_biters"].evolution_factor)
+		game.forces["north_biters"].evolution_factor = maxEvo
+		global.bb_evolution["north_biters"] = maxEvo
+		game.forces["south_biters"].evolution_factor = maxEvo
+		global.bb_evolution["south_biters"] = maxEvo
+		global.bb_threat_income[enemyBitersForceName] = evo * 25
+		global.bb_threat[enemyBitersForceName] = global.bb_threat[enemyBitersForceName] + threat
+	end
 end
 
 function Public.feed_biters(player, food)	

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -235,12 +235,7 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name] + threat, decimals)
 	
 	if global.active_special_games["shared_science_throw"] then
-		local enemyBitersForceName = ""
-		if biter_force_name == "south_biters" then
-			enemyBitersForceName = "north_biters"
-		else
-			enemyBitersForceName = "south_biters"
-		end
+		local enemyBitersForceName = tables.enemy_team_of[tables.force_translation[biter_force_name]] .. "_biters"
 		local maxEvo = math.max(game.forces["north_biters"].evolution_factor,game.forces["south_biters"].evolution_factor)
 		game.forces["north_biters"].evolution_factor = maxEvo
 		global.bb_evolution["north_biters"] = maxEvo

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -236,11 +236,10 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	
 	if global.active_special_games["shared_science_throw"] then
 		local enemyBitersForceName = tables.enemy_team_of[tables.force_translation[biter_force_name]] .. "_biters"
-		local maxEvo = math.max(game.forces["north_biters"].evolution_factor,game.forces["south_biters"].evolution_factor)
-		game.forces["north_biters"].evolution_factor = maxEvo
-		global.bb_evolution["north_biters"] = maxEvo
-		game.forces["south_biters"].evolution_factor = maxEvo
-		global.bb_evolution["south_biters"] = maxEvo
+		local maxEvoFactor = math.max(game.forces[biter_force_name].evolution_factor,game.forces[enemyBitersForceName].evolution_factor)
+		local maxBbEvo = math.max(global.bb_evolution[biter_force_name],global.bb_evolution[enemyBitersForceName])
+		game.forces[enemyBitersForceName].evolution_factor = maxEvoFactor
+		global.bb_evolution[enemyBitersForceName] = maxBbEvo
 		global.bb_threat_income[enemyBitersForceName] = evo * 25
 		global.bb_threat[enemyBitersForceName] = global.bb_threat[enemyBitersForceName] + threat
 	end

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -236,10 +236,8 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	
 	if global.active_special_games["shared_science_throw"] then
 		local enemyBitersForceName = tables.enemy_team_of[tables.force_translation[biter_force_name]] .. "_biters"
-		local maxEvoFactor = math.max(game.forces[biter_force_name].evolution_factor,game.forces[enemyBitersForceName].evolution_factor)
-		local maxBbEvo = math.max(global.bb_evolution[biter_force_name],global.bb_evolution[enemyBitersForceName])
-		game.forces[enemyBitersForceName].evolution_factor = maxEvoFactor
-		global.bb_evolution[enemyBitersForceName] = maxBbEvo
+		game.forces[enemyBitersForceName].evolution_factor = game.forces[biter_force_name].evolution_factor
+		global.bb_evolution[enemyBitersForceName] = global.bb_evolution[biter_force_name]
 		global.bb_threat_income[enemyBitersForceName] = evo * 25
 		global.bb_threat[enemyBitersForceName] = global.bb_threat[enemyBitersForceName] + threat
 	end

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -235,7 +235,7 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name] + threat, decimals)
 	
 	if global.active_special_games["shared_science_throw"] then
-		local enemyBitersForceName = tables.enemy_team_of[tables.force_translation[biter_force_name]] .. "_biters"
+		local enemyBitersForceName = enemy_team_of[force_translation[biter_force_name]] .. "_biters"
 		game.forces[enemyBitersForceName].evolution_factor = game.forces[biter_force_name].evolution_factor
 		global.bb_evolution[enemyBitersForceName] = global.bb_evolution[biter_force_name]
 		global.bb_threat_income[enemyBitersForceName] = evo * 25


### PR DESCRIPTION
### Brief description of the changes:
Special event I heard requested multiple times, basically evo is identical between both teams and the throw is shared for both teams (same +threat and +evo).

### Tested Changes:
- [x] I've tested the changes locally alone.
- [ ] I've not tested the changes.
