### PR TITLE
feat(gui): show game speed next to game time

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -54,7 +54,7 @@ local function clock(frame)
 	local total_hours = math.floor(total_minutes / 60)
 	local minutes = total_minutes - (total_hours * 60)
 
-	local clock = frame.add {type = "label", caption = string.format("Game time: %02d:%02d    Game speed: %.2f", total_hours, minutes, game.speed)}
+	local clock = frame.add {type = "label", caption = string.format("Time: %02d:%02d   Speed: %.2f", total_hours, minutes, game.speed)}
 	clock.style.font = "default-bold"
 	clock.style.font_color = {r = 0.98, g = 0.66, b = 0.22}
 	frame.add {type = "line"}

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -54,7 +54,7 @@ local function clock(frame)
 	local total_hours = math.floor(total_minutes / 60)
 	local minutes = total_minutes - (total_hours * 60)
 
-	local clock = frame.add {type = "label", caption = "Game time: " .. string.format("%02d", total_hours) .. ":" .. string.format("%02d", minutes)}
+	local clock = frame.add {type = "label", caption = string.format("Game time: %02d:%02d    Game speed: %.2f", total_hours, minutes, game.speed)}
 	clock.style.font = "default-bold"
 	clock.style.font_color = {r = 0.98, g = 0.66, b = 0.22}
 	frame.add {type = "line"}


### PR DESCRIPTION
### Brief description of the changes:
show game speed next to game time

![image](https://user-images.githubusercontent.com/5616556/212559162-9adc1384-e78f-4be4-8408-2626da41a7f0.png)

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
