### PR TITLE
group names: do not allow "()[]" characters

### DIFF
--- a/comfy_panel/group.lua
+++ b/comfy_panel/group.lua
@@ -237,8 +237,8 @@ end
 ---@param str string
 ---@return boolean
 local function alphanumeric(str)
-    -- prohibit []() because they are confusing in the UI and allow factorio rich text injection
-    return string.match(str, '^[%w%s%p]*$') ~= nil and string.match(str, '[%(%)%[%]]') ~= nil
+    -- prohibit []()= because they are confusing in the UI and allow factorio rich text injection
+    return string.match(str, '^[%w%s%p]*$') ~= nil and string.match(str, '[%(%)%[%]%=]') ~= nil
 end
 
 ---@param event EventData.on_gui_click

--- a/comfy_panel/group.lua
+++ b/comfy_panel/group.lua
@@ -237,7 +237,8 @@ end
 ---@param str string
 ---@return boolean
 local function alphanumeric(str)
-    return (string.match(str, '[^%w%s%p]') ~= nil)
+    -- prohibit []() because they are confusing in the UI and allow factorio rich text injection
+    return string.match(str, '^[%w%s%p]*$') ~= nil and string.match(str, '[%(%)%[%]]') ~= nil
 end
 
 ---@param event EventData.on_gui_click


### PR DESCRIPTION
As much as it is cute to name a group "(wisper)" or to do smart things with rich text, it seems more usable and less surprising if we just don't allow it.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
