### PR TITLE
Bugfix to avoid spam of error in log when decon

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -186,7 +186,7 @@ end
 
 local function on_marked_for_deconstruction(event)
 	if not event.entity.valid then return end
-	if not event.player_index == nil then return end
+	if not event.player_index then return end
 	if event.entity.name == "fish" then event.entity.cancel_deconstruction(game.players[event.player_index].force.name) end
 	
 	if (game.players[event.player_index].force == game.forces.north and event.entity.position.y > 0) or (game.players[event.player_index].force == game.forces.south and event.entity.position.y < 0) then

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -186,6 +186,7 @@ end
 
 local function on_marked_for_deconstruction(event)
 	if not event.entity.valid then return end
+	if not event.player_index == nil then return end
 	if event.entity.name == "fish" then event.entity.cancel_deconstruction(game.players[event.player_index].force.name) end
 	
 	if (game.players[event.player_index].force == game.forces.north and event.entity.position.y > 0) or (game.players[event.player_index].force == game.forces.south and event.entity.position.y < 0) then

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -187,10 +187,10 @@ end
 local function on_marked_for_deconstruction(event)
 	if not event.entity.valid then return end
 	if not event.player_index then return end
-	if event.entity.name == "fish" then event.entity.cancel_deconstruction(game.players[event.player_index].force.name) end
-	
-	if (game.players[event.player_index].force == game.forces.north and event.entity.position.y > 0) or (game.players[event.player_index].force == game.forces.south and event.entity.position.y < 0) then
-		event.entity.cancel_deconstruction(game.players[event.player_index].force.name)
+	local force_name = game.get_player(event.player_index).force.name
+	if event.entity.name == "fish" then event.entity.cancel_deconstruction(force_name) return end
+	if (force == "north" and event.entity.position.y > 0) or (force_name == "south" and event.entity.position.y < 0) then
+		event.entity.cancel_deconstruction(force_name)
 	end
 end
 


### PR DESCRIPTION
### Brief description of the changes:
Sometimes you see the following error in log : bad argument #3 of #3 to __index (string expected, got nil) in the if, this PR should fix it (I couldn't reproduce it...) but from the line of if, only player_index which can be optional seem to be a cause of this issue.

Should fix https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/issues/308
Maybe someone has more info..

### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
