### PR TITLE
difficulty_vote: prevent voting same difficulty.

### DIFF
--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -155,7 +155,7 @@ local function on_gui_click(event)
         return
     end
 	
-	if not (global.difficulty_player_votes[player.name] == i) or global.difficulty_player_votes[player.name] == nil then
+	if global.difficulty_player_votes[player.name] ~= i then
 		game.print(player.name .. " has voted for " .. difficulties[i].name .. " difficulty!", difficulties[i].print_color)
 		global.difficulty_player_votes[player.name] = i	
 		set_difficulty()	

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -157,10 +157,12 @@ local function on_gui_click(event)
 	
 	if not (global.difficulty_player_votes[player.name] == i) or global.difficulty_player_votes[player.name] == nil then
 		game.print(player.name .. " has voted for " .. difficulties[i].name .. " difficulty!", difficulties[i].print_color)
-		global.difficulty_player_votes[player.name] = i
+		global.difficulty_player_votes[player.name] = i	
+		set_difficulty()	
+		difficulty_gui_all()
+	else
+		player.print("You already voted for this difficulty", {r = 0.98, g = 0.66, b = 0.22})
 	end
-	set_difficulty()
-	difficulty_gui_all()
 	event.element.parent.destroy()
 end
 	

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -155,8 +155,10 @@ local function on_gui_click(event)
         return
     end
 	
-	game.print(player.name .. " has voted for " .. difficulties[i].name .. " difficulty!", difficulties[i].print_color)
-	global.difficulty_player_votes[player.name] = i
+	if not (global.difficulty_player_votes[player.name] == i) or global.difficulty_player_votes[player.name] == nil then
+		game.print(player.name .. " has voted for " .. difficulties[i].name .. " difficulty!", difficulties[i].print_color)
+		global.difficulty_player_votes[player.name] = i
+	end
 	set_difficulty()
 	difficulty_gui_all()
 	event.element.parent.destroy()


### PR DESCRIPTION
Some players tend to vote same difficulty many time in short period of time. Each vote print same messages in chat. This code prevent printing in chat message if the current vote is same as previous.


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
