### PR TITLE
Improved /inventory performance

### DIFF
--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -386,10 +386,6 @@ local function close_watchers(player)
     end
 end
 
--- TODO[discuss]: there is probably some redundant data in the `this` table
--- We are storing the watched player in multiple places:
---     this.tracking
---     this.data[player.index].player_opened
 local function update_gui(event)
     local watchers = this.tracking[event.player_index]
     local target = game.get_player(event.player_index)
@@ -445,7 +441,6 @@ local function update_gui(event)
     for watcher_idx, _ in pairs(watchers) do
         local watcher = game.get_player(watcher_idx)
 
-        -- should we discard / close watchers if they are invalid / disconnected?
         if not validate_object(watcher) then
             stop_watching_all(watcher_idx)
             goto continue

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -123,6 +123,10 @@ local function close_player_inventory(player)
         return
     end
 
+    if not data.player_opened then
+        return
+    end
+
     stop_watching(player.index, data.player_opened.index)
 
     local gui = player.gui.screen

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -276,7 +276,6 @@ local function open_inventory(source, target)
     end
 end
 
--- TODO: Refactor this, similar to update_gui
 local function on_gui_click(event)
     local player = game.players[event.player_index]
 
@@ -308,22 +307,28 @@ local function on_gui_click(event)
     data.last_tab = name
 
     local valid, target = player_opened(player)
-    if valid then
-        local main = target.get_main_inventory().get_contents()
-        local armor = target.get_inventory(defines.inventory.character_armor).get_contents()
-        local guns = target.get_inventory(defines.inventory.character_guns).get_contents()
-        local ammo = target.get_inventory(defines.inventory.character_ammo).get_contents()
-        local trash = target.get_inventory(defines.inventory.character_trash).get_contents()
 
-        local target_types = {
-            ['Main'] = main,
-            ['Armor'] = armor,
-            ['Guns'] = guns,
-            ['Ammo'] = ammo,
-            ['Trash'] = trash
+    if valid then
+        local target_inventories = {
+            ['Main'] = function()
+                return target.get_main_inventory().get_contents()
+            end,
+            ['Armor'] = function()
+                return target.get_inventory(defines.inventory.character_armor).get_contents()
+            end,
+            ['Guns'] = function()
+                return target.get_inventory(defines.inventory.character_guns).get_contents()
+            end,
+            ['Ammo'] = function()
+                return target.get_inventory(defines.inventory.character_ammo).get_contents()
+            end,
+            ['Trash'] = function()
+                return target.get_inventory(defines.inventory.character_trash).get_contents()
+            end
         }
+
         local frame = Public.get_active_frame(player)
-        local panel_type = target_types[name]
+        local panel_type = target_inventories[name]()
 
         redraw_inventory(frame, player, target, name, panel_type)
     end

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -395,12 +395,7 @@ local function update_gui(event)
         return
     end
     
-    local invisible = true
-    for _, _ in pairs(watchers) do
-        invisible = false
-        break
-    end
-    if invisible then
+    if table_size(watchers) <= 0 then
         this.tracking[event.player_index] = nil
         return
     end

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -249,7 +249,7 @@ local function open_inventory(source, target)
 
     local data = get_player_data(source)
 
-    this.tracking[target.index] = this.tracking[target.index] or {}
+    if not this.tracking[target.index] then this.tracking[target.index] = {} end
     table.insert(this.tracking[target.index], source.index)
 
     data.player_opened = target
@@ -407,16 +407,10 @@ local function update_gui(event)
         end
     }
 
-    local cache = {
-        ['Main'] = nil,
-        ['Armor'] = nil,
-        ['Guns'] = nil,
-        ['Ammo'] = nil,
-        ['Trash'] = nil
-    }
+    local cache = {}
 
     local function cache_get(key)
-        if cache[key] == nil then
+        if not cache[key] then
             cache[key] = target_inventories[key]()
         end
         return cache[key]

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -496,6 +496,10 @@ function Public.get(key)
 end
 
 Event.add(defines.events.on_player_main_inventory_changed, update_gui)
+Event.add(defines.events.on_player_gun_inventory_changed, update_gui)
+Event.add(defines.events.on_player_ammo_inventory_changed, update_gui)
+Event.add(defines.events.on_player_armor_inventory_changed, update_gui)
+Event.add(defines.events.on_player_trash_inventory_changed, update_gui)
 Event.add(defines.events.on_gui_closed, gui_closed)
 Event.add(defines.events.on_gui_click, on_gui_click)
 Event.add(defines.events.on_pre_player_left_game, on_pre_player_left_game)

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -395,7 +395,17 @@ local function update_gui(event)
     local target = game.get_player(event.player_index)
 
     -- can we skip updating GUIs for this change (are there no players watching?)
-    if watchers == nil or #watchers <= 0 then
+    if watchers == nil then
+        return
+    end
+    
+    local invisible = true
+    for _, _ in pairs(watchers) do
+        invisible = false
+        break
+    end
+    if invisible then
+        this.tracking[event.player_index] = nil
         return
     end
 

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -109,6 +109,12 @@ local function stop_watching_all(player_index)
     end
 end
 
+local function stop_watching(player_index, target_index)
+    if not this.tracking[target_index] then
+        return
+    end
+    this.tracking[target_index][player_index] = nil
+end
 
 local function close_player_inventory(player)
     local data = get_player_data(player)
@@ -117,7 +123,7 @@ local function close_player_inventory(player)
         return
     end
 
-    stop_watching_all(player.index)
+    stop_watching(player.index, data.player_opened.index)
 
     local gui = player.gui.screen
 
@@ -430,7 +436,10 @@ local function update_gui(event)
         local watcher = game.get_player(watcher_idx)
 
         -- should we discard / close watchers if they are invalid / disconnected?
-        if not validate_object(watcher) then goto continue end
+        if not validate_object(watcher) then
+            stop_watching_all(watcher_idx)
+            goto continue
+        end
         if not watcher.connected then
             stop_watching_all(watcher_idx)
             goto continue

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -293,7 +293,6 @@ local function open_inventory(source, target)
 end
 
 local function on_gui_click(event)
-    local player = game.get_player(event.player_index)
 
     local element = event.element
 
@@ -314,6 +313,7 @@ local function on_gui_click(event)
     if not types[name] then
         return
     end
+    local player = game.get_player(event.player_index)
 
     local data = get_player_data(player)
     if not data then
@@ -350,11 +350,11 @@ local function on_gui_click(event)
     end
 end
 local function gui_closed(event)
-    local player = game.get_player(event.player_index)
 
     local type = event.gui_type
 
     if type == defines.gui_type.custom then
+        local player = game.get_player(event.player_index)
         local data = get_player_data(player)
         if not data then
             return
@@ -406,7 +406,7 @@ local function update_gui(event)
     end
 
     if not validate_object(target) then
-        close_watchers(player)
+        close_watchers(target)
     end
 
     -- lazy evaluation of target inventories, avoid performance overhead

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -475,11 +475,6 @@ commands.add_command(
             end
             local target_player = game.get_player(cmd.parameter)
 
-            -- why is this not allowed?
-            -- if target_player == player then
-            --     return player.print('Cannot open self.', Color.warning)
-            -- end
-
             local valid, opened = player_opened(player)
             if valid then
                 if target_player == opened then

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -96,7 +96,7 @@ local function validate_player(player)
     if not player.connected then
         return false
     end
-    if not game.players[player.index] then
+    if not game.get_player(player.index) then
         return false
     end
     return true
@@ -277,7 +277,7 @@ local function open_inventory(source, target)
 end
 
 local function on_gui_click(event)
-    local player = game.players[event.player_index]
+    local player = game.get_player(event.player_index)
 
     local element = event.element
 
@@ -334,7 +334,7 @@ local function on_gui_click(event)
     end
 end
 local function gui_closed(event)
-    local player = game.players[event.player_index]
+    local player = game.get_player(event.player_index)
 
     local type = event.gui_type
 
@@ -348,7 +348,7 @@ local function gui_closed(event)
 end
 
 local function on_pre_player_left_game(event)
-    local player = game.players[event.player_index]
+    local player = game.get_player(event.player_index)
     close_player_inventory(player)
 end
 
@@ -360,7 +360,7 @@ local function close_watchers(player)
     end
 
     for _, watcher_idx in ipairs(watchers) do
-        local watcher = game.players[watcher_idx]
+        local watcher = game.get_player(watcher_idx)
 
         if not validate_object(watcher) then goto continue end
 
@@ -376,7 +376,7 @@ end
 --     this.data[player.index].player_opened
 local function update_gui(event)
     local watchers = this.tracking[event.player_index]
-    local target = game.players[event.player_index]
+    local target = game.get_player(event.player_index)
 
     -- can we skip updating GUIs for this change (are there no players watching?)
     if watchers == nil or #watchers <= 0 then
@@ -424,7 +424,7 @@ local function update_gui(event)
     end
 
     for _, watcher_idx in ipairs(watchers) do
-        local watcher = game.players[watcher_idx]
+        local watcher = game.get_player(watcher_idx)
 
         -- should we discard / close watchers if they are invalid / disconnected?
         if not validate_object(watcher) then goto continue end
@@ -453,7 +453,7 @@ commands.add_command(
             if not cmd.parameter then
                 return
             end
-            local target_player = game.players[cmd.parameter]
+            local target_player = game.get_player(cmd.parameter)
 
             -- why is this not allowed?
             -- if target_player == player then

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -393,7 +393,6 @@ local function update_gui(event)
         ['Main'] = function()
             return target.get_main_inventory().get_contents()
         end,
-        -- update_gui does not trigger on these events. they only update as a side effect.
         ['Armor'] = function()
             return target.get_inventory(defines.inventory.character_armor).get_contents()
         end,


### PR DESCRIPTION
Fixes #319

### Brief description of the changes:
Change how /inventory works to make it more efficient.
- no more iterating over `connected_players`
- only get category matching active tab in GUI
- only update relevant inventory GUIs, not all of them

### Other changes:
- you can `/inventory` yourself. changed for testing, though I'm not sure why this wasn't allowed before

### Tested Changes:
- [x] I've tested the changes locally *and* with people.
