### PR TITLE
move on_player_mined_entity to control-dispatch

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -372,18 +372,11 @@ local function on_entity_died(event)
     end
 end
 
---Mining Thieves History
-local function on_player_mined_entity(event)
+-- Should be pre-checked for entity/player validity
+---@param entity LuaEntity
+---@param player LuaPlayer History
+function Public.on_player_mined_entity(entity, player)
     if not this.enabled then
-        return
-    end
-    local player = game.get_player(event.player_index)
-    if not player or not player.valid then
-        return
-    end
-
-    local entity = event.entity
-    if not entity or not entity.valid then
         return
     end
 
@@ -400,8 +393,8 @@ local function on_player_mined_entity(event)
     if entity.last_user.name == player.name then return end
     local data = {
         player_name = player.name,
-        event = event.entity.name,
-        position = {x = math.floor(event.entity.position.x), y = math.floor(event.entity.position.y)},
+        event = entity.name,
+        position = {x = math.floor(entity.position.x), y = math.floor(entity.position.y)},
         time = game.ticks_played,
         server_time = game.tick
     }
@@ -835,7 +828,6 @@ function Public.get(key)
 end
 
 Event.on_init(on_init)
-Event.add(de.on_player_mined_entity, on_player_mined_entity)
 Event.add(de.on_entity_died, on_entity_died)
 Event.add(de.on_built_entity, on_built_entity)
 Event.add(de.on_gui_opened, on_gui_opened)

--- a/comfy_panel/score.lua
+++ b/comfy_panel/score.lua
@@ -435,18 +435,16 @@ local function on_player_died(event)
     score.deaths = 1 + (score.deaths or 0)
 end
 
-local function on_player_mined_entity(event)
-    if not event.entity.valid then
-        return
-    end
-    if building_and_mining_blacklist[event.entity.type] then
-        return
-    end
+---@param entity LuaEntity
+---@param player LuaPlayer
+function Public.on_player_mined_entity(entity, player)
+	if building_and_mining_blacklist[entity.type] then
+		return
+	end
 
-    local player = game.players[event.player_index]
-    Public.init_player_table(player)
-    local score = this.score_table[player.force.name].players[player.name]
-    score.mined_entities = 1 + (score.mined_entities or 0)
+	Public.init_player_table(player)
+	local score = this.score_table[player.force.name].players[player.name]
+	score.mined_entities = 1 + (score.mined_entities or 0)
 end
 
 local function on_built_entity(event)
@@ -464,7 +462,6 @@ end
 
 comfy_panel_tabs['Scoreboard'] = {gui = show_score, admin = false}
 
-Event.add(defines.events.on_player_mined_entity, on_player_mined_entity)
 Event.add(defines.events.on_player_died, on_player_died)
 Event.add(defines.events.on_built_entity, on_built_entity)
 Event.add(defines.events.on_entity_died, on_entity_died)

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -174,6 +174,15 @@ local size_of_spawn_positions = #spawn_positions
 
 local Public = {}
 
+---@param event EventData.on_player_mined_entity|EventData.on_pre_player_crafted_item|EventData.on_player_mined_item
+function Public.maybe_set_game_start_tick(event)
+	if global.bb_game_start_tick then return end
+	if not event.player_index then return end
+	local player = game.players[event.player_index]
+	if player.force.name ~= "north" and player.force.name ~= "south" then return end
+	global.bb_game_start_tick = game.ticks_played
+end
+
 function Public.biters_landfill(entity)
 	if not landfill_biters[entity.name] then return end	
 	local position = entity.position

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -27,14 +27,6 @@ require "maps.biter_battles_v2.changelog_tab"
 require 'maps.biter_battles_v2.commands'
 require "modules.spawners_contain_biters"
 
-local function maybe_set_game_start_tick(event)
-	if global.bb_game_start_tick then return end
-	if not event.player_index then return end
-	local player = game.players[event.player_index]
-	if player.force.name ~= "north" and player.force.name ~= "south" then return end
-	global.bb_game_start_tick = game.ticks_played
-end
-
 local function on_player_joined_game(event)
 	local surface = game.surfaces[global.bb_surface_name]
 	local player = game.players[event.player_index]
@@ -300,20 +292,6 @@ local function on_player_built_tile(event)
 	end
 end
 
-local function on_player_mined_entity(event)
-	maybe_set_game_start_tick(event)
-	Terrain.minable_wrecks(event)
-	AiTargets.stop_tracking(event.entity)
-end
-
-local function on_player_mined_item(event)
-	maybe_set_game_start_tick(event)
-end
-
-local function on_pre_player_crafted_item(event)
-	maybe_set_game_start_tick(event)
-end
-
 local function on_robot_mined_entity(event)
 	AiTargets.stop_tracking(event.entity)
 end
@@ -496,9 +474,6 @@ Event.add(defines.events.on_gui_click, on_gui_click)
 Event.add(defines.events.on_marked_for_deconstruction, on_marked_for_deconstruction)
 Event.add(defines.events.on_player_built_tile, on_player_built_tile)
 Event.add(defines.events.on_player_joined_game, on_player_joined_game)
-Event.add(defines.events.on_player_mined_entity, on_player_mined_entity)
-Event.add(defines.events.on_player_mined_item, on_player_mined_item)
-Event.add(defines.events.on_pre_player_crafted_item, on_pre_player_crafted_item)
 Event.add(defines.events.on_robot_mined_entity, on_robot_mined_entity)
 Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -677,14 +677,12 @@ function Public.generate_spawn_goodies(surface)
 end
 ]]
 
-function Public.minable_wrecks(event)
-	local entity = event.entity
-	if not entity then return end
-	if not entity.valid then return end
+---@param entity LuaEntity
+---@param player LuaPlayer
+function Public.minable_wrecks(entity, player)
 	if not valid_wrecks[entity.name] then return end
 
 	local surface = entity.surface
-	local player = game.players[event.player_index]
 
 	local loot_worth = math_floor(math_abs(entity.position.x * 0.02)) + global.random_generator(16, 32)
 	local blacklist = LootRaffle.get_tech_blacklist(math_abs(entity.position.x * 0.0001) + 0.10)


### PR DESCRIPTION
### Brief description of the changes:
This is a partial PR from https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/410
The purpose of this is to simplify the codebase, and in doing so, make the gui-rewrite easier. By pushing this to a separate PR, it should be easier to review and evaluate.

The way Event.add is used now leads to confusion w/r/t the order of operations, as well as makes debugging (and thus development) slower.  By incrementally moving single events to this method of dispatch, we will enable ourselves to delete more code, and expedite the gui-rework.

I tested this code locally.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
