### PR TITLE
Reset game speed to 1 after silo death

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -437,7 +437,7 @@ function Public.silo_death(event)
         global.spy_fish_timeout["south"] = game.tick + 999999
         global.server_restart_timer = 150
 
-	game.speed = 1
+        game.speed = 1
 
         local c = gui_values[global.bb_game_won_by_team].c1
         if global.tm_custom_name[global.bb_game_won_by_team] then

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -437,6 +437,8 @@ function Public.silo_death(event)
         global.spy_fish_timeout["south"] = game.tick + 999999
         global.server_restart_timer = 150
 
+	game.speed = 1
+
         local c = gui_values[global.bb_game_won_by_team].c1
         if global.tm_custom_name[global.bb_game_won_by_team] then
             c = global.tm_custom_name[global.bb_game_won_by_team]


### PR DESCRIPTION
### Brief description of the changes:

Resets game speed to 1 after the game has completed. This allows the reset game timer to complete at normal speed.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
