### PR TITLE
Set permission selected_tab_changed to true even when frozen so ui not broken anymore for special/groups

### DIFF
--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -30,6 +30,7 @@ local function freeze_players()
 		defines.input_action.gui_text_changed,
 		defines.input_action.gui_value_changed,
 		defines.input_action.edit_permission_group,
+		defines.input_action.gui_selected_tab_changed
 	}	
 	for _, d in pairs(defs) do p.set_allows_action(d, true) end
 end


### PR DESCRIPTION
Fixes https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/issues/370

### Brief description of the changes:
Set permission selected_tab_changed to true even when frozen so ui not broken anymore for special/groups


How to reproduce bug :
Freeze players, join a team, try to acecss for example special games or group...

Workaround meanwhile : 
`/c     local p = game.permissions.get_group("Default")         p.set_allows_action(defines.input_action["gui_selected_tab_changed"], true)`

### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
