### PR TITLE
close other panels when opening new

### DIFF
--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -130,25 +130,38 @@ local function on_player_joined_game(event)
     top_button(game.players[event.player_index])
 end
 
-local function close_other_gui(event)
-    local player = game.get_player(event.player_index)
-    local gui_buttons = {
-        ["comfy_panel_top_button"] = true,
-        ["bb_toggle_button"] = true,
-        ["114"] = true
-    } 
-    if not gui_buttons[event.element.name] then return end
+local function close_other_gui(event)  
+    if not event.element then
+        return
+    end
+    if not event.element.valid then
+        return
+    end
+    local player = game.players[event.player_index]  
     local gui_panels = {
-        ["comfy_panel"] = true,
-        ["bb_main_gui"] = true,
-        ["115"] = true
-    }
+        "comfy_panel",
+        "bb_main_gui",
+        "115",
+	}
+    local gui_buttons = {
+        "comfy_panel_top_button",
+        "bb_toggle_button",
+        "114",
+	}
+    local is_on_list = false
+    for _, value in pairs(gui_buttons) do
+	if value == event.element.name then 
+		 is_on_list = true		
+	end
+    end
     for k, v in pairs(gui_buttons) do 
-        if not (player.gui.top[v].name == event.element.name) then
-            if player.gui.left[gui_panels[k]] then
-                player.gui.left[gui_panels[k]].destroy()
+	if is_on_list then
+            if not (player.gui.top[v].name == event.element.name) then  
+                if player.gui.left[gui_panels[k]] then            
+                   player.gui.left[gui_panels[k]].destroy()               
+                end	
             end
-        end
+	end	        
     end
 end
 

--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -130,34 +130,26 @@ local function on_player_joined_game(event)
     top_button(game.players[event.player_index])
 end
 
-local function close_other_gui(event)   
-    local player = game.players[event.player_index]  
-    local gui_panels = {
-        "comfy_panel",
-        "bb_main_gui",
-        "115",
-        }
-
+local function close_other_gui(event)
+    local player = game.get_player(event.player_index)
     local gui_buttons = {
-        "comfy_panel_top_button",
-        "bb_toggle_button",
-        "114",
-        } 
-	local is_on_list = false
-	for _, value in pairs(gui_buttons) do
-		if value == event.element.name then 
-		    is_on_list = true		
-		end
-    end
-	for k, v in pairs(gui_buttons) do 
-		if is_on_list then
-            if not (player.gui.top[v].name == event.element.name) then  
-                if player.gui.left[gui_panels[k]] then            
-                   player.gui.left[gui_panels[k]].destroy()               
-                end	
+        ["comfy_panel_top_button"] = true,
+        ["bb_toggle_button"] = true,
+        ["114"] = true
+    } 
+    if not gui_buttons[event.element.name] the return end
+    local gui_panels = {
+        ["comfy_panel"] = true,
+        ["bb_main_gui"] = true,
+        ["115"] = true
+    }
+    for k, v in pairs(gui_buttons) do 
+        if not (player.gui.top[v].name == event.element.name) then
+            if player.gui.left[gui_panels[k]] then
+                player.gui.left[gui_panels[k]].destroy()
             end
-		end	        
-	end
+        end
+    end
 end
 
 local function on_gui_click(event)

--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -137,7 +137,7 @@ local function close_other_gui(event)
         ["bb_toggle_button"] = true,
         ["114"] = true
     } 
-    if not gui_buttons[event.element.name] the return end
+    if not gui_buttons[event.element.name] then return end
     local gui_panels = {
         ["comfy_panel"] = true,
         ["bb_main_gui"] = true,

--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -130,6 +130,36 @@ local function on_player_joined_game(event)
     top_button(game.players[event.player_index])
 end
 
+local function close_other_gui(event)   
+    local player = game.players[event.player_index]  
+    local gui_panels = {
+        "comfy_panel",
+        "bb_main_gui",
+        "115",
+        }
+
+    local gui_buttons = {
+        "comfy_panel_top_button",
+        "bb_toggle_button",
+        "114",
+        } 
+	local is_on_list = false
+	for _, value in pairs(gui_buttons) do
+		if value == event.element.name then 
+		    is_on_list = true		
+		end
+    end
+	for k, v in pairs(gui_buttons) do 
+		if is_on_list then
+            if not (player.gui.top[v].name == event.element.name) then  
+                if player.gui.left[gui_panels[k]] then            
+                   player.gui.left[gui_panels[k]].destroy()               
+                end	
+            end
+		end	        
+	end
+end
+
 local function on_gui_click(event)
     if not event.element then
         return
@@ -167,6 +197,7 @@ local function on_gui_click(event)
 end
 
 event.add(defines.events.on_player_joined_game, on_player_joined_game)
+event.add(defines.events.on_gui_click, close_other_gui)
 event.add(defines.events.on_gui_click, on_gui_click)
 
 return Public


### PR DESCRIPTION
Brief description of the changes:
now only one of those 3 panels can be open. 
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/120744927/9ae4674e-b8f2-48a6-b4e7-6980f1caa997)

this will fix gui bug #294
 this new function is called before function that cause issue. 

Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
