### PR TITLE
Add global.threat_multiplier

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -173,7 +173,7 @@ function Public.do_raw_feed(flask_amount, food, biter_force_name)
 	local current_player_count = #game.forces.north.connected_players + #game.forces.south.connected_players
 	local effects = FeedingCalculations.calc_feed_effects(evo, food_value, flask_amount, current_player_count, global.max_reanim_thresh)
 	evo = evo + effects.evo_increase
-	threat = threat + effects.threat_increase
+	threat = threat + effects.threat_increase * (global.threat_multiplier or 1)
 	evo = math_round(evo, decimals)
 	global.reanim_chance[force_index] = effects.reanim_chance
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -298,6 +298,7 @@ function Public.tables()
 	global.difficulty_vote_index = 3
 
 	global.difficulty_votes_timeout = 36000
+	global.threat_multiplier = nil
 
 	-- Maximum evolution threshold after which biters have 100% chance
 	-- to reanimate. The reanimation starts after evolution factor reaches


### PR DESCRIPTION
This gives an option of easily running a special where evo and threat grow at different than normal rates.  i.e. 25% mutagen effectiveness but 4x as much threat as normal, or 500% mutagen effectiveness but 0.1x as much threat as normal.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
