### PR TITLE
Add experimental new threat logic

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -314,9 +314,8 @@ end
 function Public.subtract_threat(entity)
 	if not threat_values[entity.name] then return end
 	local biter_not_boss_force = entity.force.name
-	local threat_modifier = 1
 	local is_boss = false
-	local health_factor = 1
+	local factor = 1
 	if entity.force.name == 'south_biters_boss' then
 		biter_not_boss_force = 'south_biters'
 		is_boss = true
@@ -326,10 +325,16 @@ function Public.subtract_threat(entity)
 	end
 	if is_boss == true then
 		local health_buff_equivalent_revive = 1.0/(1.0-global.reanim_chance[game.forces[biter_not_boss_force].index]/100)
-		health_factor = bb_config.health_multiplier_boss*health_buff_equivalent_revive
+		factor = bb_config.health_multiplier_boss*health_buff_equivalent_revive
+	else
+		if global.try_new_threat_logic then
+			-- For normal biters, we essentially want revives to be ignored - i.e. the threat should go down on
+			-- average only once per spawned biter (no matter how many times it revives). Thus if the revive
+			-- chance is 90%, we only want the threat to go down by 10% for each kill.
+			factor = 1.0 - global.reanim_chance[game.forces[biter_not_boss_force].index]/100
+		end
 	end
-	threat_modifier = 1 * health_factor
-	global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_values[entity.name] * threat_modifier
+	global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_values[entity.name] * factor
 	return true
 end
 

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -18,7 +18,8 @@ local bb_config = {
 	["max_group_evo2"] = 100,						--Limit of unit group size for biters depending on evo.
 	["max_group_evo3"] = 75,						--Limit of unit group size for biters depending on evo.
 	["max_group_evo4"] = 50,						--Limit of unit group size for biters depending on evo.
-	["health_multiplier_boss"] = 20*1.3				--Health multiplier for boss biters
+	["health_multiplier_boss"] = 20*1.3,			--Health multiplier for boss biters
+	["threat_scale_factor_past_evo100"] = 3,		--Threat scale factor past 100% evo
 }
 
 return bb_config

--- a/tests/test-feeding.lua
+++ b/tests/test-feeding.lua
@@ -11,6 +11,8 @@ local function effects_str(effects)
 	return string.format("evo_increase: %.3f threat: %.0f", effects.evo_increase, effects.threat_increase)
 end
 
+global = { try_new_threat_logic = false }
+
 function test_feed_effects_1()
 	-- Simple early-game send
 	local difficulty = 25


### PR DESCRIPTION
## Short version

A new option is added (which defaults to off, but we will probably
test for a few weeks). When the option is turned on, the following
things happen:

1. There should be zero change to anything below 100% evo, and almost
no change below ~150% evo.

2. There is no longer a big batch-send bonus that results in bonus
threat for doing a send that results in 325% evo.

3. Late game threat values will look lower, but will go down much more
slowly.

4. Sends when around 200% - 300% evo are probably more powerful than
they used to be.

5. Threat should no longer sometimes go negative after defeating large
attack waves at high evo% values.

## Long version

There are two unexpected-behaviors (bugs?) in the code today, both
related to high revive% cases (i.e. they happen as evo% approaches
325%).

1. Large batch-send threat bonus.  Specifically, the code today scales
threat by `1/(1 - revive_chance)`.  This is somewhat done in an
attempt to make revive% just look like extra health.  Specifically,
the revived biters end up subtracting threat every time they are
killed, so it take 10x as much threat to compensate for the death of a
biter that will die 10 times.  This means that for sending the same
amount of science, you get 10x as much threat at 325% evo as at 100%
evo. In many ways, This is fine. The surprising thing is that the
bonus is applied once per batch of science sent, at the final evo%
value. Thus, there is a massive benefit to having one very large send
that results in a final value of ~325% evolution.

    For instance
    ```
      /calc-send evo=100 color=white difficulty=54 players=20 count=14000
       -> +5.2M threat

      /calc-send evo=100 color=white difficulty=54 players=20 count=12000
      /calc-send evo=296 color=white difficulty=54 players=20 count=2000
       -> +2M threat + 750k threat = 2.75M threat
    ```

    This shows that the batched send results in ~2x the total threat
    generated compared to sending the same amount of science in a
    different sequence. (both sends result in the same evo% value)

2. Larger attack wave bonus. The code that calculates attack wave size
does not take revive% into account.  Thus, it essentially generates
waves that are up to 10x larger than the code really intends to. In
the case of boss biters, the code *does* take revive% properly into
account, but not for non-boss biters.  This explains why sometimes
threat can go negative after many attack waves are sent to a team that
has high revive% chance.  The net-effect of this bug is that at low
revive% chances (i.e. before 100% evolution), on average biters are
generated that account for ~40% of outstanding threat every 2
minutes. So, for instance, if 1000 biters worth of threat is given to
your team, perhaps the next waves will have 400 biters total, and then
two minutes later, the waves will have 600*0.4 = 240 biters total, and
so on, and thus the attacks will be spread out over 6-10 minutes in
many ways.  However, at high revive%, all 1000 biters (or even more!)
are likely to be sent in the first wave.

I think that both (1) and (2) are poorly understood by the community,
and are very surprising. The `/calc-send` command helps with (1), but
the behavior is still very unexpected and hard to explain.

The combination of (1) and (2) above are what make sends that push
from 100% (or lower) evo that result in the final evo being around
325% so incredibly powerful. They end up generating ~4M threat, and
then almost all of that threat is turned into the first attack wave. I
feel like this hurts game mechanics, because in some ways defence
becomes not-very-relevant, and the game turns into a race to produce
exactly enough science to hit 325%.

So, to make any changes to this, we have to weigh many different
priorities against one another.

1. We want to remove the massive batch-send-bonus that impacts final
evolution values near 325%. Specifically, there should never be any
substantial difference between sending X all at once, or doing
back-to-back sends of (x - y) and (y). (unless someone wants to
introduce a batch-send-bonus, in which case it should probably work
all of the time, not just in the 100% - 325% evo range, but I don't
really want this mechanic I think)

2. We are comfortabe with the possibility of removing a clear "you
win" condition around reaching 325% evo. However, we need a
definite-win condition to exist somewhere vaguely around 300% - 450%.
i.e. no matter how good your opponent's defence is, a send that adds
+50% evo when at 400% evo needs to result in your opponent being
overrun.

3. I would love it if overall, it felt like the difficulty difference
between 100% evo and 200% evo was greater, and the difference between
250% and 325% was smaller.  i.e. the perceived difficulty of biters
goes up very quickly from, say 85% to 95%, and then stays almost flat
for a long time (till 250% or something), and then starts
very-rapidly-increasing up to 325%.  It would be nice if that was
spread out a bit more.

4. Currently, due to (2) above (the wave-size mechanic), the impact of
a pile of threat feels different when at low revive% vs high revive%.
It would be nice if this felt consistent regardless of evo%/revive%.

This change takes a stab at addressing these issues and threading this
needle.  When global.try_new_threat_logic is set to true, the
following changes happen in the code:

1. We no longer increase threat from sending by `1/(1 - reanim_chance)`.

2. Threat from sending is buffed (because 1 ends up being a massive
nerf to the size of waves past 250% evo, even when science is sent in
many small batches).  Specifically, it is buffed by a factor of 
`(1 + (evo - 100%) * 3)`. So even at 350% evo, that is only a factor of 8.5
(compared to the factor of 10 that exists today for wave size).

3. On average, fully-killing a biter (i.e. taking into account the
number of times it revives) will only reduce the threat for a single
biter's worth of threat.

So, for instance, if try_new_threat_logic = true, then we always get a
reliable amount of threat (specifically, for the example above, 2.45M
threat, rather than 5.2M/2.75M depending on how it was batched).
However, with the new logic, it is also much harder for that number to
go down (because each kill will only result in 1/10 of the previous
reduction to threat).

It is hard for me to fully predict how all of these changes will
impact the game. For evo% under 100%, there are zero changes. And for
values under 200%, the changes should be quite small.

example outputs
```
/calc-send evo=0 color=white difficulty=50 players=20 count=1000
 -> evo 97%,    threat +47k  (unchanged by try_new_threat_logic)
/calc-send evo=0 color=white difficulty=50 players=20 count=4000
 -> evo 143%,   old logic +181k threat,  try_new_threat_logic +219k threat
/calc-send evo=0 color=white difficulty=50 players=20 count=15000
 -> evo 309%,   old logic +3.1M threat,  try_new_threat_logic +2.1M threat
```

Thus, I expect that this change will be an overall buff to sends,
especially in the 150%-250% evo range (because essentially more threat
is generated), and a substantial nerf to large sends that end up
around 300%-350% evo (because there will not be the very very high
threat-bonus where the entire send gets 10x as much threat). It is
otherwise a substantial buff to non-batched-sends (i.e. it closes the
gap between large/batched sends and unbatched sends on both
sides... making small sends better, and large sends worse).

Additionally, this will change the way that the game acts when at high
revive% values. Specifically, passive-threat-income will essentially
be much higher (passive-threat income is the same, but the threat will
require 10x as many kills to go down (at 90% revive), so it will
effectively be 10x higher). For a given threat value, the waves will
be the same size, but the amount that threat decreases will be much
lower (i.e. no more going negative on threat just for defending a
wave).