### PR TITLE
Add a spectator-force log message about which team completed a research

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -57,6 +57,7 @@ local function on_research_finished(event)
 	elseif name == 'rocket-silo' then
 		force.technologies['space-science-pack'].researched = true
 	end
+	game.forces.spectator.print("Team " .. force.name .. " completed research " .. event.research.name)
 end
 
 local function on_console_chat(event)

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -57,7 +57,7 @@ local function on_research_finished(event)
 	elseif name == 'rocket-silo' then
 		force.technologies['space-science-pack'].researched = true
 	end
-	game.forces.spectator.print("Team " .. force.name .. " completed research " .. event.research.name)
+	game.forces.spectator.print("Team " .. force.name .. " completed research [technology=" .. event.research.name .. "]")
 end
 
 local function on_console_chat(event)


### PR DESCRIPTION
This should help spectators see what is going on. It ends up being slightly redundant with the message already printed by the game engine, but with the additional context of which team it is for.

Possible log output is now:
  foo started research Automation
  Completed research Automation
  Team north completed research automation

### Tested Changes:
- I've tested the changes locally (this version had slightly different text, but I've run it since then) <img width="328" alt="Screenshot 2023-11-02 at 1 49 21 PM" src="https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/273840/c9a9ec71-1c0b-4ad6-8c4c-841fe77bbf81">

### Vote link : 
https://discord.com/channels/823696400797138974/823771211421974579/1170622174621597747
15/11/2023 : 
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/95619848/1f5f5552-d617-4b8f-b2d7-762db003573d)

