### PR TITLE
Fix mining history is empty

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -73,9 +73,7 @@ Event.add(defines.events.on_player_mined_entity, function (event)
 
 	local player = game.get_player(event.player_index)
 	if player and player.valid then
-		if Antigrief.enabled then
-			Antigrief.on_player_mined_entity(entity, player)
-		end
+		Antigrief.on_player_mined_entity(entity, player)
 		ComfyPanelScore.on_player_mined_entity(entity, player)
 		Terrain.minable_wrecks(entity, player)
 	end


### PR DESCRIPTION
Bug: mining history is empty 
Problem: `Antigrief.enabled` is a local variable and cannot be accessed from `control.lua`
Solution: Don't check `Antigrief.enabled` in `control.lua`, it is checked immediately in `Antigrief.on_player_mined_entity` anyway

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
