### PR TITLE
Do not allow players to create a new group with the name of an existing group

### DIFF
--- a/comfy_panel/group.lua
+++ b/comfy_panel/group.lua
@@ -252,7 +252,7 @@ local function on_gui_click(event)
                 return
             end
 
-            if this.tag_groups[new_group_name] ~= nil
+            if this.tag_groups[new_group_name] ~= nil then
                 player.print('Group name is taken.', {r = 0.90, g = 0.0, b = 0.0})
                 return
             end

--- a/comfy_panel/group.lua
+++ b/comfy_panel/group.lua
@@ -252,6 +252,11 @@ local function on_gui_click(event)
                 return
             end
 
+            if this.tag_groups[new_group_name] ~= nil
+                player.print('Group name is taken.', {r = 0.90, g = 0.0, b = 0.0})
+                return
+            end
+
             this.tag_groups[new_group_name] = {
                 name = new_group_name,
                 description = new_group_description,


### PR DESCRIPTION
### Description
Don't let players make a group if the group name is already taken.

Fix for https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/issues/350

### Tested Changes:
* [x]  I've tested the changes locally or with people.
* [ ]  I've not tested the changes.
