### PR TITLE
Add snow cover to map

### DIFF
--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -155,9 +155,9 @@ local functions = {
 		end
 	end,
 	["comfy_panel_snow_cover"] = function(event)
-        global.bb_settings['snow_cover_next'] = event.element.selected_index
+		global.bb_settings['snow_cover_next'] = event.element.selected_index
 		if global.bb_settings['snow_cover_next'] ~= SnowCover.type_none then
-            get_actor(event, '{Snow Cover}', "Snow Cover \"" .. SnowCover.types[global.bb_settings['snow_cover_next']] .. "\" has been enabled!", true)
+			get_actor(event, '{Snow Cover}', "Snow Cover \"" .. SnowCover.types[global.bb_settings['snow_cover_next']] .. "\" has been enabled!", true)
 		else
 			get_actor(event, '{Snow Cover}', "Snow Cover has been disabled!", true)
 		end

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -3,6 +3,7 @@ local Score = require "comfy_panel.score"
 local Tables = require "maps.biter_battles_v2.tables"
 local fifo = require "maps.biter_battles_v2.fifo"
 local Blueprint = require 'maps.biter_battles_v2.blueprints'
+local SnowCover = require 'maps.biter_battles_v2.snow_cover'
 
 local Public = {}
 
@@ -119,6 +120,9 @@ function Public.initial_setup()
 		--TEAM SETTINGS--
 		["team_balancing"] = true,			--Should players only be able to join a team that has less or equal members than the opposing team?
 		["only_admins_vote"] = false,		--Are only admins able to vote on the global difficulty?
+
+		["snow_cover"] = SnowCover.type_none,				-- Snow cover for current surface
+		["snow_cover_next"] = SnowCover.type_none,			-- Snow cover for next surface
 	}
 
 	--Disable Nauvis
@@ -170,6 +174,7 @@ function Public.draw_structures()
 	Terrain.generate_additional_rocks(surface)
 	Terrain.generate_silo(surface)
 	Terrain.draw_spawn_circle(surface)
+	Terrain.draw_snow_spawn_area(surface)
 	--Terrain.generate_spawn_goodies(surface)
 end
 
@@ -270,6 +275,10 @@ function Public.tables()
 
 	global.next_attack = "north"
 	if math.random(1,2) == 1 then global.next_attack = "south" end
+
+	if global.bb_settings then
+		global.bb_settings["snow_cover"] = SnowCover.get_next_snow_cover()
+	end
 end
 
 function Public.load_spawn()

--- a/maps/biter_battles_v2/snow_cover.lua
+++ b/maps/biter_battles_v2/snow_cover.lua
@@ -87,7 +87,7 @@ function Public.generate_snow(surface, left_top_x, left_top_y)
 
 
 	local tiles = {}
-	local replace_trees = {}
+	local replace_tree_positions = {}
 	for x = 0, 31, 1 do
 		for y = 0, 31, 1 do
 			local pos = {x = left_top_x + x, y = left_top_y + y}
@@ -117,7 +117,7 @@ function Public.generate_snow(surface, left_top_x, left_top_y)
 			end
 
 			table_insert(tiles, {name = "lab-white", position = pos})
-			replace_trees[pos.x .. "_" .. pos.y] = true
+			replace_tree_positions[pos.x .. "_" .. pos.y] = true
 
 			::continue::
 		end
@@ -125,33 +125,30 @@ function Public.generate_snow(surface, left_top_x, left_top_y)
 
 	surface.set_tiles(tiles, true)
 
-	for _, entity in pairs(surface.find_entities({{left_top_x, left_top_y}, {left_top_x + 32, left_top_y + 32}})) do
-		if entity.type == "tree" then
-			local name = nil
-
-			if entity.name == "tree-02"
-				or entity.name == "tree-02-red"
-				or entity.name == "tree-03"
-				or entity.name == "tree-05"
-				or entity.name == "tree-07"
-			then
-				name = "tree-01"
-			end
-
-			if entity.name == "tree-08"
-				or entity.name == "tree-08-red"
-				or entity.name == "tree-08-brown"
-				or entity.name == "tree-09"
-				or entity.name == "tree-09-red"
-				or entity.name == "tree-09-brown"
-			then
-				name = "tree-04"
-			end
-
-			if name then
+	local replace_tree_names = {
+		["tree-02"] = "tree-01",
+		["tree-02-red"] = "tree-01",
+		["tree-03"] = "tree-01",
+		["tree-05"] = "tree-01",
+		["tree-07"] = "tree-01",
+		["tree-08"] = "tree-04",
+		["tree-08-red"] = "tree-04",
+		["tree-08-brown"] = "tree-04",
+		["tree-09"] = "tree-04",
+		["tree-09-red"] = "tree-04",
+		["tree-09-brown"] = "tree-04",
+	}
+	local entities = surface.find_entities_filtered({
+		area = {{left_top_x, left_top_y}, {left_top_x + 32, left_top_y + 32}},
+		type = "tree",
+	})
+	for _, entity in pairs(entities) do
+		if entity.valid then
+			local name = replace_tree_names[entity.name]
+			if name ~= nil then
 				local pos = entity.position
 				local tile_pos = {x = math_floor(pos.x), y = math_floor(pos.y)}
-				if replace_trees[tile_pos.x .. "_" .. tile_pos.y] then
+				if replace_tree_positions[tile_pos.x .. "_" .. tile_pos.y] then
 					entity.destroy()
 					surface.create_entity({name = name, position = pos})
 				end

--- a/maps/biter_battles_v2/snow_cover.lua
+++ b/maps/biter_battles_v2/snow_cover.lua
@@ -1,0 +1,163 @@
+local table_insert = table.insert
+local math_round = math.round
+local math_floor = math.floor
+
+local Public = {}
+
+Public.type_none = 1
+Public.type_full = 2
+Public.type_desert = 3
+Public.type_grass = 4
+Public.type_small = 5
+Public.type_random = 6
+
+Public.types = {
+    [Public.type_none] = "none",
+    [Public.type_full] = "full snow",
+    [Public.type_desert] = "desert+snow",
+    [Public.type_grass] = "grass+snow",
+    [Public.type_small] = "small snow",
+    [Public.type_random] = "random above",
+}
+
+local random_types = {
+    Public.type_full,
+    Public.type_desert,
+    Public.type_grass,
+    Public.type_small,
+}
+
+function Public.get_next_snow_cover()
+    if global.bb_settings["snow_cover_next"] == Public.type_random then
+        return random_types[math_round(#random_types)]
+    end
+
+    return global.bb_settings["snow_cover_next"]
+end
+
+Public.transition_tiles = {
+    ["brown-refined-concrete"] = true,
+    ["orange-refined-concrete"] = true,
+}
+
+local function get_trans_tile(src_tile)
+	if src_tile == "red-desert-0" or src_tile == "red-desert-1" or global.bb_settings["snow_cover"] == Public.type_desert then
+		return "orange-refined-concrete"
+	else
+		return "brown-refined-concrete"
+	end
+end
+
+function Public.draw_biter_area_border(surface, pos)
+    local adjacent_positions = {
+        {x = pos.x - 1, y = pos.y},
+        {x = pos.x, y = pos.y - 1},
+        {x = pos.x + 1, y = pos.y},
+        {x = pos.x, y = pos.y + 1},
+    }
+    for _, adjacent_pos in pairs(adjacent_positions) do
+        if surface.get_tile(adjacent_pos).name == "lab-white" then
+            surface.set_tiles({{name = "orange-refined-concrete", position = adjacent_pos}})
+        end
+    end
+end
+
+function Public.generate_snow(surface, left_top_x, left_top_y)
+    local current_type = global.bb_settings["snow_cover"]
+	local protected = {
+		["deepwater"] = true,
+		["water"] = true,
+		["stone-path"] = true,
+	}
+
+    if current_type == Public.type_desert or current_type == Public.type_small then
+        protected["red-desert-0"] = true
+        protected["red-desert-1"] = true
+    end
+
+    if current_type == Public.type_grass or current_type == Public.type_small then
+        protected["grass-1"] = true
+        protected["grass-2"] = true
+    end
+
+    if current_type == Public.type_small then
+        protected["dirt-1"] = true
+        protected["dirt-2"] = true
+    end
+
+
+	local tiles = {}
+	local replace_trees = {}
+	for x = 0, 31, 1 do
+		for y = 0, 31, 1 do
+			local pos = {x = left_top_x + x, y = left_top_y + y}
+
+			if is_horizontal_border_river(pos) then
+				goto continue
+			end
+
+			local tile_name = surface.get_tile(pos).name
+			if protected[tile_name] or Public.transition_tiles[tile_name] then
+				goto continue
+			end
+
+			local adjacent_positions = {
+				{x = pos.x - 1, y = pos.y},
+				{x = pos.x, y = pos.y - 1},
+				{x = pos.x + 1, y = pos.y},
+				{x = pos.x, y = pos.y + 1},
+			}
+
+			for _, adjacent_pos in pairs(adjacent_positions) do
+				tile_name = surface.get_tile(adjacent_pos).name
+				if protected[tile_name] then
+					table_insert(tiles, {name = get_trans_tile(tile_name), position = pos})
+					goto continue
+				end
+			end
+
+			table_insert(tiles, {name = "lab-white", position = pos})
+			replace_trees[pos.x .. "_" .. pos.y] = true
+
+			::continue::
+		end
+	end
+
+	surface.set_tiles(tiles, true)
+
+	for _, entity in pairs(surface.find_entities({{left_top_x, left_top_y}, {left_top_x + 32, left_top_y + 32}})) do
+		if entity.type == "tree" then
+            local name = nil
+
+			if entity.name == "tree-02"
+				or entity.name == "tree-02-red"
+				or entity.name == "tree-03"
+				or entity.name == "tree-05"
+				or entity.name == "tree-07"
+			then
+				name = "tree-01"
+            end
+
+            if entity.name == "tree-08"
+                or entity.name == "tree-08-red"
+                or entity.name == "tree-08-brown"
+                or entity.name == "tree-09"
+                or entity.name == "tree-09-red"
+                or entity.name == "tree-09-brown"
+            then
+                name = "tree-04"
+            end
+
+            if name then
+				local pos = entity.position
+				local tile_pos = {x = math_floor(pos.x), y = math_floor(pos.y)}
+				if replace_trees[tile_pos.x .. "_" .. tile_pos.y] then
+					entity.destroy()
+					surface.create_entity({name = name, position = pos})
+				end
+			end
+		end
+	end
+end
+
+return Public

--- a/maps/biter_battles_v2/snow_cover.lua
+++ b/maps/biter_battles_v2/snow_cover.lua
@@ -12,32 +12,32 @@ Public.type_small = 5
 Public.type_random = 6
 
 Public.types = {
-    [Public.type_none] = "none",
-    [Public.type_full] = "full snow",
-    [Public.type_desert] = "desert+snow",
-    [Public.type_grass] = "grass+snow",
-    [Public.type_small] = "small snow",
-    [Public.type_random] = "random above",
+	[Public.type_none] = "none",
+	[Public.type_full] = "full snow",
+	[Public.type_desert] = "desert+snow",
+	[Public.type_grass] = "grass+snow",
+	[Public.type_small] = "small snow",
+	[Public.type_random] = "random above",
 }
 
 local random_types = {
-    Public.type_full,
-    Public.type_desert,
-    Public.type_grass,
-    Public.type_small,
+	Public.type_full,
+	Public.type_desert,
+	Public.type_grass,
+	Public.type_small,
 }
 
 function Public.get_next_snow_cover()
-    if global.bb_settings["snow_cover_next"] == Public.type_random then
-        return random_types[math_round(#random_types)]
-    end
+	if global.bb_settings["snow_cover_next"] == Public.type_random then
+		return random_types[math_round(#random_types)]
+	end
 
-    return global.bb_settings["snow_cover_next"]
+	return global.bb_settings["snow_cover_next"]
 end
 
 Public.transition_tiles = {
-    ["brown-refined-concrete"] = true,
-    ["orange-refined-concrete"] = true,
+	["brown-refined-concrete"] = true,
+	["orange-refined-concrete"] = true,
 }
 
 local function get_trans_tile(src_tile)
@@ -49,41 +49,41 @@ local function get_trans_tile(src_tile)
 end
 
 function Public.draw_biter_area_border(surface, pos)
-    local adjacent_positions = {
-        {x = pos.x - 1, y = pos.y},
-        {x = pos.x, y = pos.y - 1},
-        {x = pos.x + 1, y = pos.y},
-        {x = pos.x, y = pos.y + 1},
-    }
-    for _, adjacent_pos in pairs(adjacent_positions) do
-        if surface.get_tile(adjacent_pos).name == "lab-white" then
-            surface.set_tiles({{name = "orange-refined-concrete", position = adjacent_pos}})
-        end
-    end
+	local adjacent_positions = {
+		{x = pos.x - 1, y = pos.y},
+		{x = pos.x, y = pos.y - 1},
+		{x = pos.x + 1, y = pos.y},
+		{x = pos.x, y = pos.y + 1},
+	}
+	for _, adjacent_pos in pairs(adjacent_positions) do
+		if surface.get_tile(adjacent_pos).name == "lab-white" then
+			surface.set_tiles({{name = "orange-refined-concrete", position = adjacent_pos}})
+		end
+	end
 end
 
 function Public.generate_snow(surface, left_top_x, left_top_y)
-    local current_type = global.bb_settings["snow_cover"]
+	local current_type = global.bb_settings["snow_cover"]
 	local protected = {
 		["deepwater"] = true,
 		["water"] = true,
 		["stone-path"] = true,
 	}
 
-    if current_type == Public.type_desert or current_type == Public.type_small then
-        protected["red-desert-0"] = true
-        protected["red-desert-1"] = true
-    end
+	if current_type == Public.type_desert or current_type == Public.type_small then
+		protected["red-desert-0"] = true
+		protected["red-desert-1"] = true
+	end
 
-    if current_type == Public.type_grass or current_type == Public.type_small then
-        protected["grass-1"] = true
-        protected["grass-2"] = true
-    end
+	if current_type == Public.type_grass or current_type == Public.type_small then
+		protected["grass-1"] = true
+		protected["grass-2"] = true
+	end
 
-    if current_type == Public.type_small then
-        protected["dirt-1"] = true
-        protected["dirt-2"] = true
-    end
+	if current_type == Public.type_small then
+		protected["dirt-1"] = true
+		protected["dirt-2"] = true
+	end
 
 
 	local tiles = {}
@@ -127,7 +127,7 @@ function Public.generate_snow(surface, left_top_x, left_top_y)
 
 	for _, entity in pairs(surface.find_entities({{left_top_x, left_top_y}, {left_top_x + 32, left_top_y + 32}})) do
 		if entity.type == "tree" then
-            local name = nil
+			local name = nil
 
 			if entity.name == "tree-02"
 				or entity.name == "tree-02-red"
@@ -136,19 +136,19 @@ function Public.generate_snow(surface, left_top_x, left_top_y)
 				or entity.name == "tree-07"
 			then
 				name = "tree-01"
-            end
+			end
 
-            if entity.name == "tree-08"
-                or entity.name == "tree-08-red"
-                or entity.name == "tree-08-brown"
-                or entity.name == "tree-09"
-                or entity.name == "tree-09-red"
-                or entity.name == "tree-09-brown"
-            then
-                name = "tree-04"
-            end
+			if entity.name == "tree-08"
+				or entity.name == "tree-08-red"
+				or entity.name == "tree-08-brown"
+				or entity.name == "tree-09"
+				or entity.name == "tree-09-red"
+				or entity.name == "tree-09-brown"
+			then
+				name = "tree-04"
+			end
 
-            if name then
+			if name then
 				local pos = entity.position
 				local tile_pos = {x = math_floor(pos.x), y = math_floor(pos.y)}
 				if replace_trees[tile_pos.x .. "_" .. tile_pos.y] then

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -160,7 +160,7 @@ local border_river_noise = 4
 local river_width_half_min = math_floor(bb_config.border_river_width * -0.5)
 local river_width_half_max = river_width_half_min - border_river_noise
 -- pos must be from the North side
-local function is_horizontal_border_river(pos)
+function is_horizontal_border_river(pos)
 	if tile_distance_to_center(pos) < river_circle_size then return true end
 	if pos.y < river_width_half_max then return false end
 	if pos.y > river_width_half_min then return true end

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -393,7 +393,7 @@ function Public.generate(event)
 	mixed_ore(surface, left_top_x, left_top_y)
 	generate_river(surface, left_top_x, left_top_y)
 	if global.bb_settings["snow_cover"] ~= SnowCover.type_none then
-	    SnowCover.generate_snow(surface, left_top_x, left_top_y)
+		SnowCover.generate_snow(surface, left_top_x, left_top_y)
 	end
 	draw_biter_area(surface, left_top_x, left_top_y)		
 	generate_extra_worm_turrets(surface, left_top)


### PR DESCRIPTION
The goal of this PR is to add "snow cover" to the map. To create a winter mood and bring variety to the game. Snow is simulated by lab-white tiles and therefore has some limitations compared to ordinary tiles, for example, snow does not have a transition with ordinary tiles, so special concrete tiles are used as transit tiles.

Features:
- Admins have the ability to enable and disable the snow cover through the config. Changes are applied only to the map of the next game.
- Several snow coverage modes, with different amounts of snow on the map + random mode
- Made better looking trees in areas with snow

![image](https://user-images.githubusercontent.com/88335092/208282231-e5611555-fd71-4370-bf26-c57a5c1b5baa.png)

Of course, snow cover will affect the performance of map generation, but this is a price that must be paid only once when generating a chunk. I did not do tests performance, but it was playable locally.