### PR TITLE
Partially revert pathfinder settings change (#502)

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -45,18 +45,18 @@ function Public.initial_setup()
 	game.map_settings.pollution.enabled = false
 	game.map_settings.enemy_expansion.enabled = false
 
-	game.map_settings.path_finder.fwd2bwd_ratio = 2
-	game.map_settings.path_finder.goal_pressure_ratio = 3
-	game.map_settings.path_finder.general_entity_collision_penalty = 3
-	game.map_settings.path_finder.general_entity_subsequent_collision_penalty = 0
-	game.map_settings.path_finder.short_cache_size = 500
-	game.map_settings.path_finder.long_cache_size = 50
-	game.map_settings.path_finder.short_cache_min_cacheable_distance = 12
-	game.map_settings.path_finder.short_cache_min_algo_steps_to_cache = 20
-	game.map_settings.path_finder.long_cache_min_cacheable_distance = 100
-	game.map_settings.path_finder.max_clients_to_accept_any_new_request = 4
-	game.map_settings.path_finder.max_clients_to_accept_short_new_request = 150
-	game.map_settings.path_finder.start_to_goal_cost_multiplier_to_terminate_path_find = 10000
+	game.map_settings.path_finder.fwd2bwd_ratio = 2  -- default 5
+	game.map_settings.path_finder.goal_pressure_ratio = 3  -- default 2
+	game.map_settings.path_finder.general_entity_collision_penalty = 5  -- default 10
+	game.map_settings.path_finder.general_entity_subsequent_collision_penalty = 1  -- default 3
+	game.map_settings.path_finder.short_cache_size = 30  -- default 5
+	game.map_settings.path_finder.long_cache_size = 50  -- default 25
+	game.map_settings.path_finder.short_cache_min_cacheable_distance = 10  -- default 10
+	game.map_settings.path_finder.long_cache_min_cacheable_distance = 60  -- default 30
+	game.map_settings.path_finder.short_cache_min_algo_steps_to_cache = 50  -- default 50
+	game.map_settings.path_finder.max_clients_to_accept_any_new_request = 4  -- default 10
+	game.map_settings.path_finder.max_clients_to_accept_short_new_request = 150  -- default 100
+	game.map_settings.path_finder.start_to_goal_cost_multiplier_to_terminate_path_find = 10000  -- default 2000
 
 	game.create_force("north")
 	game.create_force("south")


### PR DESCRIPTION
This is primarily motivated because I believe that the high value of short_cache_size was drastically hurting performance in some situations, based on
https://forums.factorio.com/viewtopic.php?p=610324#p610324

So, the main thing that I wanted to do here is to move things closer to their default values, and closer to the values that they were before #502.  Note that I am leaving the lower-pathfinder-resolution, as I assume that that is still a big speedup for the pathfinder in general (even though the downsides are substantial).

I also added documentation of default values.

I wish that I could tell you that this change is based on actual concrete testing, but it is not. It is based on my own gut feeling that overall, after #502, some things got worse and other things got better, and that we should try and aim for the middle a bit more.  To improve performance more, we should probably consider just reducing the number of biters that we are willing to spawn in waves (i.e. essentially have more boss biters and fewer normal biters).

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
