### PR TITLE
Fix error on non exist inventory

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -222,6 +222,9 @@ function Public.feed_biters_from_inventory(player, food)
 	local biter_force_name = enemy_force_name .. "_biters"
 
 	local i = player.get_main_inventory()
+	if not i then
+		return
+	end
 	local flask_amount = i.get_item_count(food)
 	if flask_amount == 0 then
 		player.print("You have no " .. food_values[food].name .. " flask in your inventory.", {r = 0.98, g = 0.66, b = 0.22})
@@ -273,6 +276,9 @@ function Public.feed_biters_mixed_from_inventory(player, button)
 		}
 	end
 	local i = player.get_main_inventory()
+	if not i then
+		return
+	end
 	local colored_player_name = table.concat({"[color=", player.color.r * 0.6 + 0.35, ",", player.color.g * 0.6 + 0.35, ",", player.color.b * 0.6 + 0.35, "]", player.name, "[/color]"})
 	local message = {colored_player_name, " fed "}
 	for k, v in pairs(food) do

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -167,10 +167,12 @@ function Public.calc_send_command(params, difficulty_vote_value, bb_evolution, m
 	end
 	if error_msg == nil and #foods == 0 and player ~= nil then
 		local i = player.get_main_inventory()
-		for food_type, _ in pairs(Tables.food_values) do
-			local flask_amount = i.get_item_count(food_type)
-			if flask_amount > 0 then
-				foods[food_type] = flask_amount
+		if i then
+			for food_type, _ in pairs(Tables.food_values) do
+				local flask_amount = i.get_item_count(food_type)
+				if flask_amount > 0 then
+					foods[food_type] = flask_amount
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Error:
```
15268.741 Script temp/currently-playing/utils/event_core.lua:30: Error caught: ...temp/currently-playing/maps/biter_battles_v2/feeding.lua:225: attempt to index local 'i' (a nil value)
15268.741 Script /temp/currently-playing/utils/event_core.lua:32: stack traceback:
	.../temp/currently-playing/utils/event_core.lua:32: in function '__index'
	...temp/currently-playing/maps/biter_battles_v2/feeding.lua:225: in function 'feed_biters_from_inventory'
	../temp/currently-playing/maps/biter_battles_v2/gui.lua:571: in function <..../temp/currently-playing/maps/biter_battles_v2/gui.lua:516>
	[C]: in function 'xpcall'
	.../temp/currently-playing/utils/event_core.lua:49: in function 'call_handlers'
	.../temp/currently-playing/utils/event_core.lua:61: in function <.../temp/currently-playing/utils/event_core.lua:56>
```
Cause: 
player pressed "send science" button while waiting for respawn (no body, no inventory)

Fix:
Check if inventory exist before use it

Also fix `/calc-send` . It crashes the server when dead player run it

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
