### PR TITLE
fix nil entity reference

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -77,8 +77,13 @@ local function get_random_spawner(biter_force_name)
 		if size_of_spawners == 0 then return end
 		local index = math_random(1, size_of_spawners)
 		local spawner = spawners[index]
-		if spawner and spawner.valid then
-			return spawner
+		if spawner then
+			if spawner.valid then
+				return spawner
+			else
+				table.remove(spawners, index)
+				size_of_spawners = size_of_spawners - 1
+			end
 		else
 			table.remove(spawners, index)
 			size_of_spawners = size_of_spawners - 1


### PR DESCRIPTION
if spawner is nil then spawner.valid is a reference to nil breaking the entire subroutine. in practice, nil spawners cannot be removed using the original code. wonky: in a sane, adult, pants-wearing language like c, this would execute fine at runtime. on testing, lua evaluates each line as a single statement, so it asserts both if spawner (shorthand for spawner ~= nil) and if spawner.valid (which references nil if spawner is nil).

fixing this in bbb caused fairly substantial changes to biter spawning. anecdotally, the waves became less random as would be expected.