### PR TITLE
[perf] Dont refresh threat on death

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -298,20 +298,6 @@ function Public.refresh()
 			Public.create_main_gui(player)
 		end
 	end
-	global.gui_refresh_delay = game.tick + 5
-end
-
-function Public.refresh_threat()
-	if global.gui_refresh_delay > game.tick then return end
-	for _, player in pairs(game.connected_players) do
-		if player.gui.left["bb_main_gui"] then
-			if player.gui.left["bb_main_gui"].stats_north then
-				player.gui.left["bb_main_gui"].stats_north.threat_north.caption = show_pretty_threat("north_biters")
-				player.gui.left["bb_main_gui"].stats_south.threat_south.caption = show_pretty_threat("south_biters")
-			end
-		end
-	end
-	global.gui_refresh_delay = game.tick + 5
 end
 
 local get_player_data = function(player, remove)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -115,7 +115,6 @@ function Public.initial_setup()
 	for _, d in pairs(defs) do p.set_allows_action(d, true) end
 
 	global.reroll_time_limit = 1800
-	global.gui_refresh_delay = 0
 	global.game_lobby_active = true
 	global.bb_debug = false
 	global.bb_settings = {

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -83,7 +83,6 @@ end
 local function on_entity_died(event)
 	local entity = event.entity
 	if not entity.valid then return end
-	if Ai.subtract_threat(entity) then Gui.refresh_threat() end
 	AiTargets.stop_tracking(entity)
 	if Functions.biters_landfill(entity) then return end
 	Game_over.silo_death(event)


### PR DESCRIPTION
### Brief description of the changes:
Ragnarok77 ran some profiling and found that ~9% of the time spent in lategame threat farming was spent on updating the gui threat values.  This attempts to solve that by only updating threat every 180 ticks (with the rest of the gui) 

This is an alternative implementation of https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/394 where we attempt to optimize the update threat function and increase the time between updates to every 30 ticks instead of 5.

```
===
Last thing, here is a the summary of late game threat farmer lag : 
194694x "anonymous" in "...ing/Factorio/temp/currently-playing/utils/event_core.lua", line 57. Total Duration: 12065.984900ms

Out of 12k : 

190645x "anonymous" in ".../Factorio/temp/currently-playing/functions/boss_unit.lua", line 31. Total Duration: 3269.118600ms [the joy of on damage event, it might be very fast to calculate, but it's called 200k times which is a lot...]

7x "refresh" in "...rio/temp/currently-playing/maps/biter_battles_v2/gui.lua", line 295. Total Duration: 900.294900ms [refresh the gui, bad gui optim]

470x "refresh_threat" in "...rio/temp/currently-playing/maps/biter_battles_v2/gui.lua", line 304. Total Duration: 1135.801400ms [just to refresh display threat :lulw: ]

                    16x C function "clone_area". Total Duration: 500.359500ms
                16x "clone" in "...rrently-playing/maps/biter_battles_v2/mirror_terrain.lua", line 31. Total Duration: 510.973600ms

                    8x "draw_biter_area" in "...temp/currently-playing/maps/biter_battles_v2/terrain.lua", line 316. Total Duration: 1587.792500ms (which is from GetNoise, get_noise.lua line 127) 
```

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
