### PR TITLE
Change river function

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -169,7 +169,7 @@ function Public.draw_structures()
 	Terrain.generate_spawn_ore(surface)
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
-	Terrain.draw_spawn_circle(surface)
+	Terrain.draw_spawn_island(surface)
 	--Terrain.generate_spawn_goodies(surface)
 end
 

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -408,9 +408,8 @@ function Public.draw_spawn_island(surface)
 	for x = math_floor(spawn_island_size) * -1, -1, 1 do
 		for y = math_floor(spawn_island_size) * -1, -1, 1 do
 			local pos = {x = x, y = y}
-			local distance_to_center = math_sqrt(pos.x ^ 2 + pos.y ^ 2)
-			local pos = {x = x, y = y}
 			if is_within_spawn_island(pos) then
+			    local distance_to_center = tile_distance_to_center(pos)
                 local tile_name = "refined-concrete"
                 if distance_to_center < 6.3 then
                     tile_name = "sand-1"

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -656,7 +656,7 @@ end
 function Public.restrict_landfill(surface, user, tiles)
 	for _, t in pairs(tiles) do
 		local check_position = t.position
-		if check_position.y > 0 then check_position = {x = check_position.x * -1, y = (check_position.y * -1) - 1} end
+		if check_position.y > 0 then check_position = {x = check_position.x, y = (check_position.y * -1) - 1} end
 		local trusted = session.get_trusted_table()
 		if is_horizontal_border_river(check_position) then
 			surface.set_tiles({{name = t.old_tile.name, position = t.position}}, true)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -409,20 +409,20 @@ function Public.draw_spawn_island(surface)
 		for y = math_floor(spawn_island_size) * -1, -1, 1 do
 			local pos = {x = x, y = y}
 			if is_within_spawn_island(pos) then
-			    local distance_to_center = tile_distance_to_center(pos)
-                local tile_name = "refined-concrete"
-                if distance_to_center < 6.3 then
-                    tile_name = "sand-1"
-                end
+				local distance_to_center = tile_distance_to_center(pos)
+				local tile_name = "refined-concrete"
+				if distance_to_center < 6.3 then
+					tile_name = "sand-1"
+				end
 
-                if global.bb_settings['new_year_island'] then
-                    tile_name = "blue-refined-concrete"
-                    if distance_to_center < 6.3 then
-                        tile_name = "lab-white"
-                    end
-                end
+				if global.bb_settings['new_year_island'] then
+					tile_name = "blue-refined-concrete"
+					if distance_to_center < 6.3 then
+						tile_name = "lab-white"
+					end
+				end
 
-                table_insert(tiles, {name = tile_name, position = pos})
+				table_insert(tiles, {name = tile_name, position = pos})
 			end
 		end
 	end

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -424,8 +424,8 @@ function Public.draw_spawn_island(surface)
 
 	local island_area = {{-spawn_island_size, -spawn_island_size}, {spawn_island_size, 0}}
 	surface.destroy_decoratives({area = island_area})
-	for _, tree in pairs(surface.find_entities_filtered({type = "tree", area = island_area})) do
-		tree.destroy()
+	for _, entity in pairs(surface.find_entities(island_area)) do
+		entity.destroy()
 	end
 end
 


### PR DESCRIPTION
The main change in this PR is that the water around the island is now considered part of the river and is generated with it.
Previously, the water around the island (spawn circle) was drawn on top of everything, now only the island is drawn this way.
Features
- Only one function to check the river, no need to do extra check on spawn circle
- The water around the island is now exactly 39 tiles as specified
- No fish under island
- Added a single check for the river when generating the starting area, which should fix #174 for sure

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
