### PR TITLE
Refactor/standardize most code that prints out team names

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -3,6 +3,7 @@ local BiterRaffle = require "maps.biter_battles_v2.biter_raffle"
 local bb_config = require "maps.biter_battles_v2.config"
 local BossUnit = require "functions.boss_unit"
 local fifo = require "maps.biter_battles_v2.fifo"
+local Functions = require "maps.biter_battles_v2.functions"
 local Tables = require "maps.biter_battles_v2.tables"
 local AiStrikes = require "maps.biter_battles_v2.ai_strikes"
 local AiTargets = require "maps.biter_battles_v2.ai_targets"
@@ -122,11 +123,11 @@ local function spawn_biters(isItnormalBiters, maxLoopIteration,spawner,biter_thr
 
 		--Announce New Spawn
 		if(isItnormalBiters and global.biter_spawn_unseen[force_name][unit_name]) then
-			game.print({"", "A ", unit_name:gsub("-", " "), " was spotted far away on team ", (global.tm_custom_name[force_name] or force_name), "..."})
+			game.print({"", "A ", unit_name:gsub("-", " "), " was spotted far away on ", Functions.team_name_with_color(force_name), "..."})
 			global.biter_spawn_unseen[force_name][unit_name] = false
 		end
 		if(not isItnormalBiters and global.biter_spawn_unseen[boss_biter_force_name][unit_name]) then
-			game.print({"", "A ", unit_name:gsub("-", " "), " boss was spotted far away on team ", (global.tm_custom_name[force_name] or force_name), "..."})
+			game.print({"", "A ", unit_name:gsub("-", " "), " boss was spotted far away on ", Functions.team_name_with_color(force_name), "..."})
 			global.biter_spawn_unseen[boss_biter_force_name][unit_name] = false
 		end
 	end
@@ -172,7 +173,7 @@ local function get_unit_group_position(spawner)
 	end
 	p = spawner.surface.find_non_colliding_position("electric-furnace", p, 256, 1)
 	if not p then
-		if global.bb_debug then game.print("No unit_group_position found for team " .. spawner.force.name) end
+		if global.bb_debug then game.print("No unit_group_position found for force " .. spawner.force.name) end
 		return
 	end
 	return p

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -67,24 +67,15 @@ local function get_enemy_team_of(team)
 end
 
 local function print_feeding_msg(player, food, flask_amount)
-	if not get_enemy_team_of(player.force.name) then return end
-	
-	local n = bb_config.north_side_team_name
-	local s = bb_config.south_side_team_name
-	if global.tm_custom_name["north"] then n = global.tm_custom_name["north"] end
-	if global.tm_custom_name["south"] then s = global.tm_custom_name["south"] end	
-	local team_strings = {
-		["north"] = table.concat({"[color=120, 120, 255]", n, "'s[/color]"}),
-		["south"] = table.concat({"[color=255, 65, 65]", s, "'s[/color]"})
-	}
-	
+	local enemy = get_enemy_team_of(player.force.name)
+	if not enemy then return end
+
 	local colored_player_name = table.concat({"[color=", player.color.r * 0.6 + 0.35, ",", player.color.g * 0.6 + 0.35, ",", player.color.b * 0.6 + 0.35, "]", player.name, "[/color]"})
 	local formatted_food = table.concat({"[color=", food_values[food].color, "]", food_values[food].name, " juice[/color]", "[img=item/", food, "]"})
 	local formatted_amount = table.concat({"[font=heading-1][color=255,255,255]" .. flask_amount .. "[/color][/font]"})
 	
 	if flask_amount >= 20 then
-		local enemy = get_enemy_team_of(player.force.name)
-		game.print(table.concat({colored_player_name, " fed ", formatted_amount, " flasks of ", formatted_food, " to team ", team_strings[enemy], " biters!"}), {r = 0.9, g = 0.9, b = 0.9})
+		game.print(table.concat({colored_player_name, " fed ", formatted_amount, " flasks of ", formatted_food, " to ", Functions.team_name_with_color(enemy), "'s biters!"}), {r = 0.9, g = 0.9, b = 0.9})
 		Server.to_discord_bold(table.concat({player.name, " fed ", flask_amount, " flasks of ", food_values[food].name, " to team ", enemy, " biters!"}))
 	else
 		local target_team_text = "the enemy"
@@ -103,14 +94,6 @@ local function add_stats(player, food, flask_amount,biter_force_name,evo_before_
 	local colored_player_name = table.concat({"[color=", player.color.r * 0.6 + 0.35, ",", player.color.g * 0.6 + 0.35, ",", player.color.b * 0.6 + 0.35, "]", player.name, "[/color]"})
 	local formatted_food = table.concat({"[color=", food_values[food].color, "][/color]", "[img=item/", food, "]"})
 	local formatted_amount = table.concat({"[font=heading-1][color=255,255,255]" .. flask_amount .. "[/color][/font]"})	
-	local n = bb_config.north_side_team_name
-	local s = bb_config.south_side_team_name
-	if global.tm_custom_name["north"] then n = global.tm_custom_name["north"] end
-	if global.tm_custom_name["south"] then s = global.tm_custom_name["south"] end
-	local team_strings = {
-		["north"] = table.concat({"[color=120, 120, 255]", n, "[/color]"}),
-		["south"] = table.concat({"[color=255, 65, 65]", s, "[/color]"})
-	}
 	if flask_amount > 0 then
 		local tick = game.ticks_played
 		local feed_time_mins = math_round(tick / (60*60), 0)
@@ -327,15 +310,7 @@ function Public.feed_biters_mixed(player, button)
 		player.print("You have no flasks in your inventory", {r = 0.98, g = 0.66, b = 0.22})
 		return
 	end
-	local n = bb_config.north_side_team_name
-	local s = bb_config.south_side_team_name
-	if global.tm_custom_name["north"] then n = global.tm_custom_name["north"] end
-	if global.tm_custom_name["south"] then s = global.tm_custom_name["south"] end	
-	local team_strings = {
-		["north"] = table.concat({"[color=120, 120, 255]", n, "'s[/color]"}),
-		["south"] = table.concat({"[color=255, 65, 65]", s, "'s[/color]"})
-	}
-	table.insert(message, "to team " .. team_strings[enemy_force_name] .. " biters!")
+	table.insert(message, "to " .. Functions.team_name_with_color(enemy_force_name) .. "'s biters!")
 	game.print(table.concat(message), {r = 0.9, g = 0.9, b = 0.9})
 end
 

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -318,6 +318,29 @@ function Public.no_landfill_by_untrusted_user(event)
 	end
 end
 
+function Public.team_name(force_name)
+	local name = global.tm_custom_name[force_name]
+	if name == nil then
+		if force_name == "north" then
+			name = bb_config.north_side_team_name
+		elseif force_name == "south" then
+			name = bb_config.south_side_team_name
+		end
+	end
+	return name or force_name
+end
+
+function Public.team_name_with_color(force_name)
+	local name = Public.team_name(force_name)
+	if force_name == "north" then
+		return "[color=120, 120, 255]" .. name .. "[/color]"
+	elseif force_name == "south" then
+		return "[color=255, 65, 65]" .. name .. "[/color]"
+	else
+		return name
+	end
+end
+
 function Public.print_message_to_players(forcePlayerList, playerNameSendingMessage, msgToPrint, colorChosen)
 	for _, playerOfForce in pairs(forcePlayerList) do
 		if playerOfForce.connected then

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -15,8 +15,8 @@ local gui_style = require 'utils.utils'.gui_style
 local Public = {}
 
 local gui_values = {
-    ["north"] = {c1 = "Team North", color1 = {r = 0.55, g = 0.55, b = 0.99}},
-    ["south"] = {c1 = "Team South", color1 = {r = 0.99, g = 0.33, b = 0.33}}
+    ["north"] = {color1 = {r = 0.55, g = 0.55, b = 0.99}},
+    ["south"] = {color1 = {r = 0.99, g = 0.33, b = 0.33}}
 }
 
 local function shuffle(tbl)
@@ -38,15 +38,11 @@ end
 
 local function create_victory_gui(player)
     local values = gui_values[global.bb_game_won_by_team]
-    local c = values.c1
-    if global.tm_custom_name[global.bb_game_won_by_team] then
-        c = global.tm_custom_name[global.bb_game_won_by_team]
-    end
     local frame = player.gui.left.add {
         type = "frame",
         name = "bb_victory_gui",
         direction = "vertical",
-        caption = c .. " won!"
+        caption = Functions.team_name(global.bb_game_won_by_team) .. " won!"
     }
     frame.style.font = "heading-1"
     frame.style.font_color = values.color1
@@ -443,11 +439,6 @@ function Public.silo_death(event)
         global.server_restart_timer = 150
 
         game.speed = 1
-
-        local c = gui_values[global.bb_game_won_by_team].c1
-        if global.tm_custom_name[global.bb_game_won_by_team] then
-            c = global.tm_custom_name[global.bb_game_won_by_team]
-		end
 		
         north_evo = math.floor(1000 * global.bb_evolution["north_biters"]) * 0.1
         north_threat = math.floor(global.bb_threat["north_biters"])

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -58,7 +58,7 @@ local function on_research_finished(event)
 	elseif name == 'rocket-silo' then
 		force.technologies['space-science-pack'].researched = true
 	end
-	game.forces.spectator.print("Team " .. force.name .. " completed research [technology=" .. event.research.name .. "]")
+	game.forces.spectator.print(Functions.team_name_with_color(force.name) .. " completed research [technology=" .. event.research.name .. "]")
 end
 
 local function on_console_chat(event)

--- a/maps/biter_battles_v2/sciencelogs_tab.lua
+++ b/maps/biter_battles_v2/sciencelogs_tab.lua
@@ -2,6 +2,7 @@
 
 local Tabs = require 'comfy_panel.main'
 local tables = require "maps.biter_battles_v2.tables"
+local Functions = require "maps.biter_battles_v2.functions"
 local event = require 'utils.event'
 local bb_config = require "maps.biter_battles_v2.config"
 local food_values = tables.food_values
@@ -135,19 +136,11 @@ local function add_science_logs(player, element)
 		label.style.horizontal_align = "center"
 		end
 	end
-	
-	local n = bb_config.north_side_team_name
-	local s = bb_config.south_side_team_name
-	if global.tm_custom_name["north"] then n = global.tm_custom_name["north"] end
-	if global.tm_custom_name["south"] then s = global.tm_custom_name["south"] end	
-	local team_strings = {
-		["north"] = table.concat({"[color=120, 120, 255]", n, "[/color]"}),
-		["south"] = table.concat({"[color=255, 65, 65]", s, "[/color]"})
-	}
+
 	if global.science_logs_date then
 		for i = 1, #global.science_logs_date, 1 do
 			local real_force_name = global.science_logs_fed_team[i]
-			local custom_force_name = team_strings[real_force_name];
+			local custom_force_name = Functions.team_name_with_color(real_force_name);
 			local easy_food_name = food_long_to_short[global.science_logs_food_name[i]].short_name
 			
 			if dropdown_force.selected_index == 1 or real_force_name:match(dropdown_force.get_item(dropdown_force.selected_index)) then

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -1,4 +1,5 @@
 local Public = {}
+local Functions = require "maps.biter_battles_v2.functions"
 local Server = require 'utils.server'
 local gui_style = require 'utils.utils'.gui_style
 local forces = {
@@ -82,7 +83,7 @@ function Public.switch_force(player_name, force_name)
 	local player = game.players[player_name]
 	player.force = game.forces[force_name]
 				
-	game.print(player_name .. " has been switched into team " .. force_name .. ".", {r=0.98, g=0.66, b=0.22})
+	game.print(player_name .. " has been switched into " .. Functions.team_name_with_color(force_name) .. ".", {r=0.98, g=0.66, b=0.22})
     Server.to_discord_bold(player_name .. " has joined team " .. force_name .. "!")
 	
 	leave_corpse(player)
@@ -223,8 +224,7 @@ end
 function Public.custom_team_name_gui(player, force_name)
 	if player.gui.center["custom_team_name_gui"] then player.gui.center["custom_team_name_gui"].destroy() return end	
 	local frame = player.gui.center.add({type = "frame", name = "custom_team_name_gui", caption = "Set custom team name:", direction = "vertical"})
-	local text = force_name
-	if global.tm_custom_name[force_name] then text = global.tm_custom_name[force_name] end
+	local text = Functions.team_name(force_name)
 	
 	local textfield = frame.add({ type = "textfield", name = force_name, text = text })	
 	local t = frame.add({type = "table", column_count = 2})	


### PR DESCRIPTION
This tries to standardize, within reason, how we print team names.

The user-visible changes here are that team names are logged to the console and to discord more consistently, are more often colored correctly with north/south colors, and whether "team" is used as a prefix before a team name is also more consistent.

Background for this change:
 1. There are "force names" which are "north" and "south"
 2. There are the bb_config.(north|south)_side_team_name defaults "Team North" and "Team South"
 3. There are the configured global.tm_custom_name[] overridden values. Not overridden by default, but in captains games, these generally are.

Before this change, there was a combination of different things above that were used when printing out a message, often with "team " prepended. Specifically, it was common to print out ("team " .. (tm_custom_name or force_name)) which would generally work ok. However, the inconsistency was strange. Also, it was unclear when choosing a custom team name if it should be "Team BuildMixers" or "The BuildMixers" or just "BuildMixers", and it would sometimes be printed out with "team " in front of it and sometimes not.

After this change, we try and relatively consistently use the new Functions.team_name API to print out a team name, and do not prepend it with "team " (because in the default case, it will be "Team North" or "Team South"). A notable exception to this is when logging to discord, we often print out ("team " .. force_name), because discord won't support the rich-text that is often used in custom team names.

Additionally, this adds team-name-coloring to the console output in a few more places (like when a player joins a team, or when a technology is researched).

For an added bonus, this change is net-negative in terms of lines of code.

A potential risk with this change is that it changes what is logged to discord. If there is code that is parsing the discord messages, it could be broken by this change.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
