### PR TITLE
instant map reset can be done during map reroll + default yes map reroll + added possibility cancel map reroll

### DIFF
--- a/commands/misc.lua
+++ b/commands/misc.lua
@@ -365,11 +365,6 @@ commands.add_command(
                 player.print("[ERROR] You're not admin!", Color.fail)
                 return
             end
-			
-            if global.reroll_time_left ~= nil and global.reroll_time_left > 1 then 
-                player.print('The map is during the reroll period, please wait for it to finish first', Color.fail)
-                return
-            end
         end
 
         -- Safely convert cmd.parameter to a number if given

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -481,7 +481,7 @@ local function draw_reroll_gui(player)
     if player.gui.top.reroll_frame then return end
     local f = player.gui.top.add{type = "frame", name = "reroll_frame"}
     gui_style(f, {height = 38, padding = 0})
-    
+
     local t = f.add{type = "table", name = "reroll_table", column_count = 3, vertical_centering = true}
     local l = t.add{type = "label", caption = "Reroll map?\t" .. global.reroll_time_left .. "s"}
     gui_style(l, {font = "heading-2", font_color = {r = 0.88, g = 0.55, b = 0.11}, width = 105})
@@ -501,51 +501,69 @@ local reroll_buttons_token = Token.register(
     end
 )
 
-local reroll_token = Token.register(
-    function()
-        -- disable reroll buttons creation for joining players
-        Event.remove_removable(defines.events.on_player_joined_game, reroll_buttons_token)
-        -- remove existing buttons
-        for _, player in pairs(game.players) do
-            if player.gui.top["reroll_frame"] then 
-                player.gui.top["reroll_frame"].destroy()
-            end
+local function stop_map_reroll()
+    global.reroll_time_left = 0
+    -- disable reroll buttons creation for joining players
+    Event.remove_removable(defines.events.on_player_joined_game, reroll_buttons_token)
+    -- remove existing buttons
+    for _, player in pairs(game.players) do
+        if player.gui.top.reroll_frame then
+            player.gui.top.reroll_frame.destroy()
         end
-        -- count votes
-        local total_votes = table.size(global.reroll_map_voting)
-        local result = 0
-        if total_votes > 0 then
-            for _, vote in pairs(global.reroll_map_voting) do
-                result = result + vote
-            end
-            result = math.floor( 100*result / total_votes )
-            if result >= 75 then
-                game.print("Vote to reload the map has succeeded (" .. result .. "%)")
-                game.print("Map is being rerolled!", {r = 0.22, g = 0.88, b = 0.22})
-                Public.generate_new_map()
-                return
-            end
-        end
-        game.print("Vote to reload the map has failed (" .. result .. "%)")
-
     end
-)
+end
 
 local decrement_timer_token = Token.get_counter() + 1 -- predict what the token will look like
 decrement_timer_token = Token.register(
     function()
-        local reroll_time_left = global.reroll_time_left - 1
-        for _, player in pairs(game.connected_players) do
-            if player.gui.top.reroll_frame ~= nil then 
-                player.gui.top.reroll_frame.reroll_table.children[1].caption = "Reroll map?\t" .. reroll_time_left .. "s"
-            end
+        if not global.bb_settings.map_reroll then
+            stop_map_reroll()
+            return
         end
-        if reroll_time_left > 0 then
+
+        global.reroll_time_left = global.reroll_time_left - 1
+        if global.reroll_time_left > 0 then
+            for _, player in pairs(game.connected_players) do
+                if player.gui.top.reroll_frame ~= nil then
+                    player.gui.top.reroll_frame.reroll_table.children[1].caption = "Reroll map?\t" .. global.reroll_time_left .. "s"
+                end
+            end
+
             Task.set_timeout_in_ticks(60, decrement_timer_token)
-            global.reroll_time_left = reroll_time_left
+        else
+            stop_map_reroll()
+            -- count votes
+            local total_votes = table.size(global.reroll_map_voting)
+            local result = 0
+            if total_votes > 0 then
+                for _, vote in pairs(global.reroll_map_voting) do
+                    result = result + vote
+                end
+                result = math.floor( 100*result / total_votes )
+                if result >= 75 then
+                    game.print("Vote to reload the map has succeeded (" .. result .. "%)")
+                    game.print("Map is being rerolled!", {r = 0.22, g = 0.88, b = 0.22})
+                    Public.generate_new_map()
+                    return
+                end
+            end
+            game.print("Vote to reload the map has failed (" .. result .. "%)")
         end
     end
 )
+
+local function start_map_reroll()
+    if global.bb_settings.map_reroll then
+        if not global.reroll_time_left or global.reroll_time_left <= 0 then
+            Task.set_timeout_in_ticks(60, decrement_timer_token)
+            Event.add_removable(defines.events.on_player_joined_game, reroll_buttons_token)
+        end
+        global.reroll_time_left = global.reroll_time_limit / 60
+        for _, player in pairs(game.connected_players) do
+            draw_reroll_gui(player)
+        end
+    end
+end
 
 function Public.generate_new_map()
     game.speed = 1
@@ -566,17 +584,9 @@ function Public.generate_new_map()
         Gui.create_main_gui(player)
     end
     game.reset_time_played()
-    global.server_restart_timer = nil    
+    global.server_restart_timer = nil
     game.delete_surface(prev_surface)
-    if global.bb_settings.map_reroll then
-        Task.set_timeout_in_ticks(global.reroll_time_limit, reroll_token)
-        Event.add_removable(defines.events.on_player_joined_game, reroll_buttons_token)
-        global.reroll_time_left = global.reroll_time_limit / 60
-        for _, player in pairs(game.connected_players) do
-            draw_reroll_gui(player)
-        end
-        Task.set_timeout_in_ticks(60, decrement_timer_token)
-    end
+    start_map_reroll()
 end
 
 Event.add(defines.events.on_console_chat, chat_with_everyone)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -125,7 +125,7 @@ function Public.initial_setup()
 		--MAP SETTINGS--
 		["new_year_island"] = false,
 		["bb_map_reveal_toggle"] = true,
-		["map_reroll_admin_disable"] = true,
+		["map_reroll"] = true,
 	}
 
 	--Disable Nauvis


### PR DESCRIPTION
Allow restart map during ongoing map reroll countdown (`/instant-map-reset`)
Allow cancel ongoing map reroll countdown by toggling config 
Fix map reroll default config. Map reroll is enabled by default after first map restart on the server


### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
