### PR TITLE
Use Factorio button styles instead of font color on Captain UI elements for enhanced readability

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -119,8 +119,7 @@ end
 local function createButton(frame,nameButton,captionButton, wordToPutInstead)
 	local newNameButton = nameButton:gsub("Magical1@StringHere", wordToPutInstead)
 	local newCaptionButton = captionButton:gsub("Magical1@StringHere", wordToPutInstead)
-	local b = frame.add({type = "button", name = newNameButton, caption = newCaptionButton})
-	b.style.font_color = Color.green
+	local b = frame.add({type = "button", name = newNameButton, caption = newCaptionButton, style="green_button"})
 	b.style.font = "heading-2"
 	b.style.minimal_width = 100
 end

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -800,7 +800,7 @@ function Public.update_captain_referee_gui(player)
 	l.style.single_line = false
 	frame.add({type = "label", caption = string.format("Next auto picking phase in %ds", ticks_until_autopick / 60)})
 	if #special["listPlayers"] > 0 and not special["pickingPhase"] and not special["prepaPhase"] and ticks_until_autopick > 0 then
-		local button = frame.add({type = "button", name = "captain_start_join_poll", caption = "Start poll for players to join the game (instead of waiting)", style = "red_button"})
+		local button = frame.add({type = "button", name = "captain_start_join_poll", caption = "Start poll for players to join the game (instead of waiting)"})
 	end
 
 	if #special["listPlayers"] > 0 and special["pickingPhase"] then

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -116,10 +116,11 @@ local function force_end_captain_event()
 	clear_character_corpses()
 end
 
+---@param frame LuaGuiElement
 local function createButton(frame,nameButton,captionButton, wordToPutInstead)
 	local newNameButton = nameButton:gsub("Magical1@StringHere", wordToPutInstead)
 	local newCaptionButton = captionButton:gsub("Magical1@StringHere", wordToPutInstead)
-	local b = frame.add({type = "button", name = newNameButton, caption = newCaptionButton, style="green_button"})
+	local b = frame.add({type = "button", name = newNameButton, caption = newCaptionButton, style="green_button", tooltip="Click to select"})
 	b.style.font = "heading-2"
 	b.style.minimal_width = 100
 end

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -685,12 +685,12 @@ function Public.update_captain_manager_gui(player)
 	if special["prepaPhase"] and not isStringInTable(special["listTeamReadyToPlay"], force_name) then
 		frame.captain_is_ready.visible = true
 		frame.captain_is_ready.caption = "Team is Ready!"
-		frame.captain_is_ready.style.font_color = Color.green
+		frame.captain_is_ready.style = "green_button"
 		if game.ticks_played < global.difficulty_votes_timeout then
 			frame.diff_vote_duration.visible = true
-			frame.diff_vote_duration.caption = string.format("difficulty vote ongoing for %ds longer. Consider waiting until it is over before marking yourself as ready.", (global.difficulty_votes_timeout - game.ticks_played) / 60)
+			frame.diff_vote_duration.caption = string.format("Difficulty vote ongoing for %ds longer. Consider waiting until it is over before marking yourself as ready.", (global.difficulty_votes_timeout - game.ticks_played) / 60)
 			frame.captain_is_ready.caption = "Mark team as ready even though difficulty vote is ongoing!"
-			frame.captain_is_ready.style.font_color = Color.red
+			frame.captain_is_ready.style = "red_button"
 		end
 	end
 	local throwScienceSetting = special["northEnabledScienceThrow"]
@@ -784,8 +784,7 @@ function Public.update_captain_referee_gui(player)
 	if special["prepaPhase"] and special["initialPickingPhaseStarted"] and not special["pickingPhase"] then
 		if #special["listTeamReadyToPlay"] < 2 then
 			frame.add({type = "label", caption = "Teams ready to play: " .. table.concat(special["listTeamReadyToPlay"], ", ")})
-			local b = frame.add({type = "button", name = "captain_force_captains_ready", caption = "Force all captains to be ready"})
-			b.style.font_color = Color.red
+			local b = frame.add({type = "button", name = "captain_force_captains_ready", caption = "Force all captains to be ready", style="red_button"})
 		end
 	end
 
@@ -801,13 +800,11 @@ function Public.update_captain_referee_gui(player)
 	l.style.single_line = false
 	frame.add({type = "label", caption = string.format("Next auto picking phase in %ds", ticks_until_autopick / 60)})
 	if #special["listPlayers"] > 0 and not special["pickingPhase"] and not special["prepaPhase"] and ticks_until_autopick > 0 then
-		local button = frame.add({type = "button", name = "captain_start_join_poll", caption = "Start poll for players to join the game (instead of waiting)"})
-		button.style.font_color = Color.red
+		local button = frame.add({type = "button", name = "captain_start_join_poll", caption = "Start poll for players to join the game (instead of waiting)", style = "red_button"})
 	end
 
 	if #special["listPlayers"] > 0 and special["pickingPhase"] then
-		local button = frame.add({type = "button", name = "referee_force_picking_to_stop", caption = "Force the current round of picking to stop (only useful if changing captains)"})
-		button.style.font_color = Color.red
+		local button = frame.add({type = "button", name = "referee_force_picking_to_stop", caption = "Force the current round of picking to stop (only useful if changing captains)", style = "red_button"})
 	end
 
 	if special["prepaPhase"] and not special["initialPickingPhaseStarted"] then
@@ -826,19 +823,20 @@ function Public.update_captain_referee_gui(player)
 		table.sort(spectators)
 		frame.add({type = "label", caption = string.format("Everyone else: ", table.concat(spectators, " ,"))})
 		local caption
-		local color = Color.green
+		local button_style = "confirm_button"
 		if #special["captainList"] < 2 then
 			caption = "Cancel captains event (not enough captains)"
-			color = Color.red
+			button_style = "red_button"
 		elseif #special["captainList"] == 2 then
-			caption = "Confirm captions and start the picking phase"
+			caption = "Confirm captains and start the picking phase"
 		else
 			caption = "Select captains and start the picking phase"
 		end
-		local b = frame.add({type = "button", name = "captain_end_captain_choice", caption = caption})
-		b.style.font_color = color
+		---@type LuaGuiElement
+		local b = frame.add({type = "button", name = "captain_end_captain_choice", caption = caption, style = button_style})
 		b.style.font = "heading-2"
 		b.style.minimal_width = 540
+		b.style.horizontal_align = "center"
 	end
 
 	if special["prepaPhase"] and not special["initialPickingPhaseStarted"] then
@@ -875,9 +873,11 @@ function Public.draw_captain_player_gui(player)
 
 	l = frame.add({type = "label", name = "status_label"})
 	l.style.single_line = false
-	local b = frame.add({type = "button", name = "captain_player_want_to_play", caption = "I want to play"})
+	local b = frame.add({type = "button", name = "captain_player_want_to_play", caption = "I want to play", style = "confirm_button"})
 	b.style.font = "heading-1"
-	frame.add({type = "button", name = "captain_player_want_to_be_captain", caption = "I am willing to be a captain"})
+	b.style.horizontally_stretchable = true
+	b = frame.add({type = "button", name = "captain_player_want_to_be_captain", caption = "I am willing to be a captain", style = "green_button"})
+	b.style.horizontally_stretchable = true
 
 	frame.add({type = "line", name = "player_table_line"})
 	local scroll = frame.add({type = "scroll-pane", name = "player_table_scroll", direction = "vertical"})


### PR DESCRIPTION
# Description
Expansion of #514. Uses Factorio UI styles (`green_button`, `red_button`, `submit_button`) instead of setting the font color on buttons.
This enhances the readability of the buttons.

# Images
![i want to play](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/579b74cf-3dba-4a3b-9989-aff55afc1d84)
![i want to captian](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/898046cd-5fc6-41b1-8acf-c7d0af667144)
![cancel captains](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/c50ea356-5db6-4672-965f-20f7e41251d0)
![start captains](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/b9cab151-d45d-458c-af51-2da0018b302b)
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/e3b2ecc0-5725-42ec-8641-027742793cb3)
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/743d5a93-94cf-4490-9244-2c43b745f66c)
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/808649d7-ff2e-412a-8b5a-7defecf13248)
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/93e427cd-096b-4f98-85d0-1db65fa75de6)
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/57c6e5c2-da7b-403c-86b5-d2efe677186f)
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/49845522/02b06287-1aaa-4dae-8204-686978b0d486)

### Testing?
- [x] I've tested the changes locally or with people.
