### PR TITLE
Allow change_active_item_group_for_filters for spectators

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -85,6 +85,7 @@ function Public.initial_setup()
 		defines.input_action.activate_cut,
 		defines.input_action.activate_paste,
 		defines.input_action.change_active_quick_bar,
+		defines.input_action.change_active_item_group_for_filters,
 		defines.input_action.clear_cursor,
 		defines.input_action.edit_permission_group,
 		defines.input_action.gui_click,


### PR DESCRIPTION
This permission is required to be able to change tabs in Select icon gui.
Currently, spectators do not have this permission, so only the first Logistic tab is available to them.
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/88335092/eb2c51c4-1b4f-4600-a6ec-474aa18680dd)

### Tested Changes:
- [x] I've tested the changes locally
