### PR TITLE
fix boss units not traveling with the pack

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -228,8 +228,9 @@ local function create_attack_group(surface, force_name, biter_force_name)
 			unit_group.add_member(unit)
 		end
 	end
-	AiStrikes.initiate(unit_group, force_name, target_position)
-	AiStrikes.initiate(unit_group_boss, force_name, target_position)
+	local strike_position = AiStrikes.calculateStrikePosition(unit_group, target_position)
+	AiStrikes.initiate(unit_group, force_name, strike_position, target_position)
+	AiStrikes.initiate(unit_group_boss, force_name, strike_position, target_position)
 end
 
 Public.pre_main_attack = function()

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -228,7 +228,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 			unit_group.add_member(unit)
 		end
 	end
-	local strike_position = AiStrikes.calculateStrikePosition(unit_group, target_position)
+	local strike_position = AiStrikes.calculate_strike_position(unit_group, target_position)
 	AiStrikes.initiate(unit_group, force_name, strike_position, target_position)
 	AiStrikes.initiate(unit_group_boss, force_name, strike_position, target_position)
 end

--- a/maps/biter_battles_v2/ai_strikes.lua
+++ b/maps/biter_battles_v2/ai_strikes.lua
@@ -144,7 +144,7 @@ local function assassinate(unit_group, target)
     })
 end
 
-function Public.calculateStrikePosition(unit_group, target_position)
+function Public.calculate_strike_position(unit_group, target_position)
     local source_position = unit_group.position
     local normalized_source_position = { x = source_position.x, y = math_abs(source_position.y) }
     local normalized_target_position = { x = target_position.x, y = math_abs(target_position.y) }


### PR DESCRIPTION
### Brief description of the changes:
* Currently, two independent strike vectors are being calculated for waves that spawn an additional boss unit group together with the non-boss unit group
* This change makes it such that the boss and non-boss unit groups will use the same strike vector, resulting in them traveling together as one pack
* Gameplay-wise, this will result in boss-enhanced waves packing a more focused punch.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
