### PR TITLE
perf : optim damage event  and increased refresh delay for healthbar of bosses

### DIFF
--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -38,7 +38,7 @@ local function on_entity_damaged(event)
 		global.boss_units[entity.unit_number] = nil
 		entity.die()
 	else
-		if boss.last_update + 10 < game.tick then
+		if boss.last_update + 30 < game.tick then
 			set_healthbar(global.boss_units[entity.unit_number])
 			boss.last_update = game.tick
 		end

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -30,8 +30,6 @@ end
 
 local function on_entity_damaged(event)
 	local entity = event.entity
-	if not entity.valid then return end
-	if entity.type ~= "unit" then return end
 	local boss = global.boss_units[entity.unit_number]
 	if not boss then return end
 	entity.health = entity.health + event.final_damage_amount
@@ -54,4 +52,9 @@ end
 local event = require 'utils.event'
 event.on_init(on_init)
 event.add(defines.events.on_entity_damaged, on_entity_damaged)
+event.add_event_filter(defines.events.on_entity_damaged, {
+	filter = "type",
+	type = "unit",
+})
+
 return Public


### PR DESCRIPTION
### Brief description of the changes:
As in title, we filter out damage events for a type of LuaEntity "unit". The "unit" here is any biter. This change should improve performance during a threat farming and defending as we won't have to process events dedicated for nests, tress, turrets, worms and other structures.
Additionally I limited the amount of HP bar updates to 2/s, instead of 6.25/s.

### Tested Changes:
- [X] I've tested the changes locally
- [ ]  I've tested the changes online
