### PR TITLE
Add a new research info window (disabled by default)

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -471,4 +471,13 @@ function Public.map_intro_click(player, element)
 	end	
 end
 
+function Public.format_ticks_as_time(ticks)
+	local seconds = ticks / 60
+	local hours = math.floor(seconds / 3600)
+	seconds = seconds % 3600
+	local minutes = math.floor(seconds / 60)
+	seconds = seconds % 60
+	return string.format("%d:%02d:%02d", hours, minutes, seconds)
+end
+
 return Public

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -83,8 +83,7 @@ local function clock(frame, player)
 	clock_ui.style.font_color = { r = 0.98, g = 0.66, b = 0.22 }
 
 	local is_spec = player.force.name == "spectator"
-	if global.bb_show_research_info == "always" or
-			(global.bb_show_research_info == "spec" and player.force.name == "spectator") then
+	if global.bb_show_research_info == "always" or (global.bb_show_research_info == "spec" and is_spec) then
 		ResearchInfo.create_research_info_button(inner_frame)
 	end
 	frame.add { type = "line" }

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -7,6 +7,7 @@ local bb_diff = require "maps.biter_battles_v2.difficulty_vote"
 local event = require "utils.event"
 local Functions = require "maps.biter_battles_v2.functions"
 local Feeding = require "maps.biter_battles_v2.feeding"
+local ResearchInfo = require "maps.biter_battles_v2.research_info"
 local Tables = require "maps.biter_battles_v2.tables"
 local Captain_event = require "comfy_panel.special_games.captain"
 
@@ -66,7 +67,7 @@ local function create_sprite_button(player)
 	gui_style(button, { width = 38, height = 38, padding = -2, font = "default-bold" })
 end
 
-local function clock(frame)
+local function clock(frame, player)
 	local time_caption = "Not started"
 	local total_ticks = Functions.get_ticks_since_game_start()
 	if total_ticks > 0 then
@@ -76,9 +77,16 @@ local function clock(frame)
 		time_caption = string.format("Time: %02d:%02d", total_hours, minutes)
 	end
 
-	local clock_ui = frame.add { type = "label", caption = string.format("%s   Speed: %.2f", time_caption, game.speed) }
+	local inner_frame = frame.add { type = "flow", name = "bb_main_inner_gui", direction = "horizontal" }
+	local clock_ui = inner_frame.add { type = "label", caption = string.format("%s   Speed: %.2f", time_caption, game.speed) }
 	clock_ui.style.font = "default-bold"
 	clock_ui.style.font_color = { r = 0.98, g = 0.66, b = 0.22 }
+
+	local is_spec = player.force.name == "spectator"
+	if global.bb_show_research_info == "always" or
+			(global.bb_show_research_info == "spec" and player.force.name == "spectator") then
+		ResearchInfo.create_research_info_button(inner_frame)
+	end
 	frame.add { type = "line" }
 end
 
@@ -92,7 +100,7 @@ local function create_first_join_gui(player)
 	local b = frame.add { type = "label", caption = "Feed the enemy team's biters to gain advantage!" }
 	b.style.font = "heading-2"
 	b.style.font_color = { r = 0.98, g = 0.66, b = 0.22 }
-	clock(frame)
+	clock(frame, player)
 	local d = frame.add { type = "sprite-button", name = "join_random_button", caption = "AUTO JOIN" }
 	d.style.font = "default-large-bold"
 	d.style.font_color = { r = 1, g = 0, b = 1 }
@@ -183,7 +191,7 @@ function Public.create_main_gui(player)
 
 	local frame = player.gui.left.add { type = "frame", name = "bb_main_gui", direction = "vertical" }
 
-	clock(frame)
+	clock(frame, player)
 	-- Science sending GUI
 	if not is_spec then
 		frame.add { type = "table", name = "biter_battle_table", column_count = 4 }

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -119,6 +119,7 @@ function Public.initial_setup()
 	global.game_lobby_active = true
 	global.bb_debug = false
 	global.bb_draw_revive_count_text = false
+	global.bb_show_research_info = nil -- "always", "spec", nil
 	global.ignore_lists = {}
 	global.bb_settings = {
 		--TEAM SETTINGS--
@@ -208,6 +209,7 @@ end
 function Public.tables()
 	local get_score = Score.get_table()
 	get_score.score_table = {}
+	global.research_info = {completed = {}, progress = { north = {}, south = {} }}
 	global.science_logs_text = nil
 	global.science_logs_total_north = nil
 	global.science_logs_total_south = nil

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -209,7 +209,7 @@ end
 function Public.tables()
 	local get_score = Score.get_table()
 	get_score.score_table = {}
-	global.research_info = {completed = {}, progress = { north = {}, south = {} }}
+	global.research_info = {completed = {}, current_progress = { north = {}, south = {} }}
 	global.science_logs_text = nil
 	global.science_logs_total_north = nil
 	global.science_logs_total_south = nil

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -16,6 +16,7 @@ local Terrain = require "maps.biter_battles_v2.terrain"
 local Session = require 'utils.datastore.session_data'
 local Server = require 'utils.server'
 local Color = require 'utils.color_presets'
+local ResearchInfo = require 'maps.biter_battles_v2.research_info'
 local autoTagWestOutpost = "[West]"
 local autoTagEastOutpost = "[East]"
 local autoTagDistance = 600
@@ -35,6 +36,7 @@ local function on_player_joined_game(event)
 	end
 	Gui.clear_copy_history(player)
 	Functions.create_map_intro_button(player)
+	--ResearchInfo.create_research_info_button(player)
 	Team_manager.draw_top_toggle_button(player)
 end
 
@@ -45,6 +47,7 @@ local function on_gui_click(event)
 	if not element.valid then return end
 
 	if Functions.map_intro_click(player, element) then return end
+	if ResearchInfo.research_info_click(player, element) then return end
 	Team_manager.gui_click(event)
 end
 
@@ -61,7 +64,13 @@ local function on_research_finished(event)
 	elseif name == 'rocket-silo' then
 		force.technologies['space-science-pack'].researched = true
 	end
-	game.forces.spectator.print(Functions.team_name_with_color(force.name) .. " completed research [technology=" .. event.research.name .. "]")
+	game.forces.spectator.print(Functions.team_name_with_color(force.name) .. " completed research [technology=" .. name .. "]")
+	ResearchInfo.research_finished(name, force)
+end
+
+local function on_research_reversed(event)
+	-- Note that this will not really work for Functions.combat_balance, so don't go reversing technologies.
+	ResearchInfo.research_reversed(name, force)
 end
 
 local function on_console_chat(event)
@@ -456,6 +465,8 @@ Event.add(defines.events.on_marked_for_deconstruction, on_marked_for_deconstruct
 Event.add(defines.events.on_player_built_tile, on_player_built_tile)
 Event.add(defines.events.on_player_joined_game, on_player_joined_game)
 Event.add(defines.events.on_research_finished, on_research_finished)
+Event.add(defines.events.on_research_reversed, on_research_reversed)
+Event.add(defines.events.on_research_cancelled, on_research_cancelled)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)
 Event.add(defines.events.on_tick, on_tick)

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -53,7 +53,7 @@ end
 
 local function on_research_finished(event)
 	Functions.combat_balance(event)
-	
+
 	local name = event.research.name
 	local force = event.research.force
 	if name == 'uranium-processing' then
@@ -68,8 +68,16 @@ local function on_research_finished(event)
 	ResearchInfo.research_finished(name, force)
 end
 
+local function on_research_started(event)
+	local name = event.research.name
+	local force = event.research.force
+	ResearchInfo.research_started(name, force)
+end
+
 local function on_research_reversed(event)
 	-- Note that this will not really work for Functions.combat_balance, so don't go reversing technologies.
+	local name = event.research.name
+	local force = event.research.force
 	ResearchInfo.research_reversed(name, force)
 end
 
@@ -465,8 +473,8 @@ Event.add(defines.events.on_marked_for_deconstruction, on_marked_for_deconstruct
 Event.add(defines.events.on_player_built_tile, on_player_built_tile)
 Event.add(defines.events.on_player_joined_game, on_player_joined_game)
 Event.add(defines.events.on_research_finished, on_research_finished)
+Event.add(defines.events.on_research_started, on_research_started)
 Event.add(defines.events.on_research_reversed, on_research_reversed)
-Event.add(defines.events.on_research_cancelled, on_research_cancelled)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)
 Event.add(defines.events.on_tick, on_tick)

--- a/maps/biter_battles_v2/research_info.lua
+++ b/maps/biter_battles_v2/research_info.lua
@@ -1,0 +1,184 @@
+local gui_style = require 'utils.utils'.gui_style
+local Functions = require 'maps.biter_battles_v2.functions'
+local Event = require 'utils.event'
+
+local Public = {}
+
+function Public.create_research_info_button(element, player)
+    local b = element.add({type = "sprite-button", sprite = "item/space-science-pack", name = "research_info_button", tooltip = "Science Info"})
+    gui_style(b, {width = 18, height = 18, padding = -2})
+end
+
+---@param force string
+---@param tech_name string
+function Public.research_finished(tech_name, force)
+    local force_name = force.name
+    if force_name ~= "north" and force_name ~= "south" then return end
+    local tech_info = global.research_info.completed[tech_name]
+    if not tech_info then
+        tech_info = {}
+        global.research_info.completed[tech_name] = tech_info
+    end
+    tech_info[force_name] = Functions.get_ticks_since_game_start()
+    global.research_info.progress[force_name][tech_name] = nil
+end
+
+local function update_research_progress()
+    for _, force in ipairs({game.forces.north, game.forces.south}) do
+        local tech = force.current_research
+        local progress = force.research_progress
+        if tech and progress and progress > 0 then
+            local progress_info = global.research_info.progress[force.name]
+            progress_info[tech.name] = progress
+        end
+    end
+end
+
+---@param force LuaForce
+---@param tech_name string
+function Public.research_reversed(tech_name, force)
+    if force.name ~= "north" and force.name ~= "south" then return end
+    local tech_info = global.research_info.completed[tech_name]
+    if not tech_info then return end
+    tech_info[force.name] = nil
+end
+
+---@param element LuaGuiElement
+---@param filter_fn function
+local function add_completed_research_icons(element, all_technologies, filter_fn)
+    local icons_to_add = {}
+    for tech_name, tech_info in pairs(global.research_info.completed) do
+        if filter_fn(tech_name, tech_info) then
+            local tooltip = {"", all_technologies[tech_name].localised_name}
+            local time = math.huge
+            if tech_info.north then
+                table.insert(tooltip, "\nNorth: " .. Functions.format_ticks_as_time(tech_info.north))
+                time = math.min(time, tech_info.north)
+            end
+            if tech_info.south then
+                table.insert(tooltip, "\nSouth: " .. Functions.format_ticks_as_time(tech_info.south))
+                time = math.min(time, tech_info.south)
+            end
+            local icon = {type = "sprite", sprite = "technology/" .. tech_name, tooltip = tooltip}
+            table.insert(icons_to_add, {time = time, icon = icon})
+        end
+    end
+    table.sort(icons_to_add, function(a, b) return a.time < b.time end)
+    for _, icon in ipairs(icons_to_add) do
+        local tech = element.add(icon.icon)
+        gui_style(tech, {width = 38, height = 38, padding = -2, stretch_image_to_widget_size = true})
+    end
+end
+
+---@param element LuaGuiElement
+---@param force LuaForce
+local function add_research_queue_icons(element, force, all_technologies)
+    local queue = force.research_queue
+    if not queue or #queue == 0 then return end
+    local icons_to_add = {}
+    for _, tech in ipairs(queue) do
+        local tooltip = tech.localised_name
+        local time = math.huge
+        local icon = {type = "sprite", sprite = "technology/" .. tech.name, tooltip = tooltip}
+        table.insert(icons_to_add, {time = time, icon = icon})
+    end
+    local t = element.add {type = "table", column_count = #icons_to_add + 1}
+    t.add {type = "label", caption = "Queue: "}
+    for _, icon in ipairs(icons_to_add) do
+        local tech = t.add(icon.icon)
+        gui_style(tech, {width = 38, height = 38, padding = -2, stretch_image_to_widget_size = true})
+    end
+end
+
+---@param element LuaGuiElement
+---@param force LuaForce
+local function add_research_progress_icons(element, force, all_technologies)
+    local progress_info = global.research_info.progress[force.name]
+    local icons_to_add = {}
+    -- For testing:
+    -- progress_info["automation"] = 0.4
+    for tech_name, progress in pairs(progress_info) do
+        local tooltip = all_technologies[tech_name].localised_name
+        local icon = {type = "sprite", sprite = "technology/" .. tech_name, tooltip = tooltip}
+        table.insert(icons_to_add, {icon = icon, progress = progress})
+    end
+    -- Just alphabetical sort by technology name so that the order is stable
+    table.sort(icons_to_add, function(a, b) return a.icon.sprite < b.icon.sprite end)
+    for _, icon in ipairs(icons_to_add) do
+        local horizontal_flow = element.add {type = "flow", direction = "horizontal"}
+        gui_style(horizontal_flow, {vertical_align = "center"})
+        local tech = horizontal_flow.add(icon.icon)
+        gui_style(tech, {width = 38, height = 38, padding = -2, stretch_image_to_widget_size = true})
+        horizontal_flow.add {type = "label", caption = string.format("%.0f%% complete", icon.progress * 100)}
+    end
+end
+
+function Public.show_research_info(player)
+    local all_technologies = game.forces.spectator.technologies
+    if player.gui.center["research_info_frame"] then
+        player.gui.center["research_info_frame"].destroy()
+        return
+    end
+    local frame = player.gui.center.add {type = "frame", name = "research_info_frame", direction = "vertical"}
+    gui_style(frame, {padding = 8})
+    local scrollpanel = frame.add { type = "scroll-pane", name = "scroll_pane", direction = "vertical", horizontal_scroll_policy = "never", vertical_scroll_policy = "auto"}
+    local label
+    local horizontal_flow = scrollpanel.add {type = "flow", direction = "horizontal"}
+    label = horizontal_flow.add {type = "label", caption = "Research Summary for both teams"}
+    gui_style(label, {font = "heading-1"})
+    local button = horizontal_flow.add({
+        type = "button",
+        name = "research_info_close",  -- clicking on any element works to close
+        caption = "Close",
+        tooltip = "Close this window."
+    })
+    button.style.font = "heading-3"
+    label = scrollpanel.add {type = "label", caption = "North Current"}
+    gui_style(label, {font = "heading-2"})
+    add_research_queue_icons(scrollpanel, game.forces.north, all_technologies)
+    add_research_progress_icons(scrollpanel, game.forces.north, all_technologies)
+    label = scrollpanel.add {type = "label", caption = "South Current"}
+    gui_style(label, {font = "heading-2"})
+    add_research_queue_icons(scrollpanel, game.forces.south, all_technologies)
+    add_research_progress_icons(scrollpanel, game.forces.south, all_technologies)
+
+    label = scrollpanel.add {type = "label", caption = "Completed - just North"}
+    gui_style(label, {font = "heading-2"})
+    add_completed_research_icons(scrollpanel.add {type = "table", column_count = 15},
+    all_technologies,
+    function(tech_name, tech_info) return tech_info.north and not tech_info.south end)
+    label = scrollpanel.add {type = "label", caption = "Completed - just South"}
+    gui_style(label, {font = "heading-2"})
+    add_completed_research_icons(scrollpanel.add {type = "table", column_count = 15},
+    all_technologies,
+    function(tech_name, tech_info) return not tech_info.north and tech_info.south end)
+    label = scrollpanel.add {type = "label", caption = "Completed - Both"}
+    gui_style(label, {font = "heading-2"})
+    add_completed_research_icons(scrollpanel.add {type = "table", column_count = 15},
+    all_technologies,
+    function(tech_name, tech_info) return tech_info.north and tech_info.south end)
+end
+
+function Public.research_info_click(player, element)
+    local elt = element
+    while elt do
+        if elt.name == "research_info_frame" then
+            player.gui.center["research_info_frame"].destroy()
+            return true
+        end
+        elt = elt.parent
+    end
+    if element.name == "research_info_button" then
+        if player.gui.center["research_info_frame"] then
+            player.gui.center["research_info_frame"].destroy()
+            return true
+        else
+            Public.show_research_info(player)
+            return true
+        end
+    end
+end
+
+Event.on_nth_tick(61, update_research_progress)
+
+return Public

--- a/maps/biter_battles_v2/research_info.lua
+++ b/maps/biter_battles_v2/research_info.lua
@@ -20,7 +20,7 @@ function Public.research_finished(tech_name, force)
         global.research_info.completed[tech_name] = tech_info
     end
     tech_info[force_name] = Functions.get_ticks_since_game_start()
-    global.research_info.progress[force_name][tech_name] = nil
+    global.research_info.current_progress[force_name][tech_name] = nil
 end
 
 local function update_research_progress()
@@ -28,7 +28,7 @@ local function update_research_progress()
         local tech = force.current_research
         local progress = force.research_progress
         if tech and progress and progress > 0 then
-            local progress_info = global.research_info.progress[force.name]
+            local progress_info = global.research_info.current_progress[force.name]
             progress_info[tech.name] = progress
         end
     end
@@ -93,7 +93,7 @@ end
 ---@param element LuaGuiElement
 ---@param force LuaForce
 local function add_research_progress_icons(element, force, all_technologies)
-    local progress_info = global.research_info.progress[force.name]
+    local progress_info = global.research_info.current_progress[force.name]
     local icons_to_add = {}
     -- For testing:
     -- progress_info["automation"] = 0.4


### PR DESCRIPTION
This is meant to replace the white-flask that allows spectators to view research progress during captains games. Specifically, the current implementation bothers me because it actually moves players between forces, which I believe introduces many possible races/confusion/bugs. I also hope that this implementation might be more useful, as it shows a comparison of both teams at the same time.

I believe that bugs with the existing implementation led to the decision to only enable the white-flask during captain's games. I hope that this new implementation can be enabled in all games.

For now, it is disabled by default, but can be enabled by setting
  `global.bb_show_research_info = "always"`
or
  `global.bb_show_research_info = "spec"`
to enable it, and setting
  `global.bb_show_research_info = nil`
to disable it

I find UI code frustrating to write, because I am accutely aware of millions of ways in which the final UI is not perfect, but it takes a long time and many iterations to make changes, and at some ponit I have to decide "good enough for now".

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
