### PR TITLE
Centralization of on_tick

### DIFF
--- a/comfy_panel/score.lua
+++ b/comfy_panel/score.lua
@@ -428,8 +428,8 @@ local function on_entity_died(event)
     end
 end
 
-local function on_player_died(event)
-    local player = game.players[event.player_index]
+---@param player LuaPlayer
+function Public.on_player_died(player)
     Public.init_player_table(player)
     local score = this.score_table[player.force.name].players[player.name]
     score.deaths = 1 + (score.deaths or 0)
@@ -462,7 +462,6 @@ end
 
 comfy_panel_tabs['Scoreboard'] = {gui = show_score, admin = false}
 
-Event.add(defines.events.on_player_died, on_player_died)
 Event.add(defines.events.on_built_entity, on_built_entity)
 Event.add(defines.events.on_entity_died, on_entity_died)
 Event.add(defines.events.on_gui_click, on_gui_click)

--- a/control.lua
+++ b/control.lua
@@ -52,9 +52,12 @@ local AiTargets = require "maps.biter_battles_v2.ai_targets"
 local Antigrief = require "antigrief"
 local ComfyPanelScore = require "comfy_panel.score"
 local Functions = require "maps.biter_battles_v2.functions"
+local MapsBiterBattlesV2Main = require 'main.biter_battles_v2.main'
 local ModulesCorpseMarkers = require 'modules.corpse_markers'
 local Terrain = require "maps.biter_battles_v2.terrain"
+local UtilsProfiler = require 'utils.profiler'
 local UtilsServer = require 'utils.server'
+local UtilsTask = require 'utils.task'
 
 Event.add(defines.events.on_player_created, function (event)
 	local player = game.players[event.player_index]
@@ -102,3 +105,13 @@ end)
 Event.add(defines.events.on_pre_player_crafted_item, function (event)
 	Functions.maybe_set_game_start_tick(event)
 end)
+
+Event.add(defines.events.on_tick,
+	---@param event EventData.on_tick
+	function (event)
+		local tick = event.tick
+		UtilsProfiler.on_tick(tick)
+		UtilsTask.on_tick(tick)
+		MapsBiterBattlesV2Main.on_tick(tick)
+	end
+)

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -27,6 +27,8 @@ require "maps.biter_battles_v2.changelog_tab"
 require 'maps.biter_battles_v2.commands'
 require "modules.spawners_contain_biters"
 
+Public = {}
+
 local function on_player_joined_game(event)
 	local surface = game.surfaces[global.bb_surface_name]
 	local player = game.players[event.player_index]
@@ -240,9 +242,8 @@ local tick_minute_functions = {
 	[300 * 4 + 30 * 1] = anti_afk_system,
 }
 
-local function on_tick()
-	local tick = game.tick
-
+---@param tick int
+function Public.on_tick(tick)
 	if tick % 60 == 0 then 
 		global.bb_threat["north_biters"] = global.bb_threat["north_biters"] + global.bb_threat_income["north_biters"]
 		global.bb_threat["south_biters"] = global.bb_threat["south_biters"] + global.bb_threat_income["south_biters"]
@@ -478,10 +479,11 @@ Event.add(defines.events.on_robot_mined_entity, on_robot_mined_entity)
 Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)
-Event.add(defines.events.on_tick, on_tick)
 Event.on_init(on_init)
 
 commands.add_command('clear-corpses', 'Clears all the biter corpses..',
 		     clear_corpses)
 
 require "maps.biter_battles_v2.spec_spy"
+
+return Public

--- a/modules/corpse_markers.lua
+++ b/modules/corpse_markers.lua
@@ -1,4 +1,9 @@
-local function draw_map_tag(surface, force, position)
+local Public = {}
+
+---@param surface LuaSurface
+---@param force LuaForce
+---@param position MapPosition
+function Public.draw_map_tag(surface, force, position)
 	force.add_chart_tag(surface, {icon = {type = 'item', name = 'heavy-armor'}, position = position, text = "   "})
 end
 
@@ -32,7 +37,7 @@ end
 local function redraw_all_tags()
 	for _, surface in pairs(game.surfaces) do
 		for _, corpse in pairs(surface.find_entities_filtered({name = "character-corpse"})) do
-			draw_map_tag(corpse.surface, get_corpse_force(corpse), corpse.position)
+			Public.draw_map_tag(corpse.surface, get_corpse_force(corpse), corpse.position)
 		end
 	end
 end
@@ -46,11 +51,6 @@ local function find_and_destroy_tag(corpse)
 		end		
 	end
 	return false
-end
-
-local function on_player_died(event)
-	local player = game.players[event.player_index]
-	draw_map_tag(player.surface, player.force, player.position)
 end
 
 local function on_character_corpse_expired(event)
@@ -67,6 +67,7 @@ local function on_pre_player_mined_item(event)
 end
 
 local event = require 'utils.event'
-event.add(defines.events.on_player_died, on_player_died)
 event.add(defines.events.on_character_corpse_expired, on_character_corpse_expired)
 event.add(defines.events.on_pre_player_mined_item, on_pre_player_mined_item)
+
+return Public

--- a/utils/profiler.lua
+++ b/utils/profiler.lua
@@ -222,12 +222,12 @@ function Profiler.Stop(averageMs, message)
 end
 ignoredFunctions[Profiler.Stop] = true
 
-local function on_tick(event)
+---@param tick int
+function Profiler.on_tick(tick)
     --if not Profiler.IsRunning then return end
-    if not (event.tick == Profiler.AutoStopTick) then return end
-    Profiler.Stop(false, "AutoStop")    
+    if not (tick == Profiler.AutoStopTick) then return end
+    Profiler.Stop(false, "AutoStop")
 end
 
-Event.add(defines.events.on_tick, on_tick)
 return Profiler
 

--- a/utils/server.lua
+++ b/utils/server.lua
@@ -873,35 +873,27 @@ Event.add(
     end
 )
 
-Event.add(
-    defines.events.on_player_died,
-    function(event)
-        local player = game.get_player(event.player_index)
 
-        if not player or not player.valid then
-            return
-        end
+---@param player LuaPlayer
+---@param cause LuaEntity
+function Public.on_player_died(player, cause)
+	local message = {discord_bold_tag, player.name}
+	if cause and cause.valid then
+		message[#message + 1] = ' was killed by '
 
-        local cause = event.cause
+		local name = cause.name
+		if name == 'character' and cause.player then
+			name = cause.player.name
+		end
 
-        local message = {discord_bold_tag, player.name}
-        if cause and cause.valid then
-            message[#message + 1] = ' was killed by '
+		message[#message + 1] = name
+		message[#message + 1] = '.'
+	else
+		message[#message + 1] = ' has died.'
+	end
 
-            local name = cause.name
-            if name == 'character' and cause.player then
-                name = cause.player.name
-            end
-
-            message[#message + 1] = name
-            message[#message + 1] = '.'
-        else
-            message[#message + 1] = ' has died.'
-        end
-
-        message = concat(message)
-        raw_print(message)
-    end
-)
+	local str_message = concat(message)
+	raw_print(str_message)
+end
 
 return Public

--- a/utils/task.lua
+++ b/utils/task.lua
@@ -61,9 +61,8 @@ local function get_task_per_tick(tick)
     return primitives.task_per_tick
 end
 
-local function on_tick()
-    local tick = game.tick
-
+---@param tick int
+function Task.on_tick(tick)
     for i = 1, get_task_per_tick(tick) do
         local task = Queue_peek(task_queue)
         if task ~= nil then
@@ -84,11 +83,7 @@ local function on_tick()
     while callback ~= nil and tick >= callback.time do
         local success, result = pcall(Token_get(callback.func_token), callback.params)
         if not success then
-            if _DEBUG then
-                error(result)
-            else
-                log(result)
-            end
+            log(result)
         end
         PriorityQueue_pop(callbacks)
         callback = PriorityQueue_peek(callbacks)
@@ -156,7 +151,5 @@ end
 function Task.get_task_queue()
     return task_queue
 end
-
-Event.add(defines.events.on_tick, on_tick)
 
 return Task


### PR DESCRIPTION
### Brief description of the changes:
Centralize on_tick in preparation for gui rewrite. Events for on_tick are simple, no large logic changes made.  The only noteworthy change is the consolidation of using event.tick instead of game.tick for each event function.

See discussion at #440

depends on #454

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
