### PR TITLE
Implement flamethrower turret overlap protection in code

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -120,6 +120,7 @@ function Public.initial_setup()
 	global.bb_debug = false
 	global.bb_draw_revive_count_text = false
 	global.bb_show_research_info = nil -- "always", "spec", nil
+	global.bb_prevent_overlapping_flamers = true
 	global.ignore_lists = {}
 	global.bb_settings = {
 		--TEAM SETTINGS--


### PR DESCRIPTION
It has always slightly bothered me that the rules for what count as overlapping flamethrower turrets are not super clear/explicit, and are very annoying to enforce on new players that don't know the rules.

If there is already one flamethrower turret placed, this prevents another flamethrower turret being placed that is facing the same direction within a 48x2 box centered on the already placed turret. Thus rows of flamethrower turrets must be at least 24 tiles apart (front-to-front).  This distance was chosen because flamethrower turrets have a min range of 6 and a max range of 30.

I added a global variable that can be used to disable this behavior (mostly just in case it causes a strange performance issue or otherwise unexpected bug).

To disable this functionality, run
  /c global.bb_prevent_overlapping_flamers = nil

When testing, this is a useful command
  /c game.player.insert{name="flamethrower-turret", count=100}

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
