### PR TITLE
Add /spectator-chat command

### DIFF
--- a/commands/chat_commands.lua
+++ b/commands/chat_commands.lua
@@ -58,3 +58,9 @@ commands.add_command('north-chat', 'Chat with north. You can also use /nth',
     local message = tostring(cmd.parameter)
     chat_with_team(message, 'north')
 end)
+
+commands.add_command('spectator-chat', 'Chat with spectators.',
+                     function(cmd)
+    local message = tostring(cmd.parameter)
+    chat_with_team(message, 'spectator')
+end)


### PR DESCRIPTION
This is useful if users that are admins want to spectate games and chat with just the spectators.

### Brief description of the changes:
This came up when mysticamber was accidentally broadcasting because they are an admin.

For reasons that I do not totally understand, when an admin user is a spectator, all of their chats are automatically broadcast (almost as if using /s) to all forces. This only happens when they are on the spectator force (due to [these lines](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/blob/97c32c241cdb5232cf346f78c20434c57e2bd2d7/maps/biter_battles_v2/functions.lua#L354-L355)). This command allows admins to work-around this behavior.

An alternative would be to remove the lines above, which would remove the "admin users always broadcast their chats". Yet another possible option would be to make it so that "tournament mode" didn't impact the behavior at all, and require users to always use /s, which would be less surprising in many ways, but would be a larger change to the behavior that users have gotten used to. (I know that I have personally been surprised to learn that my chats as a spectator were being broadcast to both teams in non-tournament-mode games)

### Tested Changes:
- [x] I've tested the changes locally, with running two instances of factorio both connected to the same game, and verified that things worked as expected


### Vote link for this idea : 
https://discord.com/channels/823696400797138974/823771211421974579/1170621321030422591

15/11/2023 : 
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/95619848/9dba208b-383e-4438-bfc2-f6c9148e56f6)
