### PR TITLE
Speed up ai_targets random target selection

### DIFF
--- a/benchmarking/main.lua
+++ b/benchmarking/main.lua
@@ -1,4 +1,5 @@
 local Ai = require("maps.biter_battles_v2.ai")
+local AiTargets = require("maps.biter_battles_v2.ai_targets")
 local BenchmarkingBlueprints = require("benchmarking.blueprints")
 local Event = require("utils.event")
 local Feeding = require "maps.biter_battles_v2.feeding"
@@ -36,6 +37,7 @@ local function build_blueprint_from_string(bp_string, surface, offset, force)
 			entity.position = offset_pos
 			entity.force = force
 			surface.create_entity(entity)
+			AiTargets.start_tracking(entity)
 		end
 	end
 end

--- a/control.lua
+++ b/control.lua
@@ -70,7 +70,6 @@ Event.add(defines.events.on_player_mined_entity, function (event)
 	if not entity.valid then
 		return
 	end
-	AiTargets.stop_tracking(entity)
 
 	local player = game.get_player(event.player_index)
 	if player and player.valid then

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -251,7 +251,6 @@ end
 
 Public.pre_main_attack = function()
 	local force_name = global.next_attack
-	AiTargets.select(force_name)
 
 	-- In headless benchmarking, there are no connected_players so we need a global to override this
 	if not global.training_mode or (global.training_mode and (global.benchmark_mode or #game.forces[force_name].connected_players > 0))then

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -217,7 +217,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 	local threat = global.bb_threat[biter_force_name]
 	if threat <= 0 then return false end
 
-	local target_position = AiTargets.poll(force_name)
+	local target_position = AiTargets.get_random_target(force_name)
 	if not target_position then
 		print("No side target found for " .. force_name .. ".")
 		return

--- a/maps/biter_battles_v2/ai_targets.lua
+++ b/maps/biter_battles_v2/ai_targets.lua
@@ -40,17 +40,14 @@ local function origin_distance(position)
     return math_sqrt(x * x + y * y)
 end
 
-local function simple_random_sample(population_list, sample_size)
+local function simple_random_sample(population_list)
     local population_size = #population_list
-    local sample = {}
     if population_size > 0 then
-        for _ = 1, sample_size, 1 do
-            local random_index = math_random(1, population_size)
-            local individual = population_list[random_index]
-            table_insert(sample, individual)
-        end
+        local random_index = math_random(1, population_size)
+        local individual = population_list[random_index]
+        return individual
     end
-    return sample
+    return nil
 end
 
 function Public.start_tracking(entity)
@@ -59,37 +56,47 @@ function Public.start_tracking(entity)
     if target_entity_type[entity.type] and entity.unit_number then
         local targets = global.ai_targets[entity.force.name]
         if targets ~= nil then
-            targets.available[entity.unit_number] = entity
+            global.ai_target_destroyed_map[script.register_on_entity_destroyed(entity)] = entity.force.name
+            table_insert(targets.available_list, {unit_number = entity.unit_number, position = entity.position})
+            targets.available[entity.unit_number] = #targets.available_list
         end
     end
 end
 
-function Public.stop_tracking(entity)
-    if target_entity_type[entity.type] and entity.unit_number then
-        local targets = global.ai_targets[entity.force.name]
-        if targets ~= nil then
-            targets.available[entity.unit_number] = nil
+local function on_entity_destroyed(event)
+    local map = global.ai_target_destroyed_map
+    local unit_number = event.unit_number
+    local force = map[event.registration_number]
+    map[unit_number] = nil
+    local targets = global.ai_targets[force]
+    if targets ~= nil then
+        local target_list_index = targets.available[unit_number]
+        if target_list_index ~= nil then
+            -- swap the last element with the element to be removed
+            local last = targets.available_list[#targets.available_list]
+            if target_list_index ~= #targets.available_list then
+                targets.available[last.unit_number] = target_list_index
+                targets.available_list[target_list_index] = last
+            end
+            table_remove(targets.available_list)
+            targets.available[unit_number] = nil
         end
     end
 end
+
+script.on_event(defines.events.on_entity_destroyed, on_entity_destroyed)
 
 function Public.select(force_name)
-    local population_list = {}
     local targets = global.ai_targets[force_name]
-    local available = targets.available
-    for unit_number, entity in pairs(available) do
-        if entity.valid then
-            table_insert(population_list, entity.position)
-        else
-            available[unit_number] = nil
-        end
-    end
-    -- (max) 7 targets per wave * 2 sub-sample size = 14 global sample size per wave
-    local sample = simple_random_sample(population_list, 14)
+    local available_list = targets.available_list
+    -- (max) 7 targets per wave
     local selected = {}
-    for i = 1, #sample, 2 do
-        local first = sample[i]
-        local second = sample[i + 1]
+    for i = 1, 7, 1 do
+        local first_entity = simple_random_sample(available_list)
+        local second_entity = simple_random_sample(available_list)
+        if not first_entity or not second_entity then break end
+        local first = first_entity.position
+        local second = second_entity.position
         local selection
         if origin_distance(first) < origin_distance(second) then selection = first else selection = second end
         table_insert(selected, { x = selection.x, y = selection.y })

--- a/maps/biter_battles_v2/ai_targets.lua
+++ b/maps/biter_battles_v2/ai_targets.lua
@@ -67,14 +67,14 @@ local function on_entity_destroyed(event)
     local map = global.ai_target_destroyed_map
     local unit_number = event.unit_number
     local force = map[event.registration_number]
-    map[unit_number] = nil
+    map[event.registration_number] = nil
     local targets = global.ai_targets[force]
     if targets ~= nil then
         local target_list_index = targets.available[unit_number]
         if target_list_index ~= nil then
-            -- swap the last element with the element to be removed
-            local last = targets.available_list[#targets.available_list]
             if target_list_index ~= #targets.available_list then
+                -- swap the last element with the element to be removed
+                local last = targets.available_list[#targets.available_list]
                 targets.available[last.unit_number] = target_list_index
                 targets.available_list[target_list_index] = last
             end

--- a/maps/biter_battles_v2/ai_targets.lua
+++ b/maps/biter_battles_v2/ai_targets.lua
@@ -86,7 +86,7 @@ end
 
 script.on_event(defines.events.on_entity_destroyed, on_entity_destroyed)
 
-function Public.poll(force_name)
+function Public.get_random_target(force_name)
     local targets = global.ai_targets[force_name]
     local available_list = targets.available_list
     local first_entity = simple_random_sample(available_list)

--- a/maps/biter_battles_v2/ai_targets.lua
+++ b/maps/biter_battles_v2/ai_targets.lua
@@ -86,27 +86,19 @@ end
 
 script.on_event(defines.events.on_entity_destroyed, on_entity_destroyed)
 
-function Public.select(force_name)
-    local targets = global.ai_targets[force_name]
-    local available_list = targets.available_list
-    -- (max) 7 targets per wave
-    local selected = {}
-    for i = 1, 7, 1 do
-        local first_entity = simple_random_sample(available_list)
-        local second_entity = simple_random_sample(available_list)
-        if not first_entity or not second_entity then break end
-        local first = first_entity.position
-        local second = second_entity.position
-        local selection
-        if origin_distance(first) < origin_distance(second) then selection = first else selection = second end
-        table_insert(selected, { x = selection.x, y = selection.y })
-    end
-    targets.selected = selected
-end
-
 function Public.poll(force_name)
     local targets = global.ai_targets[force_name]
-    return table_remove(targets.selected)
+    local available_list = targets.available_list
+    local first_entity = simple_random_sample(available_list)
+    local second_entity = simple_random_sample(available_list)
+    if not first_entity or not second_entity then return nil end
+    local first = first_entity.position
+    local second = second_entity.position
+    if origin_distance(first) < origin_distance(second) then
+        return first
+    else
+        return second
+    end
 end
 
 return Public

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -1,3 +1,4 @@
+local AiTargets = require 'maps.biter_battles_v2.ai_targets'
 local Functions = require "maps.biter_battles_v2.functions"
 local Gui = require "maps.biter_battles_v2.gui"
 local Init = require "maps.biter_battles_v2.init"
@@ -395,6 +396,7 @@ local function respawn_silo(event)
 	entity.minable = false
 	entity.health = 5
 	global.rocket_silo[force_name] = entity
+	AiTargets.start_tracking(entity)
 end
 
 function log_to_db(message,appendBool)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -422,7 +422,8 @@ function Public.forces()
 		game.forces[force.name].technologies["cliff-explosives"].enabled = false
 		game.forces[force.name].technologies["land-mine"].enabled = false
 		game.forces[force.name].research_queue_enabled = true
-		global.ai_targets[force.name] = { available = {}, selected = {} }
+		global.ai_targets[force.name] = { available = {}, available_list = {}, selected = {} }
+		global.ai_target_destroyed_map = {}
 		global.spy_fish_timeout[force.name] = 0
 		global.bb_evolution[force.name] = 0
 		global.reanim_chance[force.index] = 0

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -422,7 +422,7 @@ function Public.forces()
 		game.forces[force.name].technologies["cliff-explosives"].enabled = false
 		game.forces[force.name].technologies["land-mine"].enabled = false
 		game.forces[force.name].research_queue_enabled = true
-		global.ai_targets[force.name] = { available = {}, available_list = {}, selected = {} }
+		global.ai_targets[force.name] = { available = {}, available_list = {} }
 		global.ai_target_destroyed_map = {}
 		global.spy_fish_timeout[force.name] = 0
 		global.bb_evolution[force.name] = 0

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -162,7 +162,6 @@ local function on_entity_died(event)
 	local entity = event.entity
 	if not entity.valid then return end
 	if Ai.subtract_threat(entity) then Gui.refresh_threat() end
-	AiTargets.stop_tracking(entity)
 	if Functions.biters_landfill(entity) then return end
 	Game_over.silo_death(event)
 end
@@ -288,10 +287,6 @@ local function on_player_built_tile(event)
 	if event.item ~= nil and event.item.name == "landfill" then
 		Terrain.restrict_landfill(player.surface, player, event.tiles)
 	end
-end
-
-local function on_robot_mined_entity(event)
-	AiTargets.stop_tracking(event.entity)
 end
 
 local function on_chunk_generated(event)
@@ -460,7 +455,6 @@ Event.add(defines.events.on_gui_click, on_gui_click)
 Event.add(defines.events.on_marked_for_deconstruction, on_marked_for_deconstruction)
 Event.add(defines.events.on_player_built_tile, on_player_built_tile)
 Event.add(defines.events.on_player_joined_game, on_player_joined_game)
-Event.add(defines.events.on_robot_mined_entity, on_robot_mined_entity)
 Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)


### PR DESCRIPTION
Specifically, by doing a bit more work when we start/stop tracking units, we can get constant-time-indexing support for fast random building selection.

This was reported in issue #476 as something that can slow down large captains games.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
