### PR TITLE
fix boss_unit death tracking

### DIFF
--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -35,8 +35,9 @@ local function on_entity_damaged(event)
 	entity.health = entity.health + event.final_damage_amount
 	boss.health = boss.health - event.final_damage_amount
 	if boss.health <= 0 then
-		global.boss_units[entity.unit_number] = nil
-		entity.die()
+		local unit_number = entity.unit_number
+		entity.die(event.cause.force, event.cause)
+		global.boss_units[unit_number] = nil
 	else
 		if boss.last_update + 30 < game.tick then
 			set_healthbar(global.boss_units[entity.unit_number])

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -36,13 +36,12 @@ local function on_entity_damaged(event)
 	entity.health = entity.health + event.final_damage_amount
 	boss.health = boss.health - event.final_damage_amount
 	if boss.health <= 0 then
-		local unit_number = entity.unit_number
+		global.boss_units[entity.unit_number] = nil
 		if event.cause then
 			entity.die(event.cause.force, event.cause)
 		else
 			entity.die()
 		end
-		global.boss_units[unit_number] = nil
 	else
 		if boss.last_update + 30 < game.tick then
 			set_healthbar(global.boss_units[entity.unit_number])

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -40,7 +40,7 @@ local function on_entity_damaged(event)
 		if event.cause then
 			entity.die(event.cause.force, event.cause)
 		else
-			entity.die(event.cause.force)
+			entity.die()
 		end
 		global.boss_units[unit_number] = nil
 	else

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -28,6 +28,7 @@ function Public.add_boss_unit(entity, health_factor, size)
 	global.boss_units[entity.unit_number] = {entity = entity, max_health = health, health = health, healthbar_id = create_healthbar(entity, s), last_update = game.tick}
 end
 
+---@param event EventData.on_entity_damaged
 local function on_entity_damaged(event)
 	local entity = event.entity
 	local boss = global.boss_units[entity.unit_number]
@@ -36,7 +37,11 @@ local function on_entity_damaged(event)
 	boss.health = boss.health - event.final_damage_amount
 	if boss.health <= 0 then
 		local unit_number = entity.unit_number
-		entity.die(event.cause.force, event.cause)
+		if event.cause then
+			entity.die(event.cause.force, event.cause)
+		else
+			entity.die(event.cause.force)
+		end
 		global.boss_units[unit_number] = nil
 	else
 		if boss.last_update + 30 < game.tick then


### PR DESCRIPTION
### Brief description of the changes:
Before this change, boss unit deaths aren't properly tracked. This change fixes that issue.

I tested this locally, no issues.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
