### PR TITLE
Automatically clear_cusor when spectating

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -448,6 +448,7 @@ function spectate(player, forced_join, stored_position)
 	end
 	
 	player.driving = false
+	player.clear_cursor()
 
 	if stored_position then
         local p_data = get_player_data(player)


### PR DESCRIPTION
Automatically clear_cusor when spectating, otherwise it is a bit confusing to have something in your cursor/hand when on spectator island.

I tested this by putting things in my hand, and then clicking the "spectate" button, and seeing if things stayed in my hand.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
