### PR TITLE
Created new alternate threatfarming special, fixed killscore for biters with non-standard threat

### DIFF
--- a/comfy_panel/score.lua
+++ b/comfy_panel/score.lua
@@ -378,8 +378,9 @@ local function on_entity_died(event)
     if event.entity.force.index == event.cause.force.index then
         return
     end
-    local threat_reduction = Ai.calc_threat_reduction(event.entity)
-    if threat_reduction == 0 then
+    --multiply threat reduction by four to keep killscore similar to the previous killscore values
+    local killscore_value = Ai.calc_threat_reduction(event.entity) * 4
+    if killscore_value == 0 then
         return
     end
     if not kill_causes[event.cause.type] then
@@ -395,13 +396,13 @@ local function on_entity_died(event)
     for _, player in pairs(players_to_reward) do
         Public.init_player_table(player)
         local score = this.score_table[player.force.name].players[player.name]
-        score.killscore = score.killscore + threat_reduction
+        score.killscore = score.killscore + killscore_value
         if global.show_floating_killscore[player.name] then
             event.entity.surface.create_entity(
                 {
                     name = 'flying-text',
                     position = event.entity.position,
-                    text = tostring(threat_reduction),
+                    text = tostring(killscore_value),
                     color = player.chat_color
                 }
             )

--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -17,6 +17,7 @@ local valid_special_games = {
     disable_sciences = require 'comfy_panel.special_games.disable_sciences',
     send_to_external_server = require 'comfy_panel.special_games.send_to_external_server',
     captain = require 'comfy_panel.special_games.captain',
+    alt_threatfarming = require 'comfy_panel.special_games.alt_threatfarming'
     --[[
     Add your special game here.
     Syntax:

--- a/comfy_panel/special_games/alt_threatfarming.lua
+++ b/comfy_panel/special_games/alt_threatfarming.lua
@@ -1,0 +1,59 @@
+local Color = require 'utils.color_presets'
+
+local function generate_alt_threatfarming(defender_mult, spawner_mult)
+    --Setup gamemode.
+    global.active_special_games["alt_threatfarming"] = true
+    if not global.special_games_variables["alt_threatfarming"] then
+        global.special_games_variables["alt_threatfarming"] = {}
+    end
+    global.special_games_variables["alt_threatfarming"]["defender_mult"] = defender_mult
+    global.special_games_variables["alt_threatfarming"]["spawner_mult"] = spawner_mult
+    global.special_games_variables["alt_threatfarming"]["spawner_biter_ids"] = {}
+    global.special_games_variables["alt_threatfarming"]["attack_biter_ids"] = {}
+    --We only want to apply this logic to biters - threat for worms and spawners should not be affected.
+    global.special_games_variables["alt_threatfarming"]["affected_entities"] = {
+        ["small-spitter"] = true,
+        ["small-biter"] = true,
+        ["medium-spitter"] = true,
+        ["medium-biter"] = true,
+        ["big-spitter"] = true,
+        ["big-biter"] = true,
+        ["behemoth-spitter"] = true,
+        ["behemoth-biter"] = true
+    }
+    local special_game_description = "Biters defending spawners are worth " .. tostring(defender_mult) .. "x threat. Biters inside spawners are worth " .. tostring(spawner_mult) .. "x threat!"
+    --Create floating text.
+    if global.special_games_variables["alt_threatfarming"]["text_id"] then
+        rendering.destroy(global.special_games_variables["alt_threatfarming"]["text_id"])
+    end
+    global.special_games_variables["alt_threatfarming"]["text_id"] = rendering.draw_text{
+        text = special_game_description,
+        surface = game.surfaces[global.bb_surface_name],
+        target = {-0,12},
+        color = Color.warning,
+        scale = 3,
+        alignment = "center",
+        scale_with_zoom = false
+    }
+    --Send message.
+    game.print("[SPECIAL GAMES] Alternate threatfarming enabled)", Color.warning)
+    game.print("[SPECIAL GAMES] " .. special_game_description, Color.warning)
+end
+
+local Public = {
+    name = {type = "label", caption = "Alternate Threatfarming", tooltip = "Biters defending spawners are worth less threat, biters inside spawners are worth more."},
+    config = {
+        [1] = {name = "label1", type = "label", caption = "Multiplier for defender biters:"},
+        [2] = {name = "defender_mult", type = "textfield", text = "0.5", numeric = true, width = 40},
+        [3] = {name = "label2", type = "label", caption = "Multiplier for spawner biters:"},
+        [4] = {name = "spawner_mult", type = "textfield", text = "5", numeric = true, width = 40},
+    },
+    button = {name = "apply", type = "button", caption = "Apply"},
+    generate = function (config, player)
+        local defender_mult = tonumber(config["defender_mult"].text)
+        local spawner_mult = tonumber(config["spawner_mult"].text)
+        generate_alt_threatfarming(defender_mult, spawner_mult)
+    end
+}
+
+return Public

--- a/modules/spawners_contain_biters.lua
+++ b/modules/spawners_contain_biters.lua
@@ -24,7 +24,12 @@ local function on_entity_died(event)
 	for _, t in pairs(biter_building_inhabitants[e]) do		
 		for x = 1, math_random(t[2],t[3]), 1 do
 			local p = event.entity.surface.find_non_colliding_position(t[1] , event.entity.position, 6, 1)			
-			if p then event.entity.surface.create_entity {name=t[1], position=p, force = event.entity.force.name} end
+			if p then
+				local unit = event.entity.surface.create_entity {name=t[1], position=p, force = event.entity.force.name}
+				if global.active_special_games["alt_threatfarming"] then
+					global.special_games_variables["alt_threatfarming"]["spawner_biter_ids"][unit.unit_number] = true
+				end
+			end
 		end
 	end	
 end


### PR DESCRIPTION
### Brief description of the changes:
I've created a new special to test a change to threatfarming that should encourage destroying nests instead of just killing biters.

In this special, biters that spawn naturally around spawners are worth 0.5x as much threat, and biters that spawn when spawners are killed are worth 5x as much threat. Spawners, worms, and biters that spawn as part of attack groups are worth the same amount of threat. These values can be configured when starting the special.

In a change that I probably should have put in a separate pull request, I've changed the killscore calculation to use the same function as the threat reduction calculations. This corrects an issue where biters that do not reduce threat by the normal amount (boss biters, normal biters under the old threat logic, defender and spawner biters in my new special) award the wrong amount of killscore.

### Tested Changes:
- [x] I've tested the changes locally.
