### PR TITLE
sciencelogs: fix a bug when looking at the UI before any sends

### DIFF
--- a/maps/biter_battles_v2/sciencelogs_tab.lua
+++ b/maps/biter_battles_v2/sciencelogs_tab.lua
@@ -132,7 +132,7 @@ local function add_science_logs(player, element)
 		end
 	end
 
-	if global.science_logs_date then
+	if global.science_logs_text then
 		for i = 1, #global.science_logs_date, 1 do
 			local real_force_name = global.science_logs_fed_team[i]
 			local custom_force_name = Functions.team_name_with_color(real_force_name);


### PR DESCRIPTION
Specifically, if one game has sends, then global.science_logs_date will be non-nil.  The global initialization logic only sets science_logs_text to nil at the beginning of each game.  Thus, only global.science_logs_text should be checked for nil-ness to figure out if there is any science logs to show.

I found this when randomly looking at server logs, and I saw the following error:

```
3685.453 Script @/opt/factorio1.1.42/temp/currently-playing/utils/event_core.lua:30: Error caught: ...rently-playing/maps/biter_battles_v2/sciencelogs_tab.lua:162: attempt to index field 'science_logs_text' (a nil value)
3685.453 Script @/opt/factorio1.1.42/temp/currently-playing/utils/event_core.lua:32: stack traceback:
        ...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:32: in function '__index'
        ...rently-playing/maps/biter_battles_v2/sciencelogs_tab.lua:162: in function 'add_science_logs'
        ...rently-playing/maps/biter_battles_v2/sciencelogs_tab.lua:191: in function 'gui'
        ...ctorio1.1.42/temp/currently-playing/comfy_panel/main.lua:62: in function 'comfy_panel_refresh_active_tab'
        ...ctorio1.1.42/temp/currently-playing/comfy_panel/main.lua:166: in function <...ctorio1.1.42/temp/currently-playing/comfy_panel/main.lua:133>
        [C]: in function 'xpcall'
        ...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:49: in function 'call_handlers'
        ...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:61: in function <...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:56>
```

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
