### PR TITLE
Clean up errors in log

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -47,6 +47,7 @@ Public.send_near_biters_to_silo = function()
 	if Functions.get_ticks_since_game_start() < 108000 then return end
 	if not global.rocket_silo["north"] then return end
 	if not global.rocket_silo["south"] then return end
+	if global.bb_game_won_by_team then return end
 
 	game.surfaces[global.bb_surface_name].set_multi_command({
 		command={

--- a/maps/biter_battles_v2/ai_strikes.lua
+++ b/maps/biter_battles_v2/ai_strikes.lua
@@ -173,6 +173,7 @@ function Public.initiate(unit_group, target_force_name, strike_position, target_
 end
 
 function Public.step(group_number, result)
+    if global.bb_game_won_by_team then return end
     local strike = global.ai_strikes[group_number]
     if strike ~= nil then
         if result == defines.behavior_result.success then

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -149,9 +149,10 @@ function Public.calc_send_command(params, difficulty_vote_value, bb_evolution, m
 					flask_count = tonumber(v)
 					if flask_count == nil or flask_count <= 0 or flask_count > 1000000000 then
 						error_msg = "Invalid flask count"
+					else
+						if foods[flask_color] == nil then foods[flask_color] = 0 end
+						foods[flask_color] = foods[flask_color] + flask_count
 					end
-					if foods[flask_color] == nil then foods[flask_color] = 0 end
-					foods[flask_color] = foods[flask_color] + flask_count
 				end
 				flask_color = nil
 			else

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -41,7 +41,7 @@ local gui_values = {
 }
 
 function Public.clear_copy_history(player)
-	if player and player.valid then
+	if player and player.valid and player.cursor_stack then
 		for i = 1, 21 do
 			-- Imports blueprint of single burner miner into the cursor stack
 			stack = player.cursor_stack.import_stack(

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -45,18 +45,18 @@ function Public.initial_setup()
 	game.map_settings.pollution.enabled = false
 	game.map_settings.enemy_expansion.enabled = false
 
-	game.map_settings.path_finder.fwd2bwd_ratio = 2
-	game.map_settings.path_finder.goal_pressure_ratio = 3
-	game.map_settings.path_finder.general_entity_collision_penalty = 3
-	game.map_settings.path_finder.general_entity_subsequent_collision_penalty = 0
-	game.map_settings.path_finder.short_cache_size = 500
-	game.map_settings.path_finder.long_cache_size = 50
-	game.map_settings.path_finder.short_cache_min_cacheable_distance = 12
-	game.map_settings.path_finder.short_cache_min_algo_steps_to_cache = 20
-	game.map_settings.path_finder.long_cache_min_cacheable_distance = 100
-	game.map_settings.path_finder.max_clients_to_accept_any_new_request = 4
-	game.map_settings.path_finder.max_clients_to_accept_short_new_request = 150
-	game.map_settings.path_finder.start_to_goal_cost_multiplier_to_terminate_path_find = 10000
+	game.map_settings.path_finder.fwd2bwd_ratio = 2  -- default 5
+	game.map_settings.path_finder.goal_pressure_ratio = 3  -- default 2
+	game.map_settings.path_finder.general_entity_collision_penalty = 5  -- default 10
+	game.map_settings.path_finder.general_entity_subsequent_collision_penalty = 1  -- default 3
+	game.map_settings.path_finder.short_cache_size = 30  -- default 5
+	game.map_settings.path_finder.long_cache_size = 50  -- default 25
+	game.map_settings.path_finder.short_cache_min_cacheable_distance = 10  -- default 10
+	game.map_settings.path_finder.long_cache_min_cacheable_distance = 60  -- default 30
+	game.map_settings.path_finder.short_cache_min_algo_steps_to_cache = 50  -- default 50
+	game.map_settings.path_finder.max_clients_to_accept_any_new_request = 4  -- default 10
+	game.map_settings.path_finder.max_clients_to_accept_short_new_request = 150  -- default 100
+	game.map_settings.path_finder.start_to_goal_cost_multiplier_to_terminate_path_find = 10000  -- default 2000
 
 	game.create_force("north")
 	game.create_force("south")


### PR DESCRIPTION
Without this change, we can end up with log entries like the following:

    .../temp/currently-playing/utils/event_core.lua:30: Error caught: Given entity doesn't exist anymore.
    .../temp/currently-playing/utils/event_core.lua:32: stack traceback:
    .../temp/currently-playing/utils/event_core.lua:32: in function <...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:29>
    [C]: in function 'set_multi_command'
    .../temp/currently-playing/maps/biter_battles_v2/ai.lua:51: in function '?'
    .../temp/currently-playing/maps/biter_battles_v2/main.lua:408: in function <...42/temp/currently-playing/maps/biter_battles_v2/main.lua:388>
    [C]: in function 'xpcall'
    .../temp/currently-playing/utils/event_core.lua:49: in function 'call_handlers'
    .../temp/currently-playing/utils/event_core.lua:61: in function <...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:56>

or

    .../temp/currently-playing/utils/event_core.lua:30: Error caught: Given entity doesn't exist anymore.
    .../temp/currently-playing/utils/event_core.lua:32: stack traceback:
    .../temp/currently-playing/utils/event_core.lua:32: in function <...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:29>
    [C]: in function 'set_command'
    ...temp/currently-playing/maps/biter_battles_v2/ai_strikes.lua:140: in function 'assassinate'
    ...temp/currently-playing/maps/biter_battles_v2/ai_strikes.lua:184: in function 'step'
    ...temp/currently-playing/maps/biter_battles_v2/main.lua:316: in function <...42/temp/currently-playing/maps/biter_battles_v2/main.lua:315>
    [C]: in function 'xpcall'
    .../temp/currently-playing/utils/event_core.lua:49: in function 'call_handlers'
    .../temp/currently-playing/utils/event_core.lua:61: in function <...ctorio1.1.42/temp/currently-playing/utils/event_core.lua:56>

I am just trying to clean up all errors from the log.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
