### PR TITLE
Centralization of on_player_died

### DIFF
--- a/comfy_panel/score.lua
+++ b/comfy_panel/score.lua
@@ -428,8 +428,8 @@ local function on_entity_died(event)
     end
 end
 
-local function on_player_died(event)
-    local player = game.players[event.player_index]
+---@param player LuaPlayer
+function Public.on_player_died(player)
     Public.init_player_table(player)
     local score = this.score_table[player.force.name].players[player.name]
     score.deaths = 1 + (score.deaths or 0)
@@ -462,7 +462,6 @@ end
 
 comfy_panel_tabs['Scoreboard'] = {gui = show_score, admin = false}
 
-Event.add(defines.events.on_player_died, on_player_died)
 Event.add(defines.events.on_built_entity, on_built_entity)
 Event.add(defines.events.on_entity_died, on_entity_died)
 Event.add(defines.events.on_gui_click, on_gui_click)

--- a/modules/corpse_markers.lua
+++ b/modules/corpse_markers.lua
@@ -1,4 +1,9 @@
-local function draw_map_tag(surface, force, position)
+local Public = {}
+
+---@param surface LuaSurface
+---@param force LuaForce
+---@param position MapPosition
+function Public.draw_map_tag(surface, force, position)
 	force.add_chart_tag(surface, {icon = {type = 'item', name = 'heavy-armor'}, position = position, text = "   "})
 end
 
@@ -32,7 +37,7 @@ end
 local function redraw_all_tags()
 	for _, surface in pairs(game.surfaces) do
 		for _, corpse in pairs(surface.find_entities_filtered({name = "character-corpse"})) do
-			draw_map_tag(corpse.surface, get_corpse_force(corpse), corpse.position)
+			Public.draw_map_tag(corpse.surface, get_corpse_force(corpse), corpse.position)
 		end
 	end
 end
@@ -46,11 +51,6 @@ local function find_and_destroy_tag(corpse)
 		end		
 	end
 	return false
-end
-
-local function on_player_died(event)
-	local player = game.players[event.player_index]
-	draw_map_tag(player.surface, player.force, player.position)
 end
 
 local function on_character_corpse_expired(event)
@@ -67,6 +67,7 @@ local function on_pre_player_mined_item(event)
 end
 
 local event = require 'utils.event'
-event.add(defines.events.on_player_died, on_player_died)
 event.add(defines.events.on_character_corpse_expired, on_character_corpse_expired)
 event.add(defines.events.on_pre_player_mined_item, on_pre_player_mined_item)
+
+return Public

--- a/utils/server.lua
+++ b/utils/server.lua
@@ -873,35 +873,27 @@ Event.add(
     end
 )
 
-Event.add(
-    defines.events.on_player_died,
-    function(event)
-        local player = game.get_player(event.player_index)
 
-        if not player or not player.valid then
-            return
-        end
+---@param player LuaPlayer
+---@param cause LuaEntity
+function Public.on_player_died(player, cause)
+	local message = {discord_bold_tag, player.name}
+	if cause and cause.valid then
+		message[#message + 1] = ' was killed by '
 
-        local cause = event.cause
+		local name = cause.name
+		if name == 'character' and cause.player then
+			name = cause.player.name
+		end
 
-        local message = {discord_bold_tag, player.name}
-        if cause and cause.valid then
-            message[#message + 1] = ' was killed by '
+		message[#message + 1] = name
+		message[#message + 1] = '.'
+	else
+		message[#message + 1] = ' has died.'
+	end
 
-            local name = cause.name
-            if name == 'character' and cause.player then
-                name = cause.player.name
-            end
-
-            message[#message + 1] = name
-            message[#message + 1] = '.'
-        else
-            message[#message + 1] = ' has died.'
-        end
-
-        message = concat(message)
-        raw_print(message)
-    end
-)
+	local str_message = concat(message)
+	raw_print(str_message)
+end
 
 return Public


### PR DESCRIPTION
### Brief description of the changes:
See discussion at: https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/440

Continuing Centralization of Events to Control.lua in preparation for gui rewrite.

not tested yet.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
