### PR TITLE
Remove Game.get_player_by_index and Game.get_player_from_any

### DIFF
--- a/comfy_panel/poll.lua
+++ b/comfy_panel/poll.lua
@@ -1,7 +1,6 @@
 local Gui = require 'utils.gui'
 local Global = require 'utils.global'
 local Event = require 'utils.event'
-local Game = require 'utils.game'
 local Server = require 'utils.server'
 local Tabs = require 'comfy_panel.main'
 local session = require 'utils.datastore.session_data'
@@ -181,7 +180,7 @@ local function redraw_poll_viewer_content(data)
     end
 
     for player_index, answer in pairs(voters) do
-        local p = Game.get_player_by_index(player_index)
+        local p = game.get_player(player_index)
         insert(tooltips[answer], p.name)
     end
 
@@ -208,7 +207,7 @@ local function redraw_poll_viewer_content(data)
     if next(edited_by_players) then
         local edit_names = {'Edited by '}
         for pi, _ in pairs(edited_by_players) do
-            local p = Game.get_player_by_index(pi)
+            local p = game.get_player(pi)
             if p and p.valid then
                 insert(edit_names, p.name)
                 insert(edit_names, ', ')
@@ -735,7 +734,7 @@ local function update_vote(voters, answer, direction)
     local tooltip = {}
     for pi, a in pairs(voters) do
         if a == answer then
-            local player = Game.get_player_by_index(pi)
+            local player = game.get_player(pi)
             insert(tooltip, player.name)
         end
     end
@@ -806,7 +805,7 @@ local function vote(event)
 end
 
 local function player_joined(event)
-    local player = Game.get_player_by_index(event.player_index)
+    local player = game.get_player(event.player_index)
     if not player or not player.valid then
         return
     end

--- a/utils/game.lua
+++ b/utils/game.lua
@@ -1,66 +1,4 @@
-local Global = require 'utils.global'
-local pairs = pairs
-
 local Game = {}
-
-local bad_name_players = {}
-Global.register(
-    bad_name_players,
-    function(tbl)
-        bad_name_players = tbl
-    end
-)
-
---[[
-    Due to a bug in the Factorio api the following expression isn't guaranteed to be true.
-    game.players[player.index] == player
-    get_player_by_index(index) will always return the correct player.
-    When looking up players by name or iterating through all players use game.players instead.
-]]
-function Game.get_player_by_index(index)
-    local p = game.players[index]
-
-    if not p then
-        return nil
-    end
-    if p.index == index then
-        return p
-    end
-
-    p = bad_name_players[index]
-    if p then
-        if p.valid then
-            return p
-        else
-            return nil
-        end
-    end
-
-    for k, v in pairs(game.players) do
-        if k == index then
-            bad_name_players[index] = v
-            return v
-        end
-    end
-end
-
---- Returns a valid LuaPlayer if given a number, string, or LuaPlayer. Returns nil otherwise.
--- obj <number|string|LuaPlayer>
-function Game.get_player_from_any(obj)
-    local o_type = type(obj)
-    local p
-    if type == 'number' then
-        p = Game.get_player_by_index(obj)
-    elseif o_type == 'string' then
-        p = game.players[obj]
-    elseif o_type == 'table' and obj.valid and obj.is_player() then
-        return obj
-    end
-
-    if p and p.valid then
-        return p
-    end
-end
 
 --- Prints to player or console.
 function Game.player_print(str)
@@ -114,7 +52,7 @@ end
     @return the created entity
 ]]
 function Game.print_player_floating_text_position(player_index, text, color, x_offset, y_offset)
-    local player = Game.get_player_by_index(player_index)
+    local player = game.get_player(player_index)
     if not player or not player.valid then
         return
     end

--- a/utils/server.lua
+++ b/utils/server.lua
@@ -2,7 +2,6 @@ local Token = require 'utils.token'
 local Task = require 'utils.task'
 local Global = require 'utils.global'
 local Event = require 'utils.event'
-local Game = require 'utils.game'
 local Print = require('utils.print_override')
 
 local serialize = serpent.serialize
@@ -817,7 +816,7 @@ commands.add_command(
 Event.add(
     defines.events.on_player_joined_game,
     function(event)
-        local player = Game.get_player_by_index(event.player_index)
+        local player = game.get_player(event.player_index)
         if not player or not player.valid then
             return
         end
@@ -829,7 +828,7 @@ Event.add(
 Event.add(
     defines.events.on_player_left_game,
     function(event)
-        local player = Game.get_player_by_index(event.player_index)
+        local player = game.get_player(event.player_index)
         if not player or not player.valid then
             return
         end


### PR DESCRIPTION
### Brief description of the changes:
Removes the function `Game.get_player_by_index` which had several uses in two files, replacing with a functionally identical `LuaGameScript::get_player` from the official Factorio Lua API. Also removes the function `Game.get_player_from_any` which had zero uses and also replicated the functionality of the official API. This reduces code complexity and eliminates the need for Factorio to copy the entire player table to Lua.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
