### PR TITLE
revamp evo/threat calculation, and add /calc-send command

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,18 @@
+name: Run Tests
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.2.1"
+      - uses: leafo/gh-actions-luarocks@v4
+      - name: setup
+        run: |
+          luarocks install lunatest
+          luarocks install serpent
+      - name: test
+        run: |
+          lua tests/test-feeding.lua

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -280,4 +280,23 @@ function Public.feed_biters_mixed(player, button)
 	game.print(table.concat(message), {r = 0.9, g = 0.9, b = 0.9})
 end
 
+local function calc_send(cmd)
+	local player
+	if cmd.player_index then
+		player = game.players[cmd.player_index]
+	end
+	local player_count = #game.forces.north.connected_players + #game.forces.south.connected_players
+	local call_succeeded, result = pcall(FeedingCalculations.calc_send_command, cmd.parameter, global.difficulty_vote_value, global.bb_evolution, global.max_reanim_thresh, global.training_mode, player_count, player)
+	if not call_succeeded then
+		log(string.format("Error in calc_send: %q  parameter: %q", result, cmd.parameter))
+	end
+	if player then
+		player.print(result)
+	else
+		game.print(result)
+	end
+end
+
+commands.add_command('calc-send', 'Calculate the impact of sending science', calc_send)
+
 return Public

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -1,5 +1,5 @@
 local bb_config = require "maps.biter_battles_v2.config"
-local Functions = require "maps.biter_battles_v2.functions"
+local FeedingCalculations = require "maps.biter_battles_v2.feeding_calculations"
 local Server = require 'utils.server'
 
 local tables = require "maps.biter_battles_v2.tables"
@@ -9,18 +9,7 @@ local enemy_team_of = tables.enemy_team_of
 local math_floor = math.floor
 local math_round = math.round
 
-local minimum_modifier = 125
-local maximum_modifier = 250
-local player_amount_for_maximum_threat_gain = 20
 local Public = {}
-function get_instant_threat_player_count_modifier()
-	local current_player_count = #game.forces.north.connected_players + #game.forces.south.connected_players
-	local gain_per_player = (maximum_modifier - minimum_modifier) / player_amount_for_maximum_threat_gain
-	local m = minimum_modifier + gain_per_player * current_player_count
-	if m > maximum_modifier then m = maximum_modifier end
-	return m
-end
-
 
 local function update_boss_modifiers(force_name_biter,damage_mod_mult,speed_mod_mult)
 	local damage_mod = math_round((global.bb_evolution[force_name_biter]) * 1.0, 3) * damage_mod_mult
@@ -163,36 +152,22 @@ end
 function set_evo_and_threat(flask_amount, food, biter_force_name)
 	local decimals = 9
 	
-	local instant_threat_player_count_modifier = get_instant_threat_player_count_modifier()
-	
 	local food_value = food_values[food].value * global.difficulty_vote_value
 
 	local evo = global.bb_evolution[biter_force_name]
 	local biter_evo = game.forces[biter_force_name].evolution_factor
 	local threat = 0.0
 	
-	for _ = 1, flask_amount, 1 do
-		---SET EVOLUTION
-		local e2 = (biter_evo * 100) + 1
-		local diminishing_modifier = (1 / (10 ^ (e2 * 0.015))) / (e2 * 0.5)
-		local evo_gain = (food_value * diminishing_modifier)
-		evo = evo + evo_gain
-		if evo <= 1 then
-			biter_evo = evo
-		else
-			biter_evo = 1
-		end
-		
-		--ADD INSTANT THREAT
-		local diminishing_modifier = 1 / (0.2 + (e2 * 0.016))
-		threat = threat + (food_value * instant_threat_player_count_modifier * diminishing_modifier)
-	end
+	local current_player_count = #game.forces.north.connected_players + #game.forces.south.connected_players
+	local effects = FeedingCalculations.calc_feed_effects(evo, food_value, flask_amount, current_player_count)
+	evo = evo + effects.evo_increase
+	threat = threat + effects.threat_increase
 	evo = math_round(evo, decimals)
 	
 	--SET THREAT INCOME
 	global.bb_threat_income[biter_force_name] = evo * 25
 	
-	game.forces[biter_force_name].evolution_factor = biter_evo
+	game.forces[biter_force_name].evolution_factor = math.min(evo, 1)
 	global.bb_evolution[biter_force_name] = evo
 	set_biter_endgame_modifiers(game.forces[biter_force_name])
 	

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -150,6 +150,7 @@ local function add_stats(player, food, flask_amount,biter_force_name,evo_before_
 end
 
 function set_evo_and_threat(flask_amount, food, biter_force_name)
+	local force_index = game.forces[biter_force_name].index
 	local decimals = 9
 	
 	local food_value = food_values[food].value * global.difficulty_vote_value
@@ -159,11 +160,12 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 	local threat = 0.0
 	
 	local current_player_count = #game.forces.north.connected_players + #game.forces.south.connected_players
-	local effects = FeedingCalculations.calc_feed_effects(evo, food_value, flask_amount, current_player_count)
+	local effects = FeedingCalculations.calc_feed_effects(evo, food_value, flask_amount, current_player_count, global.max_reanim_thresh)
 	evo = evo + effects.evo_increase
 	threat = threat + effects.threat_increase
 	evo = math_round(evo, decimals)
-	
+	global.reanim_chance[force_index] = effects.reanim_chance
+
 	--SET THREAT INCOME
 	global.bb_threat_income[biter_force_name] = evo * 25
 	
@@ -184,17 +186,6 @@ function set_evo_and_threat(flask_amount, food, biter_force_name)
 		global.max_group_size[biter_force_name] = 200
 	end
 	
-	-- Adjust threat for revive.
-	-- Note that the fact that this is done at the end, after set_biter_endgame_modifiers
-	-- (which updated reanim_chance), is what gives a bonus to large single throws of
-	-- science rather than many smaller throws (in the case where final evolution is above
-	-- 100%). Specifically, all of the science thrown gets the threat increase that would
-	-- be used for the final evolution value.
-	local force_index = game.forces[biter_force_name].index
-	local reanim_chance = global.reanim_chance[force_index]
-	if reanim_chance ~= nil and reanim_chance > 0 then
-		threat = threat * (100 / (100.001 - reanim_chance))
-	end
 	global.bb_threat[biter_force_name] = math_round(global.bb_threat[biter_force_name] + threat, decimals)
 	
 	if global.active_special_games["shared_science_throw"] then

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -1,0 +1,32 @@
+local Public = {}
+
+local function get_instant_threat_player_count_modifier(current_player_count)
+	local minimum_modifier = 125
+	local maximum_modifier = 250
+	local player_amount_for_maximum_threat_gain = 20
+	local gain_per_player = (maximum_modifier - minimum_modifier) / player_amount_for_maximum_threat_gain
+	local m = minimum_modifier + gain_per_player * current_player_count
+	return math.min(m, maximum_modifier)
+end
+
+function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_player_count)
+	local threat_increase = 0
+	local evo = initial_evo
+	for _ = 1, num_flasks, 1 do
+		local clamped_evo = math.min(evo, 1)
+		---SET EVOLUTION
+		local e2 = (clamped_evo * 100) + 1
+		local diminishing_modifier = (1 / (10 ^ (e2 * 0.015))) / (e2 * 0.5)
+		local evo_gain = (food_value * diminishing_modifier)
+		evo = evo + evo_gain
+
+		--ADD INSTANT THREAT
+		local diminishing_modifier = 1 / (0.2 + (e2 * 0.016))
+		threat_increase = threat_increase + (food_value * diminishing_modifier)
+	end
+
+	threat_increase = threat_increase * get_instant_threat_player_count_modifier(current_player_count)
+	return {evo_increase = evo - initial_evo, threat_increase = threat_increase}
+end
+
+return Public

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -1,3 +1,5 @@
+local Tables = require "maps.biter_battles_v2.tables"
+
 local math_floor = math.floor
 
 local Public = {}

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -1,3 +1,5 @@
+local math_floor = math.floor
+
 local Public = {}
 
 local function get_instant_threat_player_count_modifier(current_player_count)
@@ -9,8 +11,8 @@ local function get_instant_threat_player_count_modifier(current_player_count)
 	return math.min(m, maximum_modifier)
 end
 
-function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_player_count)
-	local threat_increase = 0
+function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_player_count, max_reanim_thresh)
+	local threat = 0
 	local evo = initial_evo
 	for _ = 1, num_flasks, 1 do
 		local clamped_evo = math.min(evo, 1)
@@ -22,11 +24,32 @@ function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_p
 
 		--ADD INSTANT THREAT
 		local diminishing_modifier = 1 / (0.2 + (e2 * 0.016))
-		threat_increase = threat_increase + (food_value * diminishing_modifier)
+		threat = threat + (food_value * diminishing_modifier)
 	end
 
-	threat_increase = threat_increase * get_instant_threat_player_count_modifier(current_player_count)
-	return {evo_increase = evo - initial_evo, threat_increase = threat_increase}
+	-- Calculates reanimation chance. This value is normalized onto
+	-- maximum re-animation threshold. For example if real evolution is 150
+	-- and max is 350, then 150 / 350 = 42% chance.
+	local reanim_chance = math_floor(math.max(evo - 1.0, 0) * 100.0)
+	reanim_chance = reanim_chance / max_reanim_thresh * 100
+	reanim_chance = math.min(math_floor(reanim_chance), 90.0)
+
+	threat = threat * get_instant_threat_player_count_modifier(current_player_count)
+	-- Adjust threat for revive.
+	-- Note that the fact that this is done at the end, after reanim_chance is calculated
+	-- is what gives a bonus to large single throws of science rather than many smaller
+	-- throws (in the case where final evolution is above 100%). Specifically, all of the
+	-- science thrown gets the threat increase that would be used for the final evolution
+	-- value.
+	if reanim_chance > 0 then
+		threat = threat * (100 / (100.001 - reanim_chance))
+	end
+
+	return {
+		evo_increase = evo - initial_evo,
+		threat_increase = threat,
+		reanim_chance = reanim_chance
+	}
 end
 
 return Public

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -2,6 +2,8 @@ local math_floor = math.floor
 
 local Public = {}
 
+---@param current_player_count integer
+---@return number
 local function get_instant_threat_player_count_modifier(current_player_count)
 	local minimum_modifier = 125
 	local maximum_modifier = 250
@@ -11,6 +13,12 @@ local function get_instant_threat_player_count_modifier(current_player_count)
 	return math.min(m, maximum_modifier)
 end
 
+---@param initial_evo number
+---@param food_value number
+---@param num_flasks integer
+---@param current_player_count integer
+---@param max_reanim_thresh number
+---@return { evo_increase: number, threat_increase: number, reanim_chance: number }
 function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_player_count, max_reanim_thresh)
 	local threat = 0
 	local evo = initial_evo
@@ -60,6 +68,140 @@ function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_p
 		threat_increase = threat,
 		reanim_chance = reanim_chance
 	}
+end
+
+-- Player can be nil
+---@param params string
+---@param difficulty_vote_value number
+---@param bb_evolution { string: number }
+---@param max_reanim_thresh number
+---@param training_mode boolean
+---@param player_count integer
+---@param player LuaPlayer|nil
+---@return string
+function Public.calc_send_command(params, difficulty_vote_value, bb_evolution, max_reanim_thresh, training_mode, player_count, player)
+	if params == nil then
+		params = ""
+	end
+	local difficulty = difficulty_vote_value * 100
+	local evo = nil
+	local error_msg
+	local flask_color
+	local flask_count
+	local force_to_send_to
+	local help_text = "\nUsage: /calc-send evo=20.0 difficulty=30 players=4 color=green count=1000" ..
+		"\nUsage: /calc-send force=north color=white count=1000"
+    if player and training_mode then
+        force_to_send_to = player.force.name
+	elseif player and player.force.name == "north" then
+		force_to_send_to = "south"
+	elseif player and player.force.name == "south" then
+		force_to_send_to = "north"
+	end
+	-- indexed by strings like "automation-science-pack"
+	local foods = {}
+	for param in string.gmatch(params, "([^%s]+)") do
+		local k, v = string.match(param, "^(%w+)=([%w%p]+)$")
+		if k and v then
+			if k == "force" then
+				if v == "n" or v == "nth" or v == "north" then
+					force_to_send_to = "north"
+				elseif v == "s" or v == "sth" or v == "south" then
+					force_to_send_to = "south"
+				else
+					error_msg = "Invalid force"
+				end
+			elseif k == "evo" then
+				evo = tonumber(v)
+				if evo == nil or evo < 0 or evo > 100000 then
+					error_msg = "Invalid evo"
+				end
+			elseif k == "difficulty" then
+				difficulty = tonumber(v)
+				if difficulty == nil or difficulty < 0 or difficulty > 10000 then
+					error_msg = "Invalid difficulty"
+				end
+			elseif k == "players" then
+				player_count = math_floor(tonumber(v))
+				if player_count == nil or player_count < 0 or player_count > 10000 then
+					error_msg = "Invalid player count"
+				end
+			elseif k == "color" then
+				if v == "red" then v = "automation-science-pack" end
+				if v == "green" then v = "logistic-science-pack" end
+				if v == "gray" or v == "grey" then v = "military-science-pack" end
+				if v == "blue" then v = "chemical-science-pack" end
+				if v == "purple" then v = "production-science-pack" end
+				if v == "yellow" then v = "utility-science-pack" end
+				if v == "white" then v = "space-science-pack" end
+				local values = Tables.food_values[v]
+				if values == nil then
+					error_msg = "Invalid science pack color"
+				else
+					flask_color = v
+				end
+			elseif k == "count" then
+				if flask_color == nil then
+					error_msg = "Must specify flask color before count"
+				else
+					flask_count = tonumber(v)
+					if flask_count == nil or flask_count <= 0 or flask_count > 1000000000 then
+						error_msg = "Invalid flask count"
+					end
+					if foods[flask_color] == nil then foods[flask_color] = 0 end
+					foods[flask_color] = foods[flask_color] + flask_count
+				end
+				flask_color = nil
+			else
+				error_msg = string.format("Invalid parameter: %q", k)
+			end
+		else
+			error_msg = string.format("Invalid parameter: %q, must do things like \"evo=120\"", param)
+		end
+		if error_msg then break end
+	end
+	if flask_color ~= nil then
+		error_msg = "Must specify \"count\" after \"color\""
+	end
+	if error_msg == nil and #foods == 0 and player ~= nil then
+		local i = player.get_main_inventory()
+		for food_type, _ in pairs(Tables.food_values) do
+			local flask_amount = i.get_item_count(food_type)
+			if flask_amount > 0 then
+				foods[food_type] = flask_amount
+			end
+		end
+	end
+	if evo == nil and force_to_send_to then
+		local biter_force_name = force_to_send_to .. "_biters"
+        if bb_evolution[biter_force_name] then
+		    evo = bb_evolution[biter_force_name] * 100
+        end
+	end
+	if error_msg == nil and evo == nil then
+		error_msg = "Must specify evo (or force)"
+	end
+	if error_msg then
+		return error_msg .. help_text
+	end
+	local total_food = 0
+	local debug_command_str = string.format("evo=%.1f difficulty=%d players=%d", evo,
+										    math.floor(difficulty), player_count)
+	for k, v in pairs(foods) do
+		total_food = total_food + v * Tables.food_values[k].value
+		debug_command_str = debug_command_str .. string.format(" color=%s count=%d", k, v)
+	end
+	if total_food == 0 then
+		error_msg = "no \"color\"/\"count\" specified and nothing found in inventory"
+	end
+	if error_msg then
+		return error_msg .. help_text
+	end
+	local effects = Public.calc_feed_effects(evo / 100, total_food * difficulty / 100, 1,
+										     player_count, max_reanim_thresh)
+	return string.format("/calc-send %s\nevo_increase: %.1f new_evo: %.1f\nthreat_increase: %d",
+						 debug_command_str, effects.evo_increase * 100, evo + effects.evo_increase * 100,
+						 math.floor(effects.threat_increase))
 end
 
 return Public

--- a/tests/test-feeding.lua
+++ b/tests/test-feeding.lua
@@ -84,7 +84,6 @@ function test_split_up_feed()
 	-- smaller total threat increase (this is a worst-case scenario)
 	local evo = 1.0
 	local difficulty = 30
-	local current_player_count = 40
 	local num_flasks = 25000
 	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
 
@@ -95,6 +94,22 @@ function test_split_up_feed()
 	-- bigger theat increase for big send
 	lunatest.assert_equal(3097157, big_send.threat, 1, "threat big")
 	lunatest.assert_equal(952984, many_send.threat, 1, "threat many")
+end
+
+function test_calc_send()
+	local player_count = 4
+	local player = nil
+	local max_reanim_thresh = 250
+	local training_mode = false
+	local difficulty_vote_value = 0.3
+	local bb_evolution = {["north_biters"] = 0.40, ["south_biters"] = 0.90}
+
+	lunatest.assert_match("Invalid parameter: \"foo\"", Functions.calc_send_command("foo", difficulty_vote_value, bb_evolution, max_reanim_thresh, training_mode, player_count, player))
+	lunatest.assert_equal(
+		"/calc-send evo=20.0 difficulty=30 players=4 color=logistic-science-pack count=1000\n" ..
+		"evo_increase: 2.9 new_evo: 22.9\n" ..
+		"threat_increase: 187",
+		Functions.calc_send_command("evo=20 color=green count=1000", difficulty_vote_value, bb_evolution, max_reanim_thresh, training_mode, player_count, player))
 end
 
 lunatest.run()

--- a/tests/test-feeding.lua
+++ b/tests/test-feeding.lua
@@ -1,0 +1,96 @@
+local lunatest = require "lunatest"
+bit32 = require "bit32"
+serpent = require "serpent"
+
+local Functions = require "maps.biter_battles_v2.feeding_calculations"
+local Tables = require "maps.biter_battles_v2.tables"
+
+local function effects_str(effects)
+	return string.format("evo_increase: %.3f threat: %.0f", effects.evo_increase, effects.threat_increase)
+end
+
+function test_feed_effects_1()
+	-- Simple early-game send
+	local difficulty = 25
+	local current_player_count = 4
+	local evo = 0.01
+	local num_flasks = 100
+	local flask_food_value = Tables.food_values["logistic-science-pack"].value * difficulty / 100
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	lunatest.assert_equal("evo_increase: 0.029 threat: 33", effects_str(calc))
+end
+
+function test_feed_effects_2()
+	-- Simple FnF send
+	local difficulty = 500
+	local current_player_count = 4
+	local evo = 0.15
+	local num_flasks = 100
+	local flask_food_value = Tables.food_values["automation-science-pack"].value * difficulty / 100
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	lunatest.assert_equal("evo_increase: 0.028 threat: 141", effects_str(calc))
+end
+
+function test_feed_effects_3()
+	-- Big yellow rush send to push above 90%
+	local difficulty = 30
+	local current_player_count = 4
+	local evo = 0.25
+	local num_flasks = 4500
+	local flask_food_value = Tables.food_values["utility-science-pack"].value * difficulty / 100
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	lunatest.assert_equal("evo_increase: 0.656 threat: 24225", effects_str(calc))
+end
+
+function test_feed_effects_4()
+	-- Huge/stalling mega send in a captains game
+	local difficulty = 35
+	local current_player_count = 40
+	local evo = 0.30
+	local num_flasks = 23000
+	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	lunatest.assert_equal("evo_increase: 2.929 threat: 564978", effects_str(calc))
+end
+
+function test_feed_effects_5()
+	-- Late game rocket push send
+	local difficulty = 40
+	local current_player_count = 4
+	local evo = 1.20
+	local num_flasks = 3000
+	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	lunatest.assert_equal("evo_increase: 0.363 threat: 49559", effects_str(calc))
+end
+
+local function feed_split_up(evo, total_flasks, flask_food_value, num_splits)
+	local flasks_per_split = total_flasks / num_splits
+	lunatest.assert_equal(math.floor(flasks_per_split), flasks_per_split)
+	local current_player_count = 4
+	local threat = 0
+	for i = 1, num_splits, 1 do
+		local calc = Functions.calc_feed_effects(evo, flask_food_value, total_flasks / num_splits, current_player_count)
+		evo = evo + calc.evo_increase
+		threat = threat + calc.threat_increase
+	end
+	return {evo = evo, threat = threat}
+end
+
+function test_split_up_feed()
+	-- test demonstrating that splitting up a send into multiple smaller sends gives a
+	-- smaller total threat increase (this is a worst-case scenario)
+	evo = 1.0
+	num_flasks = 20000
+	difficulty = 30
+	flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
+	local big_send = feed_split_up(evo, num_flasks, flask_food_value, 1)
+	local many_send = feed_split_up(evo, num_flasks, flask_food_value, 10)
+	lunatest.assert_equal(big_send.evo, many_send.evo, 0.00001, "evo")
+	-- Right now, this is true because we haven't put the revive-chance scaling into the
+	-- threat calculation. I'll fix that in the next commit.
+	lunatest.assert_equal(big_send.threat, many_send.threat, 0.1, "threat")
+	print("big_send: ", serpent.block(big_send))
+end
+
+lunatest.run()

--- a/tests/test-feeding.lua
+++ b/tests/test-feeding.lua
@@ -5,6 +5,8 @@ serpent = require "serpent"
 local Functions = require "maps.biter_battles_v2.feeding_calculations"
 local Tables = require "maps.biter_battles_v2.tables"
 
+local max_reanim_thresh = 250
+
 local function effects_str(effects)
 	return string.format("evo_increase: %.3f threat: %.0f", effects.evo_increase, effects.threat_increase)
 end
@@ -16,7 +18,7 @@ function test_feed_effects_1()
 	local evo = 0.01
 	local num_flasks = 100
 	local flask_food_value = Tables.food_values["logistic-science-pack"].value * difficulty / 100
-	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
 	lunatest.assert_equal("evo_increase: 0.029 threat: 33", effects_str(calc))
 end
 
@@ -27,7 +29,7 @@ function test_feed_effects_2()
 	local evo = 0.15
 	local num_flasks = 100
 	local flask_food_value = Tables.food_values["automation-science-pack"].value * difficulty / 100
-	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
 	lunatest.assert_equal("evo_increase: 0.028 threat: 141", effects_str(calc))
 end
 
@@ -38,7 +40,7 @@ function test_feed_effects_3()
 	local evo = 0.25
 	local num_flasks = 4500
 	local flask_food_value = Tables.food_values["utility-science-pack"].value * difficulty / 100
-	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
 	lunatest.assert_equal("evo_increase: 0.656 threat: 24225", effects_str(calc))
 end
 
@@ -49,8 +51,8 @@ function test_feed_effects_4()
 	local evo = 0.30
 	local num_flasks = 23000
 	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
-	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
-	lunatest.assert_equal("evo_increase: 2.929 threat: 564978", effects_str(calc))
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
+	lunatest.assert_equal("evo_increase: 2.929 threat: 4707755", effects_str(calc))
 end
 
 function test_feed_effects_5()
@@ -60,8 +62,8 @@ function test_feed_effects_5()
 	local evo = 1.20
 	local num_flasks = 3000
 	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
-	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count)
-	lunatest.assert_equal("evo_increase: 0.363 threat: 49559", effects_str(calc))
+	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
+	lunatest.assert_equal("evo_increase: 0.363 threat: 63537", effects_str(calc))
 end
 
 local function feed_split_up(evo, total_flasks, flask_food_value, num_splits)
@@ -70,7 +72,7 @@ local function feed_split_up(evo, total_flasks, flask_food_value, num_splits)
 	local current_player_count = 4
 	local threat = 0
 	for i = 1, num_splits, 1 do
-		local calc = Functions.calc_feed_effects(evo, flask_food_value, total_flasks / num_splits, current_player_count)
+		local calc = Functions.calc_feed_effects(evo, flask_food_value, total_flasks / num_splits, current_player_count, max_reanim_thresh)
 		evo = evo + calc.evo_increase
 		threat = threat + calc.threat_increase
 	end
@@ -80,17 +82,19 @@ end
 function test_split_up_feed()
 	-- test demonstrating that splitting up a send into multiple smaller sends gives a
 	-- smaller total threat increase (this is a worst-case scenario)
-	evo = 1.0
-	num_flasks = 20000
-	difficulty = 30
-	flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
+	local evo = 1.0
+	local difficulty = 30
+	local current_player_count = 40
+	local num_flasks = 25000
+	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
+
 	local big_send = feed_split_up(evo, num_flasks, flask_food_value, 1)
 	local many_send = feed_split_up(evo, num_flasks, flask_food_value, 10)
+	-- same evolution increase
 	lunatest.assert_equal(big_send.evo, many_send.evo, 0.00001, "evo")
-	-- Right now, this is true because we haven't put the revive-chance scaling into the
-	-- threat calculation. I'll fix that in the next commit.
-	lunatest.assert_equal(big_send.threat, many_send.threat, 0.1, "threat")
-	print("big_send: ", serpent.block(big_send))
+	-- bigger theat increase for big send
+	lunatest.assert_equal(3097157, big_send.threat, 1, "threat big")
+	lunatest.assert_equal(952984, many_send.threat, 1, "threat many")
 end
 
 lunatest.run()

--- a/tests/test-feeding.lua
+++ b/tests/test-feeding.lua
@@ -19,7 +19,7 @@ function test_feed_effects_1()
 	local num_flasks = 100
 	local flask_food_value = Tables.food_values["logistic-science-pack"].value * difficulty / 100
 	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
-	lunatest.assert_equal("evo_increase: 0.029 threat: 33", effects_str(calc))
+	lunatest.assert_equal("evo_increase: 0.032 threat: 34", effects_str(calc))
 end
 
 function test_feed_effects_2()
@@ -30,7 +30,7 @@ function test_feed_effects_2()
 	local num_flasks = 100
 	local flask_food_value = Tables.food_values["automation-science-pack"].value * difficulty / 100
 	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
-	lunatest.assert_equal("evo_increase: 0.028 threat: 141", effects_str(calc))
+	lunatest.assert_equal("evo_increase: 0.029 threat: 143", effects_str(calc))
 end
 
 function test_feed_effects_3()
@@ -41,7 +41,7 @@ function test_feed_effects_3()
 	local num_flasks = 4500
 	local flask_food_value = Tables.food_values["utility-science-pack"].value * difficulty / 100
 	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
-	lunatest.assert_equal("evo_increase: 0.656 threat: 24225", effects_str(calc))
+	lunatest.assert_equal("evo_increase: 0.661 threat: 24250", effects_str(calc))
 end
 
 function test_feed_effects_4()
@@ -52,7 +52,7 @@ function test_feed_effects_4()
 	local num_flasks = 23000
 	local flask_food_value = Tables.food_values["space-science-pack"].value * difficulty / 100
 	local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
-	lunatest.assert_equal("evo_increase: 2.929 threat: 4707755", effects_str(calc))
+	lunatest.assert_equal("evo_increase: 2.934 threat: 5136194", effects_str(calc))
 end
 
 function test_feed_effects_5()


### PR DESCRIPTION
### Brief description of the changes:
This series of commits reworks how evo/threat increases are calculated to no longer iterate through the flasks one at a time. Additionally, it adds a command that allows users to see the expected evo/threat increase from a given send (defaulting to the contents of their inventories, but fully customizable).

Additionally, this adds the first (?) unit test support to the repository, allowing some functionality to be tested in a pure-lua environment (no factorio running).

I highly recommend reviewing this commit-by-commit, as most of the commits are no-ops in terms of behavioral changes.

I am very open to feedback about how the change should work, and the UI of the /calc-send command itself.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
