### PR TITLE
Change color, fix and refactor Captain mode text

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -522,8 +522,8 @@ local function generate_captain_mode(refereeName,autoTrust,captainKick,pickingMo
 	renderText("captainLineTwelve","Speedrunners", {6,-5}, {1,1,1,1}, 2, "heading-1")
 	renderText("captainLineThirteen","BB veteran players", {-6, -5}, {1,1,1,1}, 2, "heading-1")
 	renderText("captainLineFourteen","New players", {6,5}, {1,1,1,1}, 2, "heading-1")
-	renderText("captainLineFifteen","Not veteran but not new players", {-6,5}, {1,1,1,1}, 2, "heading-1")
-	renderText("captainLineSixteen","Spectators", {-12,0}, {1,1,1,1}, 2, "heading-1")
+	renderText("captainLineFifteen","Not veteran but not new players", {-8,5}, {1,1,1,1}, 2, "heading-1")
+	renderText("captainLineSixteen","Spectators", {-12,-1}, {1,1,1,1}, 2, "heading-1")
 
 	for i=-9,-16,-1 do
 		for k=2,-2,-1 do

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -584,8 +584,18 @@ local function poll_pickLateJoiners(player)
 end
 
 local function generate_vs_text_rendering()
-	if global.active_special_games and global.special_games_variables["rendering"] and global.special_games_variables["rendering"]["captainLineVersus"] then rendering.destroy(global.special_games_variables["rendering"]["captainLineVersus"]) end
-	generateRendering("captainLineVersus","team " .. global.special_games_variables["captain_mode"]["captainList"][1] .. " vs team " .. global.special_games_variables["captain_mode"]["captainList"][2] .. ". Referee: " .. global.special_games_variables["captain_mode"]["refereeName"]  .. ". Teams on VC",0,10,0.87,0.13,0.5,1,1.5,"heading-1")
+	if global.active_special_games and global.special_games_variables["rendering"] and global.special_games_variables["rendering"]["captainLineVersus"] then
+		rendering.destroy(global.special_games_variables["rendering"]["captainLineVersus"])
+	end
+
+	local cptMode = global.special_games_variables["captain_mode"]
+	local text = string.format("Team %s (North) vs (South) Team %s. Referee: %s. Teams on Voice Chat",
+		cptMode["captainList"][1],
+		cptMode["captainList"][2],
+		cptMode["refereeName"]
+	)
+
+	generateRendering("captainLineVersus", text, 0,10,0.87,  0.13,0.5,1,1, 1.5,  "heading-1")
 end
 
 local function start_captain_event()
@@ -632,7 +642,7 @@ local countdown_captain_start_token = Token.register(
     function()
 		if global.special_games_variables["captain_mode"]["countdown"] > 0 then
 			for _, player in pairs(game.connected_players) do
-				local _sprite="file/png/"..global.special_games_variables["captain_mode"]["countdown"]..".png" 
+				local _sprite="file/png/"..global.special_games_variables["captain_mode"]["countdown"]..".png"
 				if player.gui.center["bb_captain_countdown"] then player.gui.center["bb_captain_countdown"].destroy() end
 				player.gui.center.add{name = "bb_captain_countdown", type = "sprite", sprite = _sprite}
 			end	

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -304,17 +304,12 @@ local function poll_captain_late_joiners(player)
 	"captain_poll_latejoiner_question","Do you want to play?","Yes","captain_late_joiner_yes","No","captain_late_joiner_no","No and please dont ask me again for the event (you will be blacklisted from any other late joiners poll for the current captain match only)","captain_late_joiner_no_blacklist")
 end
 
-local function generateRendering(nameRendering,textChosen, xPos, yPos, rColor,gColor,bColor,aColor, scaleChosen,fontChosen)
-	global.special_games_variables["rendering"][nameRendering] = rendering.draw_text{
+local function renderText(textId, textChosen, targetPos, color, scaleChosen, fontChosen)
+	global.special_games_variables["rendering"][textId] = rendering.draw_text{
 		text = textChosen,
 		surface = game.surfaces[global.bb_surface_name],
-		target = {xPos,yPos},
-		color = {
-			r = rColor,
-			g = gColor,
-			b = bColor,
-			a = aColor
-		},
+		target = targetPos,
+		color = color,
 		scale = scaleChosen,
 		font = fontChosen,
 		alignment = "center",
@@ -324,23 +319,32 @@ end
 
 local function generateGenericRenderingCaptain()
 	local y = -14
-	generateRendering("captainLineOne","Special event rule only : ",-65,y,1,1,1,1,3,"heading-1")
+	renderText("captainLineOne", "Special event rule only : ",
+		{-65,y}, {1,1,1,1}, 3, "heading-1")
 	y = y + 2
-	generateRendering("captainLineTwo","-Use of /nth /sth /north-chat /south-chat /s /shout by spectator can be punished (warn-tempban event)",-65,y,0.87,0.13,0.5,1,3,"heading-1")
+	renderText("captainLineTwo","-Use of /nth /sth /north-chat /south-chat /s /shout by spectator can be punished (warn-tempban event)",
+		{-65,y}, {.87,0.13,0.5,1}, 3, "heading-1")
 	y = y + 4
-	generateRendering("captainLineThree","Notes : ",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineThree","Notes: ",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	generateRendering("captainLineFour","-Chat of spectator can only be seen by spectators for players",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineFour","-Chat of spectator can only be seen by spectators for players",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	generateRendering("captainLineFive","-For admins, as spectator, use ping to talk only to spectators",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineFive","-For admins, as spectator, use ping to talk only to spectators",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	generateRendering("captainLineSix","-Teams are locked, if you want to play, ask to be moved to a team",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineSix","-Teams are locked, if you want to play, ask to be moved to a team",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	generateRendering("captainLineSeven","-We are using discord bb for coms (not required), feel free to join to listen ,even if no mic",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineSeven","-We are using discord bb for comms (not required), feel free to join to listen, even if no mic",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	generateRendering("captainLineEight","-If you are not playing, you can listen to any team, but your mic must be off",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineEight","-If you are not playing, you can listen to any team, but your mic must be off",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	generateRendering("captainLineNine","-No sign up required, anyone can play the event !",-65,y,1,1,1,1,2.5,"heading-1")
+	renderText("captainLineNine","-No sign up required, anyone can play the event!",
+		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
 end
 
@@ -505,8 +509,8 @@ local function generate_captain_mode(refereeName,autoTrust,captainKick,pickingMo
 	local y = 0
 	if global.special_games_variables["rendering"] == nil then global.special_games_variables["rendering"] = {} end
 	rendering.clear()
-	generateRendering("captainLineTen","Special Captain's tournament mode enabled",0,-16,1,0,0,1,5,"heading-1")
-	generateRendering("captainLineEleven","team xx vs team yy. Referee: " .. refereeName .. ". Teams on VC",0,10,0.87,0.13,0.5,1,1.5,"heading-1")
+	renderText("captainLineTen","Special Captain's tournament mode enabled", {0,-16}, {1,0,0,1}, 5, "heading-1")
+	renderText("captainLineEleven","team xx vs team yy. Referee: " .. refereeName .. ". Teams on VC", {0,10}, {0.87,0.13,0.5,1}, 1.5,"heading-1")
 	generateGenericRenderingCaptain()
 	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {-9, -2}, to = {-9,3}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
 	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {0, 9}, to = {0,4}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
@@ -515,11 +519,11 @@ local function generate_captain_mode(refereeName,autoTrust,captainKick,pickingMo
 	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {4, 0}, to = {9,0}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
 	rendering.draw_circle{surface = game.surfaces[global.bb_surface_name], target = {0, 0}, radius = 4, filled= false,draw_on_ground = true, color = {r = 1}, width = 3} 
 
-	generateRendering("captainLineTwelve","Speedrunners",6,-5,1,1,1,1,2,"heading-1")
-	generateRendering("captainLineThirteen","BB veteran players",-6,-5,1,1,1,1,2,"heading-1")
-	generateRendering("captainLineFourteen","New players",6,5,1,1,1,1,2,"heading-1")
-	generateRendering("captainLineFifteen","Not veteran but not new players",-6,5,1,1,1,1,2,"heading-1")
-	generateRendering("captainLineSixteen","Spectators",-12,0,1,1,1,1,2,"heading-1")
+	renderText("captainLineTwelve","Speedrunners", {6,-5}, {1,1,1,1}, 2, "heading-1")
+	renderText("captainLineThirteen","BB veteran players", {-6, -5}, {1,1,1,1}, 2, "heading-1")
+	renderText("captainLineFourteen","New players", {6,5}, {1,1,1,1}, 2, "heading-1")
+	renderText("captainLineFifteen","Not veteran but not new players", {-6,5}, {1,1,1,1}, 2, "heading-1")
+	renderText("captainLineSixteen","Spectators", {-12,0}, {1,1,1,1}, 2, "heading-1")
 
 	for i=-9,-16,-1 do
 		for k=2,-2,-1 do
@@ -595,7 +599,7 @@ local function generate_vs_text_rendering()
 		cptMode["refereeName"]
 	)
 
-	generateRendering("captainLineVersus", text, 0,10,0.87,  0.13,0.5,1,1, 1.5,  "heading-1")
+	renderText("captainLineVersus", text, {0,10}, {0.87, 0.13, 0.5, 1}, 1.5, "heading-1")
 end
 
 local function start_captain_event()
@@ -626,10 +630,10 @@ local function start_captain_event()
 	if playerToClear.gui.top["captain_poll_team_ready_frame"] then playerToClear.gui.top["captain_poll_team_ready_frame"].destroy() end
 	local y = 0
 	rendering.clear()
-	generateRendering("captainLineSeventeen","Special Captain's tournament mode enabled",0,-16,1,0,0,1,5,"heading-1")
+	renderText("captainLineSeventeen","Special Captain's tournament mode enabled", {0, -16}, {1,0,0,1}, 5, "heading-1")
 	generate_vs_text_rendering()
 	generateGenericRenderingCaptain()
-	generateRendering("captainLineEighteen","Want to play ? Ask to join a team!",0,-9,1,1,1,1,3,"heading-1")
+	renderText("captainLineEighteen","Want to play? Ask to join a team!", {0, -9}, {1,1,1,1}, 3, "heading-1")
 	
 	for _, player in pairs(game.connected_players) do
 		if player.force.name == "north" or player.force.name == "south" then

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -323,7 +323,7 @@ local function generateGenericRenderingCaptain()
 		{-65,y}, {1,1,1,1}, 3, "heading-1")
 	y = y + 2
 	renderText("captainLineTwo","-Use of /nth /sth /north-chat /south-chat /s /shout by spectator can be punished (warn-tempban event)",
-		{-65,y}, {.87,0.13,0.5,1}, 3, "heading-1")
+		{-65,y}, Color.captain_versus_float, 3, "heading-1")
 	y = y + 4
 	renderText("captainLineThree","Notes: ",
 		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
@@ -510,7 +510,7 @@ local function generate_captain_mode(refereeName,autoTrust,captainKick,pickingMo
 	if global.special_games_variables["rendering"] == nil then global.special_games_variables["rendering"] = {} end
 	rendering.clear()
 	renderText("captainLineTen","Special Captain's tournament mode enabled", {0,-16}, {1,0,0,1}, 5, "heading-1")
-	renderText("captainLineEleven","team xx vs team yy. Referee: " .. refereeName .. ". Teams on VC", {0,10}, {0.87,0.13,0.5,1}, 1.5,"heading-1")
+	renderText("captainLineEleven","team xx vs team yy. Referee: " .. refereeName .. ". Teams on VC", {0,10}, Color.captain_versus_float, 1.5,"heading-1")
 	generateGenericRenderingCaptain()
 	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {-9, -2}, to = {-9,3}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
 	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {0, 9}, to = {0,4}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
@@ -599,7 +599,7 @@ local function generate_vs_text_rendering()
 		cptMode["refereeName"]
 	)
 
-	renderText("captainLineVersus", text, {0,10}, {0.87, 0.13, 0.5, 1}, 1.5, "heading-1")
+	renderText("captainLineVersus", text, {0,10}, Color.captain_versus_float, 1.5, "heading-1")
 end
 
 local function start_captain_event()

--- a/utils/color_presets.lua
+++ b/utils/color_presets.lua
@@ -153,5 +153,5 @@ return {
     warning = {r = 255, g = 255, b = 0},
     fail = {r = 255, g = 51, b = 51},
     info = {r = 255, g = 255, b = 255},
-    captain_versus_float = {r = 0.87, g = 0.5, b = 0.13, a = 1}
+    captain_versus_float = {r = 0.96, g = 0.85, b = 0.13, a = 1},
 }

--- a/utils/color_presets.lua
+++ b/utils/color_presets.lua
@@ -152,5 +152,6 @@ return {
     success = {r = 0, g = 255, b = 0},
     warning = {r = 255, g = 255, b = 0},
     fail = {r = 255, g = 51, b = 51},
-    info = {r = 255, g = 255, b = 255}
+    info = {r = 255, g = 255, b = 255},
+    captain_versus_float = {r = 0.87, g = 0.5, b = 0.13, a = 1}
 }


### PR DESCRIPTION
### Brief description of the changes:

Captain game text: better position for spawn text

Turn the captain_versus_float color brighter yellow

captain.lua: Change Versus mode text color to be readable
It has been magenta on aqua (water tiles) until now. It was not a
pleasant color combination to read even with good color sight. Changed
the vesus color to orange, it's supposed to be better for color
blindness palettes I've found.

color_presets.lua is mixed type between 0-255 and 0-1.0 for now...

captain.lua: Refactor generateText -> renderText
- changed name
- reduced number of arguments to avoid mistakes
- position arg is now a table (passed through)
- color arg is now a table (passed through)
- fixed another copy-paste instance of versus-game not having alpha
  argument

Restructure and fix Captain game text line
Fix: text size and style were NOT applied before because the function
arguments were misaligned due to missing Alpha channel argument. It will
scale differently "as intended" now.

Restructured function code

PS: Even though I had been fixing that missing argument, I fell to the SAME MISTAKE twice while rewriting arguments into tables. I hope this will not happen ever again with fewer arguments present. Apparently Factorio just ignored invalid arguments in this case.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
