### PR TITLE
Fix on_built_entity

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -141,7 +141,7 @@ local function on_console_command(event)
 end
 
 local function on_built_entity(event)
-	maybe_set_game_start_tick(event)
+	Functions.maybe_set_game_start_tick(event)
 	Functions.no_landfill_by_untrusted_user(event, Session.get_trusted_table())
 	Functions.no_turret_creep(event)
 	Terrain.deny_enemy_side_ghosts(event)


### PR DESCRIPTION
This might currently be breaking things like turret creep, landfill trust, and enemy ghosts.  Yikes.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
