### PR TITLE
Update infinity_chest.lua

### DIFF
--- a/comfy_panel/special_games/infinity_chest.lua
+++ b/comfy_panel/special_games/infinity_chest.lua
@@ -60,7 +60,7 @@ local Public = {
         [5] = {name = "eq5", type = "choose-elem-button", elem_type = "item"},
         [6] = {name = "eq6", type = "choose-elem-button", elem_type = "item"},
         [7] = {name = "eq7", type = "choose-elem-button", elem_type = "item"},
-        [8] = {name = "separate_chests", type = "switch", switch_state = "left", tooltip = "Single chest / Multiple chests"},
+        [8] = {name = "separate_chests", type = "switch", switch_state = "right", tooltip = "Single chest / Multiple chests"},
         [9] = {name = "operable", type = "switch", switch_state = "right", tooltip = "Operable? Y / N"},
         [10] = {name = "label1", type = "label", caption = "Gap size"},
         [11] = {name = "gap", type = "textfield", text = "3", numeric = true, width = 40},


### PR DESCRIPTION
Special games multiple chest toggle is always single chest. Change default toggle to right for multiple chests

### Brief description of the changes:
Special games multiple chest toggle is always single chest. Change default toggle to right for multiple chests.
It is annoying for me to change the toggle each time. I assume the same for other admins that run free item special games.


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
