### PR TITLE
Do a cheeky optimization of two `__index` calls

### DIFF
--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -57,9 +57,13 @@ local function on_init()
 	global.boss_units = {}
 	boss_units = global.boss_units
 end
+local function on_load()
+	Public.force_resync("from_global")
+end
 
 local event = require 'utils.event'
 event.on_init(on_init)
+event.on_load(on_load)
 event.add(defines.events.on_entity_damaged, on_entity_damaged)
 event.add_event_filter(defines.events.on_entity_damaged, {
 	filter = "type",

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -28,6 +28,14 @@ function Public.add_boss_unit(entity, health_factor, size)
 	boss_units[entity.unit_number] = {entity = entity, max_health = health, health = health, healthbar_id = create_healthbar(entity, s), last_update = game.tick}
 end
 
+function Public.force_resync(type_of_resync)
+	if type_of_resync == "to_global" then
+		global.boss_units = boss_units
+	elseif type_of_resync == "from_global" then
+		boss_units = global.boss_units
+	end
+end
+
 local function on_entity_damaged(event)
 	local entity = event.entity
 	local boss = boss_units[entity.unit_number]

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -25,7 +25,7 @@ function Public.add_boss_unit(entity, health_factor, size)
 	if health == 0 then return end
 	local s = 0.5
 	if size then s = size end
-	global.boss_units[entity.unit_number] = {entity = entity, max_health = health, health = health, healthbar_id = create_healthbar(entity, s), last_update = game.tick}
+	boss_units[entity.unit_number] = {entity = entity, max_health = health, health = health, healthbar_id = create_healthbar(entity, s), last_update = game.tick}
 end
 
 local function on_entity_damaged(event)

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -1,6 +1,6 @@
 --adds a health bar and health increase to a unit
 local Public = {}
-
+local boss_units = global.boss_units
 local function create_healthbar(entity, size)
 	return rendering.draw_sprite({
 		sprite="virtual-signal/signal-white",
@@ -30,7 +30,7 @@ end
 
 local function on_entity_damaged(event)
 	local entity = event.entity
-	local boss = global.boss_units[entity.unit_number]
+	local boss = boss_units[entity.unit_number]
 	if not boss then return end
 	entity.health = entity.health + event.final_damage_amount
 	boss.health = boss.health - event.final_damage_amount
@@ -47,6 +47,7 @@ end
 
 local function on_init()
 	global.boss_units = {}
+	boss_units = global.boss_units
 end
 
 local event = require 'utils.event'

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -3,6 +3,7 @@ local Score = require "comfy_panel.score"
 local Tables = require "maps.biter_battles_v2.tables"
 local fifo = require "maps.biter_battles_v2.fifo"
 local Blueprint = require 'maps.biter_battles_v2.blueprints'
+local BossUnits = require 'functions.boss_unit'
 
 local Public = {}
 
@@ -306,6 +307,8 @@ function Public.tables()
 	-- Container for storing chance of reanimation. The stored value
 	-- is a range between [0, 100], accessed by key with force's index.
 	global.reanim_chance = {}
+
+	boss_unit.force_resync 'from_global'
 
 	fifo.init()
 


### PR DESCRIPTION
closes #396 

### Brief description of the changes:
The objective of this is to move the `boss_units` from a global table index and another index (resulting in 2 indexes) to 0 indexes by simply turning it into an upvalue

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [X] I've not tested the changes.
