### PR TITLE
Bugfix : total playtime is now logged

### DIFF
--- a/comfy_panel/player_list.lua
+++ b/comfy_panel/player_list.lua
@@ -366,8 +366,8 @@ local function get_sorted_list(sort_by)
         player_list[i].name = player.name
 
         local t = 0
-        if play_table[player.name] then
-            t = play_table[player.name]
+        if global.total_time_online_players[player.name] then
+            t = global.total_time_online_players[player.name]
         end
 
         player_list[i].total_played_time = get_formatted_playtime(t)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -128,6 +128,8 @@ function Public.initial_setup()
 		["map_reroll_admin_disable"] = true,
 	}
 
+	global.total_time_online_players = {}
+	global.already_logged_current_session_time_online_players = {}
 	--Disable Nauvis
 	local surface = game.surfaces[1]
 	local map_gen_settings = surface.map_gen_settings

--- a/utils/datastore/session_data.lua
+++ b/utils/datastore/session_data.lua
@@ -14,7 +14,7 @@ local trusted = {}
 local settings = {
     -- local trusted_value = 2592000 -- 12h
     trusted_value = 5184000, -- 24h
-    nth_tick = 54000
+    nth_tick = 54000 --15min
 }
 local set_data = Server.set_data
 local try_get_data = Server.try_get_data

--- a/utils/datastore/session_data.lua
+++ b/utils/datastore/session_data.lua
@@ -14,7 +14,7 @@ local trusted = {}
 local settings = {
     -- local trusted_value = 2592000 -- 12h
     trusted_value = 5184000, -- 24h
-    nth_tick = 60 -- nearest prime to 5 minutes in ticks
+    nth_tick = 54000
 }
 local set_data = Server.set_data
 local try_get_data = Server.try_get_data

--- a/utils/datastore/session_data.lua
+++ b/utils/datastore/session_data.lua
@@ -14,7 +14,7 @@ local trusted = {}
 local settings = {
     -- local trusted_value = 2592000 -- 12h
     trusted_value = 5184000, -- 24h
-    nth_tick = 18000 -- nearest prime to 5 minutes in ticks
+    nth_tick = 60 -- nearest prime to 5 minutes in ticks
 }
 local set_data = Server.set_data
 local try_get_data = Server.try_get_data
@@ -87,7 +87,7 @@ local nth_tick_token =
     function(data)
         local player = data.player
         if player and player.valid then
-            Public.try_ul_data(player.name)
+			Server.upload_time_played(player)
         end
     end
 )
@@ -119,61 +119,10 @@ function Public.format_time(ticks, h, m)
         return string.format('%02dm', minutes, min)
     end
 end
-
---- Tries to get data from the webpanel and updates the local table with values.
--- @param data_set player token
-function Public.try_dl_data(key)
-    key = tostring(key)
-    local secs = Server.get_current_time()
-    if secs == nil then
-        session[key] = game.players[key].online_time
-        return
-    else
-        try_get_data(session_data_set, key, try_download_data)
-    end
-end
-
---- Tries to get data from the webpanel and updates the local table with values.
--- @param data_set player token
-function Public.try_ul_data(key)
-    key = tostring(key)
-    local secs = Server.get_current_time()
-    if secs == nil then
-        return
-    else
-        try_get_data(session_data_set, key, try_upload_data)
-    end
-end
-
---- Checks if a player exists within the table
--- @param player_name <string>
--- @return <boolean>
-function Public.exists(player_name)
-    return session[player_name] ~= nil
-end
-
---- Prints a list of all players in the player_session table.
-function Public.print_sessions()
-    local result = {}
-
-    for k, _ in pairs(session) do
-        result[#result + 1] = k
-    end
-
-    result = concat(result, ', ')
-    Game.player_print(result)
-end
-
 --- Returns the table of session
 -- @return <table>
 function Public.get_session_table()
     return session
-end
-
---- Returns the table of online_track
--- @return <table>
-function Public.get_tracker_table()
-    return online_track
 end
 
 --- Returns the table of trusted
@@ -182,26 +131,6 @@ function Public.get_trusted_table()
     return trusted
 end
 
---- Returns the table of settings
--- @return <table>
-function Public.get_settings_table()
-    return settings
-end
-
---- Clears a given player from the session tables.
--- @param LuaPlayer
-function Public.clear_player(player)
-    local name = player.name
-    if session[name] then
-        session[name] = nil
-    end
-    if online_track[name] then
-        online_track[name] = nil
-    end
-    if trusted[name] then
-        trusted[name] = nil
-    end
-end
 
 Event.add(
     defines.events.on_player_joined_game,
@@ -210,8 +139,7 @@ Event.add(
         if not player or not player.valid then
             return
         end
-
-        Public.try_dl_data(player.name)
+		Server.set_total_time_played(player)
     end
 )
 
@@ -222,25 +150,10 @@ Event.add(
         if not player or not player.valid then
             return
         end
-
-        Public.try_ul_data(player.name)
+		Server.upload_time_played(player)
     end
 )
 
 Event.on_nth_tick(settings.nth_tick, upload_data)
-
-Server.on_data_set_changed(
-    session_data_set,
-    function(data)
-        session[data.key] = data.value
-        if data.value > settings.trusted_value then
-            trusted[data.key] = true
-        else
-            if trusted[data.key] then
-                trusted[data.key] = false
-            end
-        end
-    end
-)
 
 return Public

--- a/utils/server.lua
+++ b/utils/server.lua
@@ -60,6 +60,8 @@ local query_players_tag = '[QUERY-PLAYERS]'
 local player_join_tag = '[PLAYER-JOIN]'
 local player_chat_tag = '[PLAYER-CHAT]'
 local player_leave_tag = '[PLAYER-LEAVE]'
+local data_add_onlinetime_tag = '[DATA-ADD-TOTAL-ONLINE-TIME]'
+local data_set_total_onlinetime_tag = '[DATA-SET-TOTAL-ONLINE-TIME]'
 
 Public.raw_print = raw_print
 
@@ -731,9 +733,16 @@ function Public.get_current_time()
     if secs == nil then
         return nil
     end
+	if not global.total_time_online_players[player.name] then global.total_time_online_players[player.name] = 0 end
+	local time_to_add = player.online_time - global.already_logged_current_session_time_online_players[player.name]
+	
+	raw_print(data_add_onlinetime_tag .. '['..player.name..']'..time_to_add)
+	global.already_logged_current_session_time_online_players[player.name] = global.already_logged_current_session_time_online_players[player.name] + time_to_add
+	global.total_time_online_players[player.name] = global.total_time_online_players[player.name] + time_to_add
+end
 
-    local diff = game.tick - server_time.tick
-    return math.floor(secs + diff / game.speed / 60)
+function Public.set_total_time_played(player)
+	raw_print(data_set_total_onlinetime_tag .. "[".. player.name .. "]")
 end
 
 --- Called be the web server to re sync which players are online.

--- a/utils/server.lua
+++ b/utils/server.lua
@@ -733,6 +733,10 @@ function Public.get_current_time()
     if secs == nil then
         return nil
     end
+end
+
+function Public.upload_time_played(player)
+	if not global.already_logged_current_session_time_online_players[player.name] then global.already_logged_current_session_time_online_players[player.name] = 0 end
 	if not global.total_time_online_players[player.name] then global.total_time_online_players[player.name] = 0 end
 	local time_to_add = player.online_time - global.already_logged_current_session_time_online_players[player.name]
 	


### PR DESCRIPTION
### Brief description of the changes:
Playtime has been broken for a very long time, it requires to be stored on the server, here is the PR that makes it possible, by showing messages in server log.
I also cleaned a bit some unused code.

It will upload playtime to server every 15 minutes, or when a player leaves.
It will set the total playtime when a player joins.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
