### PR TITLE
Game start time: set it to 0 when something actually happens

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -43,7 +43,7 @@ local function get_threat_ratio(biter_force_name)
 end
 
 Public.send_near_biters_to_silo = function()
-	if game.ticks_played < 108000 then return end
+	if Functions.get_ticks_since_game_start() < 108000 then return end
 	if not global.rocket_silo["north"] then return end
 	if not global.rocket_silo["south"] then return end
 
@@ -272,7 +272,7 @@ end
 Public.raise_evo = function()
 	if global.freeze_players then return end
 	if not global.training_mode and (#game.forces.north.connected_players == 0 or #game.forces.south.connected_players == 0) then return end
-	if game.ticks_played < 7200 then return end
+	if Functions.get_ticks_since_game_start() < 7200 then return end
 	if ( 1 <= global.difficulty_vote_index) and ( 3 >= global.difficulty_vote_index) then
 		local x = game.ticks_played/3600 -- current length of the match in minutes
 		global.difficulty_vote_value = ((x / 470) ^ 3.7) + Tables.difficulties[global.difficulty_vote_index].value

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -85,7 +85,7 @@ local function add_stats(player, food, flask_amount,biter_force_name,evo_before_
 	local formatted_food = table.concat({"[color=", food_values[food].color, "][/color]", "[img=item/", food, "]"})
 	local formatted_amount = table.concat({"[font=heading-1][color=255,255,255]" .. flask_amount .. "[/color][/font]"})	
 	if flask_amount > 0 then
-		local tick = game.ticks_played
+		local tick = Functions.get_ticks_since_game_start()
 		local feed_time_mins = math_round(tick / (60*60), 0)
 		local minute_unit = ""
 		if feed_time_mins <= 1 then

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -336,6 +336,14 @@ function Public.no_landfill_by_untrusted_user(event, trusted_table)
 	end
 end
 
+--- Returns the number of ticks since the game started, or 0 if it has not started.
+--- @return integer
+function Public.get_ticks_since_game_start()
+	local start_tick = global.bb_game_start_tick
+	if not start_tick then return 0 end
+	return game.ticks_played - start_tick
+end
+
 function Public.team_name(force_name)
 	local name = global.tm_custom_name[force_name]
 	if name == nil then

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -330,7 +330,7 @@ function Public.server_restart()
 end
 
 local function set_victory_time()
-    local tick = game.ticks_played
+    local tick = Functions.get_ticks_since_game_start()
     local minutes = tick % 216000
     local hours = tick - minutes
     minutes = math.floor(minutes / 3600)
@@ -471,7 +471,7 @@ function Public.silo_death(event)
 			log_to_db('[NorthTeam]'..listPicks..'\n',true)
 			listPicks = table.concat(global.special_games_variables["captain_mode"]["stats"]["southPicks"],";")
 			log_to_db('[SouthTeam]'..listPicks..'\n',true)
-			log_to_db('[Gamelength]'..game.ticks_played..'\n',true)
+			log_to_db('[Gamelength]'..Functions.get_ticks_since_game_start()..'\n',true)
 			log_to_db('[StartTick]'..global.special_games_variables["captain_mode"]["stats"]["tickGameStarting"]..'\n',true)
 			log_to_db('[WinnerTeam]'..global.bb_game_won_by_team..'\n',true)
 			log_to_db('[ExtraInfo]'..global.special_games_variables["captain_mode"]["stats"]["extrainfo"]..'\n',true)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -52,13 +52,18 @@ local function create_sprite_button(player)
 end
 
 local function clock(frame)
-	local total_minutes = math.floor(game.ticks_played / (60 * 60))
-	local total_hours = math.floor(total_minutes / 60)
-	local minutes = total_minutes - (total_hours * 60)
+	local time_caption = "Not started"
+	local total_ticks = Functions.get_ticks_since_game_start()
+	if total_ticks > 0 then
+		local total_minutes = math.floor(total_ticks / (60 * 60))
+		local total_hours = math.floor(total_minutes / 60)
+		local minutes = total_minutes - (total_hours * 60)
+		time_caption = string.format("Time: %02d:%02d", total_hours, minutes)
+	end
 
-	local clock = frame.add {type = "label", caption = string.format("Time: %02d:%02d   Speed: %.2f", total_hours, minutes, game.speed)}
-	clock.style.font = "default-bold"
-	clock.style.font_color = {r = 0.98, g = 0.66, b = 0.22}
+	local clock_ui = frame.add {type = "label", caption = string.format("%s   Speed: %.2f", time_caption, game.speed)}
+	clock_ui.style.font = "default-bold"
+	clock_ui.style.font_color = {r = 0.98, g = 0.66, b = 0.22}
 	frame.add {type = "line"}
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -236,6 +236,7 @@ function Public.tables()
 	global.reroll_map_voting = {}
 	global.bb_evolution = {}
 	global.bb_game_won_by_team = nil
+	global.bb_game_start_tick = nil
 	global.bb_threat = {}
 	global.bb_threat_income = {}
 	global.chosen_team = {}

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -24,6 +24,14 @@ require "maps.biter_battles_v2.changelog_tab"
 require 'maps.biter_battles_v2.commands'
 require "modules.spawners_contain_biters"
 
+local function maybe_set_game_start_tick(event)
+	if global.bb_game_start_tick then return end
+	if not event.player_index then return end
+	local player = game.players[event.player_index]
+	if player.force.name ~= "north" and player.force.name ~= "south" then return end
+	global.bb_game_start_tick = game.ticks_played
+end
+
 local function on_player_joined_game(event)
 	local surface = game.surfaces[global.bb_surface_name]
 	local player = game.players[event.player_index]
@@ -138,6 +146,7 @@ local function on_console_command(event)
 end
 
 local function on_built_entity(event)
+	maybe_set_game_start_tick(event)
 	Functions.no_landfill_by_untrusted_user(event, Session.get_trusted_table())
 	Functions.no_turret_creep(event)
 	Terrain.deny_enemy_side_ghosts(event)
@@ -289,8 +298,17 @@ local function on_player_built_tile(event)
 end
 
 local function on_player_mined_entity(event)
+	maybe_set_game_start_tick(event)
 	Terrain.minable_wrecks(event)
 	AiTargets.stop_tracking(event.entity)
+end
+
+local function on_player_mined_item(event)
+	maybe_set_game_start_tick(event)
+end
+
+local function on_pre_player_crafted_item(event)
+	maybe_set_game_start_tick(event)
 end
 
 local function on_robot_mined_entity(event)
@@ -476,6 +494,8 @@ Event.add(defines.events.on_marked_for_deconstruction, on_marked_for_deconstruct
 Event.add(defines.events.on_player_built_tile, on_player_built_tile)
 Event.add(defines.events.on_player_joined_game, on_player_joined_game)
 Event.add(defines.events.on_player_mined_entity, on_player_mined_entity)
+Event.add(defines.events.on_player_mined_item, on_player_mined_item)
+Event.add(defines.events.on_pre_player_crafted_item, on_pre_player_crafted_item)
 Event.add(defines.events.on_robot_mined_entity, on_robot_mined_entity)
 Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)


### PR DESCRIPTION
This will change the "Time:" displayed in the GUI to show 0:00 when the first player actually mines or crafts an item. I think that this is especially valuable in captains games, which often include 20+ minutes of team selection and discussion before the game actually starts. I could potentially also hook into on_player_changed_position to cover even more cases, but this seems good enough for a first pass.

There are other ways that could potentially accomplish the goal behind this change.  For instance, we could pause the timer whenever global.freeze_players is set to true. This would work well for captains games, but wouldn't help in public games where nobody joins for 10+ minutes.

There is some slightly related logic in the passive feeding code (in ai.lua:raise_evo) that doesn't do any passive feeding until after both teams have players. However, I don't think that the logic is really the same, and I don't think that it makes sense to tie these two.

There is potentially some interaction with the antigrief logic, which will display raw game.ticks_played timestamps, which will no longer agree with the "Time:" displayed in the UI. I am not an admin and have not used this personally, so I don't know if this matters.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
