### PR TITLE
Make player always 'trusted' in singleplayer

### DIFF
--- a/utils/datastore/session_data.lua
+++ b/utils/datastore/session_data.lua
@@ -11,6 +11,13 @@ local session_data_set = 'sessions'
 local session = {}
 local online_track = {}
 local trusted = {}
+setmetatable(trusted, {__index = function()
+    -- Hacky way to ensure singleplayer is always "trusted" besides being an admin
+    -- Since players are accessed by name, return true on missing keys.
+    if not game.is_multiplayer() then return true end
+end
+})
+
 local settings = {
     -- local trusted_value = 2592000 -- 12h
     trusted_value = 5184000, -- 24h


### PR DESCRIPTION
Note this does NOT affect multiplayer even if hosted yourself. In singleplayer you will now be trusted + game admin, but hosting multiplayer you are game admin but NOT trusted due to play time.

This allows to use the profiler immediately in a new singleplayer game.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
