### PR TITLE
Ping improvements, and default to on

### DIFF
--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -105,7 +105,7 @@ local functions = {
         if event.element.switch_state == 'left' then
             global.want_pings[player.name] = true
         else
-            global.want_pings[player.name] = nil
+            global.want_pings[player.name] = false
             global.ping_gui_locations[player.name] = nil
         end
     end,
@@ -341,6 +341,13 @@ local function add_switch(element, switch_state, name, description_main, descrip
     return switch
 end
 
+function player_wants_pings(name)
+    if global.want_pings[name] ~= nil then
+        return global.want_pings[name]
+    end
+    return global.want_pings_default_value
+end
+
 local build_config_gui = (function(player, frame)
     local AG = Antigrief.get()
     local switch_state
@@ -383,7 +390,7 @@ local build_config_gui = (function(player, frame)
         'Toggles zoom-to-world view noise effect.\nEnvironmental sounds will be based on map view.'
     )
 
-    switch_state = global.want_pings[player.name] and 'left' or 'right'
+    switch_state = player_wants_pings(player.name) and 'left' or 'right'
     add_switch(
         scroll_pane,
         switch_state,

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -381,12 +381,15 @@ function Functions.team_name_with_color(force_name)
 	end
 end
 
--- Returns every possible player name that follows "@" or "@ " in the message
+-- Returns every possible player name that follows "@" or "@ " in the message, as well as every name that preceeds "@"
 --- @param message string
 --- @return table<string, boolean>
 function Functions.extract_possible_pings(message)
 	local possible_pings = {}
 	for name in string.gmatch(message, "@%s?([a-zA-Z0-9_-]+)") do
+		possible_pings[name] = true
+	end
+	for name in string.gmatch(message, "([a-zA-Z0-9_-]+)@") do
 		possible_pings[name] = true
 	end
 	return possible_pings

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -134,6 +134,8 @@ function Public.initial_setup()
 		["bb_map_reveal_toggle"] = true,
 		["map_reroll"] = true,
 	}
+	global.want_pings = {}
+	global.want_pings_default_value = true
 
 	global.total_time_online_players = {}
 	global.already_logged_current_session_time_online_players = {}

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -124,9 +124,10 @@ function do_ping(from_player_name, to_player, message)
 	-- to_player.play_sound({path = "utility/new_objective", volume_modifier = 0.6})
 	-- to_player.surface.create_entity({name = 'big-explosion', position = to_player.position})
 	local ping_header = to_player.gui.screen["ping_header"]
+	local uis = to_player.display_scale
 	if not ping_header then
 		ping_header = to_player.gui.screen.add({type = "frame", caption = "Message", name = "ping_header", direction = "vertical"})
-		ping_header.style.width = 105
+		ping_header.style.width = 110
 		ping_header.style.height = 38
 
 		local line = ping_header.add({type="line"})
@@ -148,7 +149,8 @@ function do_ping(from_player_name, to_player, message)
 	if not ping_messages then
 		ping_messages = to_player.gui.screen.add({type = "flow", name = "ping_messages", direction = "vertical"})
 		ping_messages.style.width = 400
-		ping_messages.location = {x = ping_header.location.x, y = ping_header.location.y + 42}
+		ping_messages.style.left_padding = 10
+		ping_messages.location = {x = ping_header.location.x, y = ping_header.location.y + 42 * uis}
 	end
 
 	local label = ping_messages.add({type = "label", caption = message})
@@ -169,7 +171,7 @@ local function on_gui_location_changed(event)
 		if not player then return end
 		global.ping_gui_locations[player.name] = element.location
 
-		player.gui.screen["ping_messages"].location = {x = element.location.x, y = element.location.y + 42}
+		player.gui.screen["ping_messages"].location = {x = element.location.x, y = element.location.y + 42 * player.display_scale}
 	end
 end
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -107,8 +107,8 @@ local clear_pings_token = Token.register(
 ---@param to_player_name string
 ---@return boolean
 local function ignore_message(from_player_name, to_player_name)
-	local ignore_list = global.ignore_lists[from_player_name]
-	return ignore_list and ignore_list[to_player_name]
+	local ignore_list = global.ignore_lists[to_player_name]
+	return ignore_list and ignore_list[from_player_name]
 end
 
 ---@param from_player_name string

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -117,7 +117,7 @@ end
 function do_ping(from_player_name, to_player, message)
 	local to_player_name = to_player.name
 	if ignore_message(from_player_name, to_player_name) then return end
-	if not global.want_pings[to_player_name] then return end
+	if not player_wants_pings(to_player_name) then return end
 	if to_player.character and to_player.character.get_health_ratio() > 0.99 then
 		to_player.character.damage(0.001, "player")
 	end

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -137,7 +137,10 @@ function do_ping(from_player_name, to_player, message)
 		line.style.top_margin = -5
 
 		if global.ping_gui_locations[to_player.name] then
-			ping_header.location = global.ping_gui_locations[to_player.name]
+			local saved_location = global.ping_gui_locations[to_player.name]
+			saved_location.x = math.min(saved_location.x, to_player.display_resolution.width - 200 * uis)
+			saved_location.y = math.min(saved_location.y, to_player.display_resolution.height - 100 * uis)
+			ping_header.location = saved_location
 		else
 			local res = to_player.display_resolution
 			local uis = to_player.display_scale

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -269,7 +269,7 @@ local function on_console_command(event)
 		local to_player_name, rest_of_message = string.match(param, "^%s*(%S+)%s*(.*)")
 		local to_player = game.get_player(to_player_name)
 		if to_player then
-			do_ping(player.name, to_player, player.name .. " (wisper): " .. rest_of_message)
+			do_ping(player.name, to_player, player.name .. " (whisper): " .. rest_of_message)
 			global.reply_target[to_player_name] = player.name
 		end
 	elseif cmd == "r" or cmd == "reply" then
@@ -277,7 +277,7 @@ local function on_console_command(event)
 		if to_player_name then
 			local to_player = game.get_player(to_player_name)
 			if to_player then
-				do_ping(player.name, to_player, player.name .. " (wisper): " .. param)
+				do_ping(player.name, to_player, player.name .. " (whisper): " .. param)
 			end
 		end
 	elseif cmd == "s" or cmd == "shout" then


### PR DESCRIPTION
This has a variety of changes

1. \@Ping support defaults to "on", but it can be turned off at Fish -> Config
2. The Ping popup looks better at a variety of display scales
3. /ignore now works properly to block the ping popups
4. you can use any of "username\@" "\@username" or "\@ username" to message someone.  The first and last ones of those are easiest to use with factorio's tab-autocompletion
5. Even if you move the window to the bottom-right of the screen, and then resize your window to be smaller, the next popup will still be visible

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
