### PR TITLE
Changes to the pathfinder settings

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -238,6 +238,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 	local unit_group_boss = surface.create_unit_group({position = unit_group_position, force = boss_force_name})
 	for _, unit in pairs(units)
 	do
+		unit.ai_settings.path_resolution_modifier = -1
 		if unit.force.name == boss_force_name then
 			unit_group_boss.add_member(unit)
 		else

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -47,10 +47,13 @@ function Public.initial_setup()
 
 	game.map_settings.path_finder.fwd2bwd_ratio = 2
 	game.map_settings.path_finder.goal_pressure_ratio = 3
-	game.map_settings.path_finder.short_cache_size = 30
+	game.map_settings.path_finder.general_entity_collision_penalty = 3
+	game.map_settings.path_finder.general_entity_subsequent_collision_penalty = 0
+	game.map_settings.path_finder.short_cache_size = 500
 	game.map_settings.path_finder.long_cache_size = 50
-	game.map_settings.path_finder.short_cache_min_cacheable_distance = 8
-	game.map_settings.path_finder.long_cache_min_cacheable_distance = 60
+	game.map_settings.path_finder.short_cache_min_cacheable_distance = 12
+	game.map_settings.path_finder.short_cache_min_algo_steps_to_cache = 20
+	game.map_settings.path_finder.long_cache_min_cacheable_distance = 100
 	game.map_settings.path_finder.max_clients_to_accept_any_new_request = 4
 	game.map_settings.path_finder.max_clients_to_accept_short_new_request = 150
 	game.map_settings.path_finder.start_to_goal_cost_multiplier_to_terminate_path_find = 10000


### PR DESCRIPTION
### Brief description of the changes:
Changes to the pathfinder to
- Make the short path cache much bigger and increase the minimal length of a path to be cached into the short path cache to make sure that really short paths and thus fast to compute won't fill the cache and override longer paths. I found the value of 12 by testing some and taking the value that filled the cache to a little less than 100% when waves attack walls. Should reduce lag.

- Increase the minimal length of a path to be cached into the long path cache to reserve this cache for wave paths. With this setting set to 60, I have seen some situation where a group of biters will be distracted by something (and each of them will calculate a 1 path to that thing) that is more than 60 tiles away and thus completely override all the 50 wave paths cached. This happens when a player attacks a spawner to threat farm and that all biters near that spawner attack the player, which can be more than 60 tiles away. Should make the pathfinder faster to compute wave paths.

- Reduce the entity collision penalty, should reduce lag and solve the problem of AFK waves we often see.

- Reduce the path finder resolution to -1, should reduce lag but make the biters a little more dumb when attacking checkerboard-like walls. I have set the modifier to -1 but we may want reduce it even more later if the pathfinder still causes lag. Note: this modifier has a really predictable impact of performance and should multiple the amount of work of the pathfinder by 2^2n.

### Tested Changes:
- [x] I've tested the changes locally or with people. See [this video](https://www.youtube.com/watch?v=mftnBqhQ9tY)
- [ ] I've not tested the changes.
