### PR TITLE
Healthbar text take 2

### DIFF
--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -182,6 +182,12 @@ local functions = {
 			game.print("Map Reroll is disabled!")
 		end
 	end,
+    ["bb_map_show_healthbar_numbers"] = function(event)
+        local boss = package.loaded['functions.boss_unit']
+        local player = game.get_player(event.player_index)
+        if not player or not player.valid then return end
+        boss.healthbarnumbers_enable_for_player(player.name, event.element.switch_state == "left")
+    end,
 }
 
 local poll_function = {
@@ -403,6 +409,22 @@ local build_config_gui = (function(player, frame)
             'comfy_panel_poll_no_notify_toggle',
             'Notify on polls',
             'Receive a message when new polls are created and popup the poll.'
+        )
+        scroll_pane.add({type = 'line'})
+    end
+
+    if package.loaded['functions.boss_unit'] then
+        local boss = package.loaded['functions.boss_unit']
+        switch_state = 'right'
+        if boss.healthbarnumbers_enabled_for_player(player.name) then
+            switch_state = 'left'
+        end
+        add_switch(
+            scroll_pane,
+            switch_state,
+            'bb_map_show_healthbar_numbers',
+            'Healthbar Numbers',
+            'Show health values on boss units'
         )
         scroll_pane.add({type = 'line'})
     end

--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -133,55 +133,55 @@ local functions = {
         end
         spaghett()
     end,
-	["bb_team_balancing_toggle"] = function(event) 
-		if event.element.switch_state == "left" then
-			global.bb_settings.team_balancing = true
-			game.print("Team balancing has been enabled!")
-		else
-			global.bb_settings.team_balancing = false
-			game.print("Team balancing has been disabled!")
-		end
-	end,
-	
-	["bb_only_admins_vote"] = function(event) 
-		if event.element.switch_state == "left" then
-			global.bb_settings.only_admins_vote = true
-			global.difficulty_player_votes = {}
-			game.print("Admin-only difficulty voting has been enabled!")
-		else
-			global.bb_settings.only_admins_vote = false
-			game.print("Admin-only difficulty voting has been disabled!")
-		end
-	end,
-	["comfy_panel_new_year_island"] = function(event)
-		if event.element.switch_state == "left" then
-			global.bb_settings['new_year_island'] = true
+    ["bb_team_balancing_toggle"] = function(event)
+        if event.element.switch_state == "left" then
+            global.bb_settings.team_balancing = true
+            game.print("Team balancing has been enabled!")
+        else
+            global.bb_settings.team_balancing = false
+            game.print("Team balancing has been disabled!")
+        end
+    end,
+
+    ["bb_only_admins_vote"] = function(event)
+        if event.element.switch_state == "left" then
+            global.bb_settings.only_admins_vote = true
+            global.difficulty_player_votes = {}
+            game.print("Admin-only difficulty voting has been enabled!")
+        else
+            global.bb_settings.only_admins_vote = false
+            game.print("Admin-only difficulty voting has been disabled!")
+        end
+    end,
+    ["comfy_panel_new_year_island"] = function(event)
+        if event.element.switch_state == "left" then
+            global.bb_settings['new_year_island'] = true
             get_actor(event, '{New Year Island}', "New Year island has been enabled!", true)
-		else
-			global.bb_settings['new_year_island'] = false
-			get_actor(event, '{New Year Island}', "New Year island has been disabled!", true)
-		end
-	end,
-  
-	["bb_map_reveal_toggle"] = function(event)
-		if event.element.switch_state == "left" then
-			global.bb_settings['bb_map_reveal_toggle'] = true
-			game.print("Reveal map at start has been enabled!")
-		else
-			global.bb_settings['bb_map_reveal_toggle'] = false
-			game.print("Reveal map at start has been disabled!")
-		end
-	end,
-  
-	["bb_map_reroll_toggle"] = function(event)
-		if event.element.switch_state == "left" then
-			global.bb_settings.map_reroll = true
-			game.print("Map Reroll is enabled!")
-		else
-			global.bb_settings.map_reroll = false
-			game.print("Map Reroll is disabled!")
-		end
-	end,
+        else
+            global.bb_settings['new_year_island'] = false
+            get_actor(event, '{New Year Island}', "New Year island has been disabled!", true)
+        end
+    end,
+
+    ["bb_map_reveal_toggle"] = function(event)
+        if event.element.switch_state == "left" then
+            global.bb_settings['bb_map_reveal_toggle'] = true
+            game.print("Reveal map at start has been enabled!")
+        else
+            global.bb_settings['bb_map_reveal_toggle'] = false
+            game.print("Reveal map at start has been disabled!")
+        end
+    end,
+
+    ["bb_map_reroll_toggle"] = function(event)
+        if event.element.switch_state == "left" then
+            global.bb_settings.map_reroll = true
+            game.print("Map Reroll is enabled!")
+        else
+            global.bb_settings.map_reroll = false
+            game.print("Map Reroll is disabled!")
+        end
+    end,
     ["bb_map_show_healthbar_numbers"] = function(event)
         local boss = package.loaded['functions.boss_unit']
         local player = game.get_player(event.player_index)
@@ -505,8 +505,8 @@ local build_config_gui = (function(player, frame)
             'Left = Enables antigrief / Right = Disables antigrief'
         )
         scroll_pane.add({type = 'line'})
-		
-		
+
+
         if package.loaded['maps.biter_battles_v2.main'] then
             label = scroll_pane.add({type = 'label', caption = 'Biter Battles Settings'})
             label.style.font = 'default-bold'
@@ -518,36 +518,36 @@ local build_config_gui = (function(player, frame)
             label.style.font_color = Color.green
 
             scroll_pane.add({type = 'line'})
-			
-			local switch_state = "right"
-			if global.bb_settings.team_balancing then switch_state = "left" end
-			local switch = add_switch(scroll_pane, switch_state, "bb_team_balancing_toggle", "Team Balancing", "Players can only join a team that has less or equal players than the opposing.")
-			if not admin then switch.ignored_by_interaction = true end
-			
-			scroll_pane.add({type = 'line'})
-			
-			local switch_state = "right"
-			if global.bb_settings["bb_map_reveal_toggle"] then switch_state = "left" end
-			local switch = add_switch(scroll_pane, switch_state, "bb_map_reveal_toggle", "Reveal map", "Reveal map at start.")
-			if not admin then switch.ignored_by_interaction = true end
-				
-			scroll_pane.add({type = 'line'})
 
-			local switch_state = "right"
-			if global.bb_settings.only_admins_vote then switch_state = "left" end
-			local switch = add_switch(scroll_pane, switch_state, "bb_only_admins_vote", "Admin Vote", "Only admins can vote for map difficulty. Clears all currently existing votes.")
-			if not admin then switch.ignored_by_interaction = true end
-			
-			scroll_pane.add({type = 'line'})
-				
-			local switch_state = "right"	
+            local switch_state = "right"
+            if global.bb_settings.team_balancing then switch_state = "left" end
+            local switch = add_switch(scroll_pane, switch_state, "bb_team_balancing_toggle", "Team Balancing", "Players can only join a team that has less or equal players than the opposing.")
+            if not admin then switch.ignored_by_interaction = true end
+
+            scroll_pane.add({type = 'line'})
+
+            local switch_state = "right"
+            if global.bb_settings["bb_map_reveal_toggle"] then switch_state = "left" end
+            local switch = add_switch(scroll_pane, switch_state, "bb_map_reveal_toggle", "Reveal map", "Reveal map at start.")
+            if not admin then switch.ignored_by_interaction = true end
+
+            scroll_pane.add({type = 'line'})
+
+            local switch_state = "right"
+            if global.bb_settings.only_admins_vote then switch_state = "left" end
+            local switch = add_switch(scroll_pane, switch_state, "bb_only_admins_vote", "Admin Vote", "Only admins can vote for map difficulty. Clears all currently existing votes.")
+            if not admin then switch.ignored_by_interaction = true end
+
+            scroll_pane.add({type = 'line'})
+
+            local switch_state = "right"
             if global.bb_settings.map_reroll then switch_state = "left" end
-			local switch = add_switch(scroll_pane, switch_state, "bb_map_reroll_toggle", "Map Reroll", "Enables map reroll feature.")
-			if not admin then switch.ignored_by_interaction = true end
-			
-			scroll_pane.add({type = 'line'})
-		end
-		
+            local switch = add_switch(scroll_pane, switch_state, "bb_map_reroll_toggle", "Map Reroll", "Enables map reroll feature.")
+            if not admin then switch.ignored_by_interaction = true end
+
+            scroll_pane.add({type = 'line'})
+        end
+
         if package.loaded['maps.mountain_fortress_v3.main'] then
             label = scroll_pane.add({type = 'label', caption = 'Mountain Fortress Settings'})
             label.style.font = 'default-bold'

--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -133,55 +133,55 @@ local functions = {
         end
         spaghett()
     end,
-    ["bb_team_balancing_toggle"] = function(event)
-        if event.element.switch_state == "left" then
-            global.bb_settings.team_balancing = true
-            game.print("Team balancing has been enabled!")
-        else
-            global.bb_settings.team_balancing = false
-            game.print("Team balancing has been disabled!")
-        end
-    end,
-
-    ["bb_only_admins_vote"] = function(event)
-        if event.element.switch_state == "left" then
-            global.bb_settings.only_admins_vote = true
-            global.difficulty_player_votes = {}
-            game.print("Admin-only difficulty voting has been enabled!")
-        else
-            global.bb_settings.only_admins_vote = false
-            game.print("Admin-only difficulty voting has been disabled!")
-        end
-    end,
-    ["comfy_panel_new_year_island"] = function(event)
-        if event.element.switch_state == "left" then
-            global.bb_settings['new_year_island'] = true
+	["bb_team_balancing_toggle"] = function(event) 
+		if event.element.switch_state == "left" then
+			global.bb_settings.team_balancing = true
+			game.print("Team balancing has been enabled!")
+		else
+			global.bb_settings.team_balancing = false
+			game.print("Team balancing has been disabled!")
+		end
+	end,
+	
+	["bb_only_admins_vote"] = function(event) 
+		if event.element.switch_state == "left" then
+			global.bb_settings.only_admins_vote = true
+			global.difficulty_player_votes = {}
+			game.print("Admin-only difficulty voting has been enabled!")
+		else
+			global.bb_settings.only_admins_vote = false
+			game.print("Admin-only difficulty voting has been disabled!")
+		end
+	end,
+	["comfy_panel_new_year_island"] = function(event)
+		if event.element.switch_state == "left" then
+			global.bb_settings['new_year_island'] = true
             get_actor(event, '{New Year Island}', "New Year island has been enabled!", true)
-        else
-            global.bb_settings['new_year_island'] = false
-            get_actor(event, '{New Year Island}', "New Year island has been disabled!", true)
-        end
-    end,
-
-    ["bb_map_reveal_toggle"] = function(event)
-        if event.element.switch_state == "left" then
-            global.bb_settings['bb_map_reveal_toggle'] = true
-            game.print("Reveal map at start has been enabled!")
-        else
-            global.bb_settings['bb_map_reveal_toggle'] = false
-            game.print("Reveal map at start has been disabled!")
-        end
-    end,
-
-    ["bb_map_reroll_toggle"] = function(event)
-        if event.element.switch_state == "left" then
-            global.bb_settings.map_reroll = true
-            game.print("Map Reroll is enabled!")
-        else
-            global.bb_settings.map_reroll = false
-            game.print("Map Reroll is disabled!")
-        end
-    end,
+		else
+			global.bb_settings['new_year_island'] = false
+			get_actor(event, '{New Year Island}', "New Year island has been disabled!", true)
+		end
+	end,
+  
+	["bb_map_reveal_toggle"] = function(event)
+		if event.element.switch_state == "left" then
+			global.bb_settings['bb_map_reveal_toggle'] = true
+			game.print("Reveal map at start has been enabled!")
+		else
+			global.bb_settings['bb_map_reveal_toggle'] = false
+			game.print("Reveal map at start has been disabled!")
+		end
+	end,
+  
+	["bb_map_reroll_toggle"] = function(event)
+		if event.element.switch_state == "left" then
+			global.bb_settings.map_reroll = true
+			game.print("Map Reroll is enabled!")
+		else
+			global.bb_settings.map_reroll = false
+			game.print("Map Reroll is disabled!")
+		end
+	end,
     ["bb_map_show_healthbar_numbers"] = function(event)
         local boss = package.loaded['functions.boss_unit']
         local player = game.get_player(event.player_index)
@@ -505,8 +505,8 @@ local build_config_gui = (function(player, frame)
             'Left = Enables antigrief / Right = Disables antigrief'
         )
         scroll_pane.add({type = 'line'})
-
-
+		
+		
         if package.loaded['maps.biter_battles_v2.main'] then
             label = scroll_pane.add({type = 'label', caption = 'Biter Battles Settings'})
             label.style.font = 'default-bold'
@@ -518,36 +518,36 @@ local build_config_gui = (function(player, frame)
             label.style.font_color = Color.green
 
             scroll_pane.add({type = 'line'})
+			
+			local switch_state = "right"
+			if global.bb_settings.team_balancing then switch_state = "left" end
+			local switch = add_switch(scroll_pane, switch_state, "bb_team_balancing_toggle", "Team Balancing", "Players can only join a team that has less or equal players than the opposing.")
+			if not admin then switch.ignored_by_interaction = true end
+			
+			scroll_pane.add({type = 'line'})
+			
+			local switch_state = "right"
+			if global.bb_settings["bb_map_reveal_toggle"] then switch_state = "left" end
+			local switch = add_switch(scroll_pane, switch_state, "bb_map_reveal_toggle", "Reveal map", "Reveal map at start.")
+			if not admin then switch.ignored_by_interaction = true end
+				
+			scroll_pane.add({type = 'line'})
 
-            local switch_state = "right"
-            if global.bb_settings.team_balancing then switch_state = "left" end
-            local switch = add_switch(scroll_pane, switch_state, "bb_team_balancing_toggle", "Team Balancing", "Players can only join a team that has less or equal players than the opposing.")
-            if not admin then switch.ignored_by_interaction = true end
-
-            scroll_pane.add({type = 'line'})
-
-            local switch_state = "right"
-            if global.bb_settings["bb_map_reveal_toggle"] then switch_state = "left" end
-            local switch = add_switch(scroll_pane, switch_state, "bb_map_reveal_toggle", "Reveal map", "Reveal map at start.")
-            if not admin then switch.ignored_by_interaction = true end
-
-            scroll_pane.add({type = 'line'})
-
-            local switch_state = "right"
-            if global.bb_settings.only_admins_vote then switch_state = "left" end
-            local switch = add_switch(scroll_pane, switch_state, "bb_only_admins_vote", "Admin Vote", "Only admins can vote for map difficulty. Clears all currently existing votes.")
-            if not admin then switch.ignored_by_interaction = true end
-
-            scroll_pane.add({type = 'line'})
-
-            local switch_state = "right"
+			local switch_state = "right"
+			if global.bb_settings.only_admins_vote then switch_state = "left" end
+			local switch = add_switch(scroll_pane, switch_state, "bb_only_admins_vote", "Admin Vote", "Only admins can vote for map difficulty. Clears all currently existing votes.")
+			if not admin then switch.ignored_by_interaction = true end
+			
+			scroll_pane.add({type = 'line'})
+				
+			local switch_state = "right"	
             if global.bb_settings.map_reroll then switch_state = "left" end
-            local switch = add_switch(scroll_pane, switch_state, "bb_map_reroll_toggle", "Map Reroll", "Enables map reroll feature.")
-            if not admin then switch.ignored_by_interaction = true end
-
-            scroll_pane.add({type = 'line'})
-        end
-
+			local switch = add_switch(scroll_pane, switch_state, "bb_map_reroll_toggle", "Map Reroll", "Enables map reroll feature.")
+			if not admin then switch.ignored_by_interaction = true end
+			
+			scroll_pane.add({type = 'line'})
+		end
+		
         if package.loaded['maps.mountain_fortress_v3.main'] then
             label = scroll_pane.add({type = 'label', caption = 'Mountain Fortress Settings'})
             label.style.font = 'default-bold'

--- a/functions/boss_unit.lua
+++ b/functions/boss_unit.lua
@@ -1,20 +1,30 @@
 --adds a health bar and health increase to a unit
 local Public = {}
+local healthbartext_playerlist
 
 local function create_healthbar(entity, size)
-	return rendering.draw_sprite({
+	global.next_healthbar_update = entity.unit_number
+
+	local healthbar_id = rendering.draw_sprite({
 		sprite="virtual-signal/signal-white",
 		tint={0, 200, 0},
 		x_scale=size * 15, y_scale=size, render_layer="light-effect",
 		target=entity, target_offset={0, -2.5}, surface=entity.surface,
 	})
-end
 
-local function set_healthbar(boss_unit)
-	local m = boss_unit.health / boss_unit.max_health
-	local x_scale = rendering.get_y_scale(boss_unit.healthbar_id) * 15
-	rendering.set_x_scale(boss_unit.healthbar_id, x_scale * m)
-	rendering.set_color(boss_unit.healthbar_id, {math.floor(255 - 255 * m), math.floor(200 * m), 0})
+	local healthtext_id = rendering.draw_text({
+		text = 0,
+		surface=entity.surface,
+		target=entity,
+		target_offset={0, -3},
+		scale = 1.5,
+		alignment='center',
+		color={1, 1, 1, 1},
+		players=healthbartext_playerlist, --need to do this because empty playerlist means no filter and cannot give it fake names
+		visible=#healthbartext_playerlist > 0,
+	})
+
+	return healthbar_id, healthtext_id
 end
 
 function Public.add_boss_unit(entity, health_factor, size)
@@ -25,10 +35,47 @@ function Public.add_boss_unit(entity, health_factor, size)
 	if health == 0 then return end
 	local s = 0.5
 	if size then s = size end
-	global.boss_units[entity.unit_number] = {entity = entity, max_health = health, health = health, healthbar_id = create_healthbar(entity, s), last_update = game.tick}
+	local healthbar_id, healthtext_id = create_healthbar(entity, s)
+	global.boss_units[entity.unit_number] = {entity = entity, max_health = health, health = health, healthbar_id = healthbar_id, healthtext_id = healthtext_id}
 end
 
----@param event EventData.on_entity_damaged
+function Public.healthbarnumbers_enable_for_player(playerName, enable)
+	local foundIndex, didChanges
+	for i = 1, #healthbartext_playerlist do
+		if healthbartext_playerlist[i] == playerName then
+			foundIndex = i
+			break
+		end
+	end
+
+	if (enable) then
+		if not foundIndex then
+			didChanges = true
+			table.insert(healthbartext_playerlist, playerName)
+		end
+	else
+		if (foundIndex) then
+			didChanges = true
+			table.remove(healthbartext_playerlist, foundIndex)
+		end
+	end
+
+	if didChanges then
+		for _,boss in pairs(global.boss_units) do
+			rendering.set_visible(boss.healthtext_id ,#healthbartext_playerlist>0)
+			rendering.set_players(boss.healthtext_id ,healthbartext_playerlist)
+		end
+	end
+end
+
+function Public.healthbarnumbers_enabled_for_player(playerName)
+	for i = 1, #healthbartext_playerlist do
+		if healthbartext_playerlist[i] == playerName then
+			return true
+		end
+	end
+end
+
 local function on_entity_damaged(event)
 	local entity = event.entity
 	local boss = global.boss_units[entity.unit_number]
@@ -37,26 +84,52 @@ local function on_entity_damaged(event)
 	boss.health = boss.health - event.final_damage_amount
 	if boss.health <= 0 then
 		global.boss_units[entity.unit_number] = nil
-		if event.cause then
-			entity.die(event.cause.force, event.cause)
-		else
-			entity.die()
+		entity.die()
+		if not next(global.boss_units) then
+			global.next_healthbar_update = nil
 		end
-	else
-		if boss.last_update + 30 < game.tick then
-			set_healthbar(global.boss_units[entity.unit_number])
-			boss.last_update = game.tick
+	end
+end
+
+local function on_tick()
+	if global.next_healthbar_update then
+		local current_boss = global.boss_units[global.next_healthbar_update]
+		if current_boss then
+			-- update healthbar
+			local m = current_boss.health / current_boss.max_health
+			local x_scale = rendering.get_y_scale(current_boss.healthbar_id) * 15
+			rendering.set_x_scale(current_boss.healthbar_id, x_scale * m)
+			rendering.set_color(current_boss.healthbar_id, {math.floor(255 - 255 * m), math.floor(200 * m), 0})
+
+			local text = 0
+			if current_boss.health >= 10^6 then
+		        text = string.format("%.2fM", current_boss.health / 10^6)
+		    elseif current_boss.health >= 10^3 then
+		        text = string.format("%.2fK", current_boss.health / 10^3)
+		    else
+		        text = tostring(current_boss.health)
+		    end
+			rendering.set_text(current_boss.healthtext_id, text)
+
+			global.next_healthbar_update = next(global.boss_units, global.next_healthbar_update)
+			if not global.next_healthbar_update then
+				global.next_healthbar_update = next(global.boss_units)
+			end
+		else
+			global.next_healthbar_update = next(global.boss_units)
 		end
 	end
 end
 
 local function on_init()
 	global.boss_units = {}
+	healthbartext_playerlist = {}
 end
 
 local event = require 'utils.event'
 event.on_init(on_init)
 event.add(defines.events.on_entity_damaged, on_entity_damaged)
+event.add(defines.events.on_tick, on_tick)
 event.add_event_filter(defines.events.on_entity_damaged, {
 	filter = "type",
 	type = "unit",


### PR DESCRIPTION
### Brief description of the changes:

So a update to the previous healthbar text patch, because i've no idea how this github stuff works so i just made a new one.
I added option to hide the text, it's opt in. Changeable in the config window together with the notify on poll etc.

To answer rag's question i want to have it on on tick because the health text is more responsive when there's fewer bosses around and thats when you want it to be most responsive. It can update at maximum one healthbar per tick so i believe this is also a small  performance increase but not sure. And sorry for the space spam, not sure how to fix it.

And yeah, would probably be wise to test these changes :)

Earlier post:
Added text to the healthbar, heard worries about UPS but shouldn't be much impact, its only 1 text updated each second. 

https://cdn.discordapp.com/attachments/823771633021747210/1179497243036897380/image.png?ex=6579ff68&is=65678a68&hm=3c7ce440bfc6605fff1f85afb4fa7ab9fbd9fe4487c0d5535c4a928aa7460190&

### Tested Changes:
- [🍑] I've tested the changes locally or with people.
- [ ] I've not tested the changes.