### PR TITLE
Reveal map at start

### DIFF
--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -162,6 +162,15 @@ local functions = {
 			get_actor(event, '{New Year Island}', "New Year island has been disabled!", true)
 		end
 	end,
+	["bb_map_reveal_toggle"] = function(event)
+		if event.element.switch_state == "left" then
+			global.bb_settings['bb_map_reveal_toggle'] = true
+			game.print("Reveal map at start has been enabled!")
+		else
+			global.bb_settings['bb_map_reveal_toggle'] = false
+			game.print("Reveal map at start has been disabled!")
+		end
+	end,
 }
 
 local poll_function = {
@@ -483,7 +492,14 @@ local build_config_gui = (function(player, frame)
 			if not admin then switch.ignored_by_interaction = true end
 			
 			scroll_pane.add({type = 'line'})
+			
+			local switch_state = "right"
+			if global.bb_settings["bb_map_reveal_toggle"] then switch_state = "left" end
+			local switch = add_switch(scroll_pane, switch_state, "bb_map_reveal_toggle", "Reveal map", "Reveal map at start.")
+			if not admin then switch.ignored_by_interaction = true end
 				
+			scroll_pane.add({type = 'line'})
+
 			local switch_state = "right"
 			if global.bb_settings.only_admins_vote then switch_state = "left" end
 			local switch = add_switch(scroll_pane, switch_state, "bb_only_admins_vote", "Admin Vote", "Only admins can vote for map difficulty. Clears all currently existing votes.")

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -326,8 +326,8 @@ function Public.server_restart()
         Init.forces()
         Init.draw_structures()
         Gui.reset_tables_gui()
-		Init.load_spawn()
-		Init.reveal_map()
+        Init.load_spawn()
+        Init.reveal_map()
 
             for _, player in pairs(game.players) do
                 Functions.init_player(player)

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -326,7 +326,8 @@ function Public.server_restart()
         Init.forces()
         Init.draw_structures()
         Gui.reset_tables_gui()
-            Init.load_spawn()
+		Init.load_spawn()
+		Init.reveal_map()
 
             for _, player in pairs(game.players) do
                 Functions.init_player(player)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -3,9 +3,6 @@ local Score = require "comfy_panel.score"
 local Tables = require "maps.biter_battles_v2.tables"
 local fifo = require "maps.biter_battles_v2.fifo"
 local Blueprint = require 'maps.biter_battles_v2.blueprints'
-local Token = require 'utils.token'
-local Task = require 'utils.task'
-local Event = require 'utils.event'
 
 local Public = {}
 
@@ -183,24 +180,19 @@ function Public.draw_structures()
 	--Terrain.generate_spawn_goodies(surface)
 end
 
-local reveal_token = Token.register(
-    function()
-		if global.bb_settings["bb_map_reveal_toggle"] then
-			local surface = game.surfaces[global.bb_surface_name]
-			local radius = 2000
-			game.forces["north"].chart(surface, {{0-radius, 500}, {0+radius, -500}})
-			game.forces["south"].chart(surface, {{0-radius, 500}, {0+radius, -500}})
-		end
-    end
-)
-
 function Public.reveal_map()
 	if global.bb_settings["bb_map_reveal_toggle"] then
 		local surface = game.surfaces[global.bb_surface_name]
-		local radius = 2000
-		game.forces["north"].chart(surface, {{0-radius, 500}, {0+radius, -500}}) 
-		game.forces["south"].chart(surface, {{0-radius, 500}, {0+radius, -500}}) 
-		Task.set_timeout_in_ticks(10800, reveal_token)
+		local width = 2000 -- for one side
+		local height = 500 -- for one side
+		for x = 16, width, 32 do
+			for y = 16, height, 32 do
+				game.forces["spectator"].chart(surface, {{-x, -y}, {-x, -y}})
+				game.forces["spectator"].chart(surface, {{x, -y}, {x, -y}})
+				game.forces["spectator"].chart(surface, {{-x, y}, {-x, y}})
+				game.forces["spectator"].chart(surface, {{x, y}, {x, y}})
+			end
+		end
 	end
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -182,21 +182,12 @@ end
 
 local reveal_token = Token.register(
     function()
-		local surface = game.surfaces[global.bb_surface_name]
-		local radius = 2000
-		game.forces["north"].chart(surface, {{0-radius, 500}, {0+radius, -500}}) 
-		game.forces["south"].chart(surface, {{0-radius, 500}, {0+radius, -500}}) 
-    end
-)
-
-local decrement_timer_token = Token.get_counter() + 1 -- predict what the token will look like
-decrement_timer_token = Token.register(
-    function()
-        local reveal_time_left = global.reveal_time_left - 1
-        if reveal_time_left > 0 then
-            Task.set_timeout_in_ticks(180, decrement_timer_token)
-            global.reveal_time_left = reveal_time_left
-        end
+		if global.bb_settings["bb_map_reveal_toggle"] then
+			local surface = game.surfaces[global.bb_surface_name]
+			local radius = 2000
+			game.forces["north"].chart(surface, {{0-radius, 500}, {0+radius, -500}})
+			game.forces["south"].chart(surface, {{0-radius, 500}, {0+radius, -500}})
+		end
     end
 )
 
@@ -207,8 +198,6 @@ function Public.reveal_map()
 		game.forces["north"].chart(surface, {{0-radius, 500}, {0+radius, -500}}) 
 		game.forces["south"].chart(surface, {{0-radius, 500}, {0+radius, -500}}) 
 		Task.set_timeout_in_ticks(10800, reveal_token)
-		global.reveal_time_left = 180
-		Task.set_timeout_in_ticks(180, decrement_timer_token)
 	end
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -85,6 +85,7 @@ function Public.initial_setup()
 		defines.input_action.activate_cut,
 		defines.input_action.activate_paste,
 		defines.input_action.change_active_quick_bar,
+		defines.input_action.change_active_item_group_for_filters,
 		defines.input_action.clear_cursor,
 		defines.input_action.edit_permission_group,
 		defines.input_action.gui_click,

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -377,6 +377,7 @@ local function on_init()
 	Init.forces()
 	Init.draw_structures()
 	Init.load_spawn()
+	Init.reveal_map()
 end
 
 

--- a/utils/token.lua
+++ b/utils/token.lua
@@ -22,6 +22,11 @@ function Token.register(var)
     return counter
 end
 
+--- Returns current counter
+-- Helpful for recurrent functions
+function Token.get_counter()
+    return counter
+end
 function Token.get(token_id)
     return tokens[token_id]
 end

--- a/utils/token.lua
+++ b/utils/token.lua
@@ -22,11 +22,6 @@ function Token.register(var)
     return counter
 end
 
---- Returns current counter
--- Helpful for recurrent functions
-function Token.get_counter()
-    return counter
-end
 function Token.get(token_id)
     return tokens[token_id]
 end


### PR DESCRIPTION
### Brief description of the changes:
Reveal map at start for 2k distance, first both team, then 3 minutes later, do a second reveal so south has the map too as the mirror was not yet done, so to see ores in south you need this second scan.
Toggleable by admin

Vote :
https://discord.com/channels/823696400797138974/823771211421974579/1127593258940366859
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/95619848/4987755d-a19c-454d-abdd-843fa257072c)
+ second one : 
https://discord.com/channels/823696400797138974/823771211421974579/1113151225098162358
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/95619848/6a0d8308-54cf-43a2-ad33-f909afd5181a)


### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
