### PR TITLE
Fix error printing to show real stacktraces

### DIFF
--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -26,6 +26,12 @@ local log = log
 local script_on_event = script.on_event
 local script_on_nth_tick = script.on_nth_tick
 
+local function errorHandler(err)
+    log("Error caught: " .. err)
+    -- Print the full stack trace
+    log(debug.traceback())
+end
+
 local call_handlers
 function call_handlers(handlers, event)
 	if not handlers then
@@ -40,11 +46,7 @@ function call_handlers(handlers, event)
 			end
 		end
 		if handler ~= nil then
-			local success, error = pcall(handler, event)
-			if not success then
-				local info = debug_getinfo(handler, 'S')
-				log({'', '[ERROR] ', error, ' in ', info.short_src, ":", info.linedefined})
-			end
+			xpcall(handler, errorHandler, event)
 		else
 			log('nil handler')
 		end


### PR DESCRIPTION
This has annoyed me so much. I am unreasonably excited about this change.

Specifically, before this change, we might see an error like the following:

```
  16.678 Script @/Users/cliff/factorio-local/Contents/temp/currently-playing/utils/event_core.lua:46: [ERROR] LuaEntity doesn't contain key x. in ...ts/temp/currently-playing/maps/biter_battles_v2/main.lua:243
```

And after this change, we instead see an error like this:
```
  11.962 Script @/Users/cliff/factorio-local/Contents/temp/currently-playing/utils/event_core.lua:30: Error caught: LuaEntity doesn't contain key x.
  11.962 Script @/Users/cliff/factorio-local/Contents/temp/currently-playing/utils/event_core.lua:32: stack traceback:
	...cal/Contents/temp/currently-playing/utils/event_core.lua:32: in function <...cal/Contents/temp/currently-playing/utils/event_core.lua:29>
	[C]: in function '__index'
	...p/currently-playing/maps/biter_battles_v2/ai_targets.lua:38: in function 'origin_distance'
	...p/currently-playing/maps/biter_battles_v2/ai_targets.lua:100: in function 'select'
	...ents/temp/currently-playing/maps/biter_battles_v2/ai.lua:254: in function '?'
	...ts/temp/currently-playing/maps/biter_battles_v2/main.lua:264: in function <...ts/temp/currently-playing/maps/biter_battles_v2/main.lua:243>
	[C]: in function 'xpcall'
	...cal/Contents/temp/currently-playing/utils/event_core.lua:49: in function 'call_handlers'
	...cal/Contents/temp/currently-playing/utils/event_core.lua:61: in function <...cal/Contents/temp/currently-playing/utils/event_core.lua:56>
```

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
