### PR TITLE
feat: add send to server in admin gui

### DIFF
--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -506,17 +506,17 @@ local function on_gui_click(event)
 		player.print("To stop redirecting new players, run /stop-send-to-external-server")
 		for _, connected_player in pairs(game.connected_players) do
 			connected_player.connect_to_server{
-				address,
-				name,
-				description,
+				address = address,
+				name = name,
+				description = description
 			}
 		end
 
 		global.send_to_external_server_player_joined_game_handler = function(event)
 			game.get_player(event.player_index).connect_to_server{
-				address,
-				name,
-				description,
+				address = address,
+				name = name,
+				description = description
 			}
 		end
 		Event.add_removable_function(defines.events.on_player_joined_game, global.send_to_external_server_player_joined_game_handler)

--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -3,6 +3,7 @@ local Color = require 'utils.color_presets'
 local Public = {}
 global.active_special_games = {}
 global.special_games_variables = {}
+
 local valid_special_games = {
 	--[[ 
 	Add your special game here.
@@ -99,8 +100,20 @@ local valid_special_games = {
 			[3] = {name = "label2", type = "label", caption = "(0 to reset)"},
 		},
 		button = {name = "limited_lives_apply", type = "button", caption = "Apply"}
-	}
+	},
 
+	send_to_external_server = {
+		name = {type = "label", caption = "Send to external server", tooltip = "Sends all online players an invite to an external server"},
+		config =  {
+			[1] = {name = "label1", type = "label", caption = "IP address"},
+			[2] = {name = "address", type = "textfield", width = 90},
+			[3] = {name = "label2", type = "label", caption = "Server name"},
+			[4] = {name = "server_name", type = "textfield", width = 100},
+			[5] = {name = "label3", type = "label", caption = "Message"},
+			[6] = {name = "description", type = "textfield", width = 100},
+		},
+		button = {name = "send_to_external_server_btn", type = "button", caption = "Apply & Confirm"}
+	},
 }
 
 function Public.reset_active_special_games() for _, i in ipairs(global.active_special_games) do i = false end end
@@ -364,7 +377,7 @@ local create_special_games_panel = (function(player, frame)
 		local a = frame.add {type = "frame"}
 		a.style.width = 750
 		local table = a.add {name = k, type = "table", column_count = 3, draw_vertical_lines = true}
-		table.add(v.name).style.width = 100
+		table.add(v.name).style.width = 110
 		local config = table.add {name = k .. "_config", type = "flow", direction = "horizontal"}
 		config.style.width = 500
 		for _, i in ipairs(v.config) do
@@ -478,6 +491,25 @@ local function on_gui_click(event)
 		local lives_limit = tonumber(config["lives_limit"].text)
 
 		generate_limited_lives(lives_limit)
+
+	elseif element.name == "send_to_external_server_btn" then
+		local address = config["address"].text
+		local name = config["server_name"].text
+		local description = config["description"].text
+
+		if address == "" or name == "" or description == "" then
+			player.print("The target address, server name and description must be provided")
+			return
+		end
+
+		player.print("Sending players (other than host) to the specified server")
+		for _, connected_player in pairs(game.connected_players) do
+			connected_player.connect_to_server{
+				address,
+				name,
+				description,
+			}
+		end
 	end
 
 

--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -104,7 +104,7 @@ local valid_special_games = {
 	},
 
 	send_to_external_server = {
-		name = {type = "label", caption = "Send to external server", tooltip = "Sends all online players an invite to an external server"},
+		name = {type = "label", caption = "Send to external server", tooltip = "Sends all online players an invite to an external server.\nLeave empty to disable"},
 		config =  {
 			[1] = {name = "label1", type = "label", caption = "IP address"},
 			[2] = {name = "address", type = "textfield", width = 90},
@@ -372,11 +372,7 @@ end
 
 local send_to_external_server_handler = Token.register(
 	function(event)
-		game.get_player(event.player_index).connect_to_server{
-			address = global.special_games_variables.send_to_external_server.address,
-			name = global.special_games_variables.send_to_external_server.name,
-			description = global.special_games_variables.send_to_external_server.description
-		}
+		game.get_player(event.player_index).connect_to_server(global.special_games_variables.send_to_external_server)
 	end
 )
 
@@ -509,12 +505,12 @@ local function on_gui_click(event)
 		local description = config["description"].text
 
 		if address == "" or name == "" or description == "" then
-			player.print("The target address, server name and description must be provided")
+			Event.remove_removable(defines.events.on_player_joined_game, send_to_external_server_handler)
+			player.print("Stopped sending players to external server")
 			return
 		end
 
 		player.print("Sending players (other than host) to the specified server")
-		player.print("To stop redirecting new players, run /stop-send-to-external-server")
 		for _, connected_player in pairs(game.connected_players) do
 			connected_player.connect_to_server{
 				address = address,
@@ -553,17 +549,6 @@ local function on_player_died(event)
 		Color.warning
 	)
 end
-
-commands.add_command("stop-send-to-external-server", nil, function(command)
-	local command_player = game.get_player(command.player_index)
-	if not command_player.admin then
-		command_player.print("Only admins can stop sending players to external server")
-		return
-	end
-
-	command_player.print("Stopped sending players to external server")
-	Event.remove_removable(defines.events.on_player_joined_game, send_to_external_server_handler)
-  end)
 
 comfy_panel_tabs['Special games'] = {gui = create_special_games_panel, admin = true}
 

--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -503,6 +503,7 @@ local function on_gui_click(event)
 		end
 
 		player.print("Sending players (other than host) to the specified server")
+		player.print("To stop redirecting new players, run /stop-send-to-external-server")
 		for _, connected_player in pairs(game.connected_players) do
 			connected_player.connect_to_server{
 				address,
@@ -510,6 +511,15 @@ local function on_gui_click(event)
 				description,
 			}
 		end
+
+		global.send_to_external_server_player_joined_game_handler = function(event)
+			game.get_player(event.player_index).connect_to_server{
+				address,
+				name,
+				description,
+			}
+		end
+		Event.add_removable_function(defines.events.on_player_joined_game, global.send_to_external_server_player_joined_game_handler)
 	end
 
 
@@ -539,6 +549,17 @@ local function on_player_died(event)
 		Color.warning
 	)
 end
+
+commands.add_command("stop-send-to-external-server", nil, function(command)
+	local command_player = game.get_player(command.player_index)
+	if not command_player.admin then
+		command_player("Only admins can stop sending players to external server")
+		return
+	end
+
+	command_player.print("Stopped sending players to external server")
+	Event.remove_removable_function(defines.events.on_player_joined_game, global.send_to_external_server_player_joined_game_handler)
+  end)
 
 comfy_panel_tabs['Special games'] = {gui = create_special_games_panel, admin = true}
 


### PR DESCRIPTION
### Brief description of the changes:
Add item in admin GUI special games tab to send players to external server
so that we don't need to find the command everytime

![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/5616556/56672977-dba0-4b1f-bcfc-47f701fe7cc0)

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes. (can't connect to the same server with the same account name)
