### PR TITLE
Stop always broadcasting admin chat messages

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -345,9 +345,6 @@ local function generateGenericRenderingCaptain()
 	renderText("captainLineFour","-Chat of spectator can only be seen by spectators for players",
 		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2
-	renderText("captainLineFive","-For admins, as spectator, use ping to talk only to spectators",
-		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
-	y = y + 2
 	renderText("captainLineSix","-Teams are locked, if you want to play, ask to be moved to a team",
 		{-65,y}, {1,1,1,1}, 2.5, "heading-1")
 	y = y + 2

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -102,7 +102,7 @@ local function on_console_chat(event)
 		Functions.print_message_to_players(game.forces.spectator.players,player_name,msg,color)
 	end
 
-	if global.tournament_mode and not player.admin then return end
+	if global.tournament_mode then return end
 
 	--Skip messages that would spoil coordinates from spectators and don't send gps coord to discord
 	local a, b = string.find(event.message, "gps=", 1, false)


### PR DESCRIPTION
This was voted on by the admins and universally agreed to be confusing behavior. It is confusing for admins because they have to remember to use /spectator-chat. It is confusing for non-admins because they see chat messages that are not /shouts from other players, and assume that perhaps their chat messages work the same way.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
