### PR TITLE
Allows group name and description to include spaces and punctuation characters

### DIFF
--- a/comfy_panel/group.lua
+++ b/comfy_panel/group.lua
@@ -202,7 +202,7 @@ local function on_gui_text_changed(event)
 end
 
 local function alphanumeric(str)
-    return (string.match(str, '[^%w]') ~= nil)
+    return (string.match(str, '[^%w%s%p]') ~= nil)
 end
 
 local function on_gui_click(event)


### PR DESCRIPTION
[Comfy already did this ](https://github.com/ComfyFactory/ComfyFactorio/blob/3cd408b65e6f97ab812fc8b81ff8c7f9c6299a98/utils/gui/group.lua#L238)
People may be more wild with naming but I don't see obvious flaws in it.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
