### PR TITLE
fix team name on biters spotted

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -174,12 +174,16 @@ local function spawn_biters(isItnormalBiters, maxLoopIteration,spawner,biter_thr
 		end
 		
 		--Announce New Spawn
+		local team_name = force_name
+		if global.tm_custom_name[force_name] ~= nil then
+			team_name = global.tm_custom_name[force_name]
+		end
 		if(isItnormalBiters and global.biter_spawn_unseen[force_name][unit_name]) then
-			game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. force_name .. "...")
+			game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. team_name .. "...")
 			global.biter_spawn_unseen[force_name][unit_name] = false
 		end
 		if(not isItnormalBiters and global.biter_spawn_unseen[boss_biter_force_name][unit_name]) then
-			game.print("A " .. unit_name:gsub("-", " ") .. " boss was spotted far away on team " .. force_name .. "...")
+			game.print("A " .. unit_name:gsub("-", " ") .. " boss was spotted far away on team " .. team_name .. "...")
 			global.biter_spawn_unseen[boss_biter_force_name][unit_name] = false
 		end
 	end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -174,16 +174,12 @@ local function spawn_biters(isItnormalBiters, maxLoopIteration,spawner,biter_thr
 		end
 		
 		--Announce New Spawn
-		local team_name = force_name
-		if global.tm_custom_name[force_name] ~= nil then
-			team_name = global.tm_custom_name[force_name]
-		end
 		if(isItnormalBiters and global.biter_spawn_unseen[force_name][unit_name]) then
-			game.print("A " .. unit_name:gsub("-", " ") .. " was spotted far away on team " .. team_name .. "...")
+			game.print({"", "A ", unit_name:gsub("-", " "), " was spotted far away on team ", (global.tm_custom_name[force_name] or force_name), "..."})
 			global.biter_spawn_unseen[force_name][unit_name] = false
 		end
 		if(not isItnormalBiters and global.biter_spawn_unseen[boss_biter_force_name][unit_name]) then
-			game.print("A " .. unit_name:gsub("-", " ") .. " boss was spotted far away on team " .. team_name .. "...")
+			game.print({"", "A ", unit_name:gsub("-", " "), " boss was spotted far away on team ", (global.tm_custom_name[force_name] or force_name), "..."})
 			global.biter_spawn_unseen[boss_biter_force_name][unit_name] = false
 		end
 	end


### PR DESCRIPTION
message printed in chat when biters are spotted kept default names "north" "south" after those names got changed in team manager.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
