### PR TITLE
Avoid "LuaTile API call when LuaTile was invalid." error

### DIFF
--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -107,7 +107,7 @@ local function get_replacement_tile(surface, position)
 		table.shuffle_table(vectors)
 		for _, v in pairs(vectors) do
 			local tile = surface.get_tile(position.x + v[1], position.y + v[2])
-			if not tile.collides_with("resource-layer") then
+			if tile.valid and not tile.collides_with("resource-layer") then
 				if tile.name ~= "refined-concrete" then
 					return tile.name
 				end


### PR DESCRIPTION
I get this error when I run the biter battles scenario with map settings of width=50, height=50.  Not that this is a reasonable way to run the scenario, but somehow this is how the settings are if I use --load-scenario when starting factorio.  Also, even if this is not a good choice/setting for running the game, it seems best if we don't have any crashes/lua-errors when running in that configuration.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
