### PR TITLE
Captain : remove ground markers of new/not new/vet/speedrunner and spect part

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -512,24 +512,6 @@ local function generate_captain_mode(refereeName,autoTrust,captainKick,pickingMo
 	renderText("captainLineTen","Special Captain's tournament mode enabled", {0,-16}, {1,0,0,1}, 5, "heading-1")
 	renderText("captainLineEleven","team xx vs team yy. Referee: " .. refereeName .. ". Teams on VC", {0,10}, Color.captain_versus_float, 1.5,"heading-1")
 	generateGenericRenderingCaptain()
-	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {-9, -2}, to = {-9,3}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
-	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {0, 9}, to = {0,4}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
-	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {0, -4}, to = {0,-9}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
-	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {-9, 0}, to = {-4,0}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
-	rendering.draw_line{surface = game.surfaces[global.bb_surface_name], from = {4, 0}, to = {9,0}, color = {r = 1},draw_on_ground = true, width = 3, gap_length = 0, dash_length = 1} 
-	rendering.draw_circle{surface = game.surfaces[global.bb_surface_name], target = {0, 0}, radius = 4, filled= false,draw_on_ground = true, color = {r = 1}, width = 3} 
-
-	renderText("captainLineTwelve","Speedrunners", {6,-5}, {1,1,1,1}, 2, "heading-1")
-	renderText("captainLineThirteen","BB veteran players", {-6, -5}, {1,1,1,1}, 2, "heading-1")
-	renderText("captainLineFourteen","New players", {6,5}, {1,1,1,1}, 2, "heading-1")
-	renderText("captainLineFifteen","Not veteran but not new players", {-8,5}, {1,1,1,1}, 2, "heading-1")
-	renderText("captainLineSixteen","Spectators", {-12,-1}, {1,1,1,1}, 2, "heading-1")
-
-	for i=-9,-16,-1 do
-		for k=2,-2,-1 do
-			game.surfaces[global.bb_surface_name].set_tiles({{name = "green-refined-concrete", position = {x=i,y=k}}}, true)
-		end
-	end 
 end
 
 local function are_all_players_picked()


### PR DESCRIPTION
### Brief description of the changes:
Remove all the markers (red line and circle) on the island that splits the island visually in 4 (speedrunner, vet, not new not vet, new player) and remove the spectator island part in green, which were shown during picking phase

Vote : 
https://discord.com/channels/823696400797138974/823771211421974579/1237122117619945493
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/95619848/c20ab940-2868-4870-b51e-19bcb379cc1c)


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
