### PR TITLE
Document Event/EventCore modules

### DIFF
--- a/utils/event.lua
+++ b/utils/event.lua
@@ -8,7 +8,7 @@
 -- control stage add the handler in both on_init and on_load.
 -- Handlers added with Event.add cannot be removed.
 -- For handlers that need to be removed or added at runtime use Event.add_removable.
--- @usage
+---@usage
 -- local Event = require 'utils.event'
 -- Event.add(
 --     defines.events.on_built_entity,
@@ -27,7 +27,7 @@
 -- Event.add_removable cannot be called in on_load, doing so will crash the game on loading.
 -- Token is used because it's a desync risk to store closures inside the global table.
 --
--- @usage
+---@usage
 -- local Token = require 'utils.token'
 -- local Event = require 'utils.event'
 --
@@ -55,7 +55,7 @@
 -- func cannot be a closure in this case, as there is no safe way to store closures in the global table.
 -- A closure is a function that uses a local variable not defined in the function.
 --
--- @usage
+---@usage
 -- local Event = require 'utils.event'
 --
 -- If you want to remove the handler you will need to keep a reference to it.
@@ -140,7 +140,7 @@ Global.register(
 
 ---Finds the handler by value in tbl and removes it, shifting all values down
 ---@param tbl table
----@param handler<any> # must be a unique value inside table, typically a function
+---@param handler any  # must be a unique value inside table, typically a function
 local function remove(tbl, handler)
     if tbl == nil then
         return
@@ -158,8 +158,8 @@ end
 --- Register a handler for the event_name event.
 -- This function must be called in the control stage or in Event.on_init or Event.on_load.
 -- See documentation at top of file for details on using events.
--- @param event_name<number>
--- @param handler<function>
+---@param event_name number 
+---@param handler fun(event: EventData): nil
 ---@see Event.on_init
 ---@see Event.on_load
 ---@see Event.on_nth_tick
@@ -174,7 +174,7 @@ end
 --- Register a handler for the script.on_init event.
 -- This function must be called in the control stage or in Event.on_init or Event.on_load
 -- See documentation at top of file for details on using events.
--- @param handler<function>
+---@param handler fun(): nil
 function Event.on_init(handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.on_init after on_init() or on_load() has run is a desync risk.', 2)
@@ -186,7 +186,7 @@ end
 --- Register a handler for the script.on_load event.
 -- This function must be called in the control stage or in Event.on_init or Event.on_load
 -- See documentation at top of file for details on using events.
--- @param handler<function>
+---@param handler fun(): nil
 function Event.on_load(handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.on_load after on_init() or on_load() has run is a desync risk.', 2)
@@ -198,8 +198,8 @@ end
 --- Register a handler for the nth_tick event.
 -- This function must be called in the control stage or in Event.on_init or Event.on_load.
 -- See documentation at top of file for details on using events.
--- @param tick<number> The handler will be called every nth tick
--- @param handler<function>
+---@param tick uint # The handler will be called every nth tick
+---@param handler fun(event: NthTickEventData): nil
 function Event.on_nth_tick(tick, handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.on_nth_tick after on_init() or on_load() has run is a desync risk.', 2)
@@ -211,8 +211,8 @@ end
 --- Register a token handler that can be safely added and removed at runtime.
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  token<number>
+---@param event_name string | defines.events
+---@param token number # Registered token via Token lib
 function Event.add_removable(event_name, token)
     if type(token) ~= 'number' then
         error('token must be a number', 2)
@@ -237,8 +237,8 @@ end
 --- Removes a token handler for the given event_name.
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  token<number>
+---@param event_name string | defines.events
+---@param token number # Registered token via Token lib
 function Event.remove_removable(event_name, token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -264,9 +264,9 @@ end
 -- The handler must not be a closure, as that is a desync risk (the caller must ensure the func's state is synchronized across save/load).
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  func<function>
--- @param  name<string>
+---@param event_name string | defines.events
+---@param func fun(event: EventData): nil
+---@param name string | any # table key
 function Event.add_removable_function(event_name, func, name)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -306,8 +306,8 @@ end
 --- Removes a handler for the given event_name.
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  name<string>
+---@param event_name string | defines.events
+---@param name string | any # table key
 function Event.remove_removable_function(event_name, name)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -346,8 +346,8 @@ end
 --- Register a token handler for the nth tick that can be safely added and removed at runtime.
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  token<number>
+---@param tick uint
+---@param token number # Registered token via Token lib
 function Event.add_removable_nth_tick(tick, token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -372,8 +372,8 @@ end
 --- Removes a token handler for the nth tick.
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  token<number>
+---@param tick uint
+---@param token number # Registered token via Token lib
 function Event.remove_removable_nth_tick(tick, token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -399,8 +399,11 @@ end
 -- The handler must not be a closure, as that is a desync risk (the caller must ensure the func's state is synchronized across save/load).
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  func<function>
+---
+---Bug: I assume this doesn't event work (pun was a typo), the table structure of funcs doesn't match what's accessed in EventCore
+---@param tick uint
+---@param func fun(event: NthTickEventData): nil # Nth tick handler
+---@param name string | any # Table key
 function Event.add_removable_nth_tick_function(tick, func, name)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -440,8 +443,8 @@ end
 --- Removes a handler for the nth tick.
 -- Calling this during on_load stage is not allowed.
 -- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  func<function>
+---@param tick uint
+---@param name string # table key
 function Event.remove_removable_nth_tick_function(tick, name)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -486,7 +489,7 @@ function Event.remove_removable_nth_tick_function(tick, name)
 end
 
 --- Generate a new, unique event ID.
--- @param <string> name of the event/variable that is exposed
+---@param name string of the event/variable that is exposed
 function Event.generate_event_name(name)
     local event_id = generate_event_name()
 
@@ -494,7 +497,9 @@ function Event.generate_event_name(name)
 end
 
 ---Simply a proxy for game's `script.on_configuration_changed`, therefore only one function can be registered.
----@bug Does not allow to unset the function, use a dummy func if you need.
+---
+---Bug: Does not allow to unset the function, use a dummy func if you need.
+---@param func fun(changed: ConfigurationChangedData): nil
 function Event.on_configuration_changed(func)
     if type(func) == 'function' then
         script.on_configuration_changed(func)
@@ -504,7 +509,7 @@ end
 ---Adds the filter to currently active filters hooked to the game event.
 ---This probably shouldn't be used, because there's no way to remove a filter through this API and it's unclear how Factorio handles multiple filters, probably it's an AND filter chain, i.e. ALL filters must pass for the event to trigger.
 ---@param event uint Target event ID
----@param filter EventFiler
+---@param filter EventFilter
 function Event.add_event_filter(event, filter)
     local current_filters = script.get_event_filter(event)
 

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -38,6 +38,7 @@ local call_handlers
 ---Safely executes all functions handling current event.
 ---@param handlers ( fun(event: EventData): nil )[]
 ---@param event EventData # The respective event data type
+---@return nil
 function call_handlers(handlers, event)
 	if not handlers then
 		return log('Handlers was nil!')

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -1,7 +1,7 @@
 -- This module exists to break the circular dependency between event.lua and global.lua.
 -- It is not expected that any user code would require this module instead event.lua should be required.
 
-local Public = {}
+local EventCore = {}
 
 local init_event_name = -1
 local load_event_name = -2
@@ -110,7 +110,7 @@ end
 ---If it is the first handler, register the orchestrator handler with the game
 ---@param event_name string # event.name or event.input_name (technically any key)
 ---@param handler fun(event: EventData): nil # Respective event data type
-function Public.add(event_name, handler)
+function EventCore.add(event_name, handler)
     if event_name == defines.events.on_entity_damaged then
         error("on_entity_damaged is managed outside of the event framework.")
     end
@@ -130,7 +130,7 @@ end
 ---Registers/inserts the handler function to work with on_init event.
 ---If it is the first handler, register the orchestrator handler with the game
 ---@param handler fun(): nil
-function Public.on_init(handler)
+function EventCore.on_init(handler)
     local handlers = event_handlers[init_event_name]
     if not handlers then
         event_handlers[init_event_name] = {handler}
@@ -147,7 +147,7 @@ end
 ---Registers/inserts the handler function to work with on_load event.
 ---If it is the first handler, register the orchestrator handler with the game
 ---@param handler fun(): nil
-function Public.on_load(handler)
+function EventCore.on_load(handler)
     local handlers = event_handlers[load_event_name]
     if not handlers then
         event_handlers[load_event_name] = {handler}
@@ -166,7 +166,7 @@ end
 ---@see NthTickEventData
 ---@param tick uint
 ---@param handler fun(event: NthTickEventData): nil
-function Public.on_nth_tick(tick, handler)
+function EventCore.on_nth_tick(tick, handler)
     local handlers = on_nth_tick_event_handlers[tick]
     if not handlers then
         on_nth_tick_event_handlers[tick] = {handler}
@@ -181,14 +181,14 @@ end
 
 ---Returns the table with event_handlers
 ---@return table<event_name, function[]> # each event_name stores an array of handlers
-function Public.get_event_handlers()
+function EventCore.get_event_handlers()
     return event_handlers
 end
 
 ---Returns the table with only Nth tick handlers
 ---@return table<uint, function[]> # each Nth tick stores an array of handlers
-function Public.get_on_nth_tick_event_handlers()
+function EventCore.get_on_nth_tick_event_handlers()
     return on_nth_tick_event_handlers
 end
 
-return Public
+return EventCore

--- a/utils/global.lua
+++ b/utils/global.lua
@@ -1,4 +1,4 @@
-local Event = require 'utils.event_core'
+local EventCore = require 'utils.event_core'
 local Token = require 'utils.token'
 
 local Global = {}
@@ -21,7 +21,7 @@ function Global.register(tbl, callback)
 
     names[token] = concat {token, ' - ', filepath}
 
-    Event.on_load(
+    EventCore.on_load(
         function()
             callback(Token.get_global(token))
         end
@@ -46,14 +46,14 @@ function Global.register_init(tbl, init_handler, callback)
 
     names[token] = concat {token, ' - ', filepath}
 
-    Event.on_init(
+    EventCore.on_init(
         function()
             init_handler(tbl)
             callback(tbl)
         end
     )
 
-    Event.on_load(
+    EventCore.on_load(
         function()
             callback(Token.get_global(token))
         end

--- a/utils/global.lua
+++ b/utils/global.lua
@@ -7,6 +7,10 @@ local concat = table.concat
 local names = {}
 Global.names = names
 
+---Registers a function persistently for the `on_load` event (loading from a saved game).
+---@see EventData.on_load
+---@param tbl table Data-only table that will be persistently stored in `global` using given token.
+---@param callback fun(registered_as_token: number)
 function Global.register(tbl, callback)
     if _LIFECYCLE ~= _STAGE.control then
         error('can only be called during the control stage', 2)
@@ -26,6 +30,13 @@ function Global.register(tbl, callback)
     return token
 end
 
+---Registers a function persistently for the `on_load` event (loading from a saved game) and `on_init` (when started for the first time).
+---Otherwise identical to Global.register
+---@see EventData.on_load
+---@see EventData.on_init
+---@param tbl table Data-only table that will be persistently stored in `global` using given token.
+---@param init_handler fun(tbl: table)
+---@param callback fun(registered_as_token: number) | fun(tbl: table) # in on_init, both functions will receive the passed tbl table
 function Global.register_init(tbl, init_handler, callback)
     if _LIFECYCLE ~= _STAGE.control then
         error('can only be called during the control stage', 2)

--- a/utils/token.lua
+++ b/utils/token.lua
@@ -4,10 +4,14 @@ local tokens = {}
 
 local counter = 0
 
---- Assigns a unquie id for the given var.
+--- Assigns a unique id for the given var and LOCALLY stores the var.
 -- This function cannot be called after on_init() or on_load() has run as that is a desync risk.
 -- Typically this is used to register functions, so the id can be stored in the global table
 -- instead of the function. This is becasue closures cannot be safely stored in the global table.
+-- NOTE:
+-- This function is mostly useless, because you can only store effectively immutable data that's loaded from code when the map/scenario is loaded for the first time.
+-- In most cases you can drop its usage and refer to the "var" directly in code.
+-- The only useful scenario: you need a unique serializable key to be stored in Factorio's persistent "global" - then this approach gives you a unique key that will be valid for the entire playthrough of the current map... until your code updates for the current game save and causes a SHIFT in values due to changing the order in which this function was called.
 -- @param  var<any>
 -- @return number the unique token for the variable.
 function Token.register(var)
@@ -21,18 +25,25 @@ function Token.register(var)
 
     return counter
 end
---- Returns current counter
--- Helpful for recurrent functions
+---Returns how many variables were stored locally so far.
+---@return number
 function Token.get_counter()
     return counter
 end
 
+---Returns locally stored variable
+---@param token_id number
+---@see Token.register
 function Token.get(token_id)
     return tokens[token_id]
 end
 
 global.tokens = {}
 
+---Stores a var to persist across save/load and returns the token it was saved under.
+---This is different from Token.register and uses a different token namespace.
+---@param var serializable Any type that's allowed inside Factorio's "global" table. Excludes functions; tables will lose their metatables on load/player join
+---@return number
 function Token.register_global(var)
     local c = #global.tokens + 1
 
@@ -41,16 +52,24 @@ function Token.register_global(var)
     return c
 end
 
+---Returns the variable that was saved using Token.register_global
+---@param token_id number A global token
+---@return var serializable
 function Token.get_global(token_id)
     return global.tokens[token_id]
 end
 
+---Sets the variable under token_id that was previously saved using Token.register_global
+---@param token_id number A global token
+---@param var serializable
 function Token.set_global(token_id, var)
     global.tokens[token_id] = var
 end
 
 local uid_counter = 100
 
+---Returns a unique, immutable ID on each call
+---@return number
 function Token.uid()
     uid_counter = uid_counter + 1
 


### PR DESCRIPTION
### Brief description of the changes:

event libs: fix param annotation and finish doc
EmmyLua annotations have a specific syntax. I am not sure if the author
pretended to write annotations (fooled me indeed) or actually had a
plugin that accepted these custom annotations.

The fixed syntax is that of official EmmyLua and it's picked up
correctly by sumneko's LSP too.

require rename utils.event_core: EventCoreI -- renamed the `Public` library holding exported functions to EventCore so code search is usable.

utils/event libs: add documentation

utils/token.lua: add doc

utils/global.lua: add doc


This should be a comment-only change. If the comments don't read clearly or are hard to understand, note it down, it's probably a hole in my understanding of code or explanation. 

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes. But luac -p syntax check didn't bite me

----

This is the first in this series of PRs. Next I will go on a renaming spree because I am getting lost in all these "inlined" upvalues that only serve the purpose of eliminating a single table lookup IN LUA SPACE, which is already very cheap. It's the Lua code<->C boundary that is expensive. The otherwise readable function names look like variables and with all this heavy "inlining" it's like going through spaghetti.