### PR TITLE
Fix too-many-captains race condition

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1423,10 +1423,12 @@ local function on_gui_click(event)
 	if element.name == "captain_gui_close" then
 		element.parent.parent.destroy()
 	elseif element.name == "captain_player_want_to_play" then
-		insertPlayerByPlaytime(player.name)
-		Public.update_all_captain_player_guis()
+		if not global.special_games_variables["captain_mode"]["pickingPhase"] then
+			insertPlayerByPlaytime(player.name)
+			Public.update_all_captain_player_guis()
+		end
 	elseif element.name == "captain_player_want_to_be_captain" then
-		if not isStringInTable(special["captainList"], player.name) then
+		if not special["initialPickingPhaseStarted"] and not isStringInTable(special["captainList"], player.name) then
 			table.insert(special["captainList"], player.name)
 			Public.update_all_captain_player_guis()
 		end


### PR DESCRIPTION
If there was a race of the referee choosing exactly 2 captains, and others volunteering to be captain, then more than two players could end up on the captains list.

This would cause these players to be listed as a "captain" in the captains list even though they were not the captain of the team.

I also removed a similar race with someone adding themselves to the list of players just as the game started. This could theoretically have made it so that the player couldn't have been the first pick, but they would show up in the next pick screen, which would be funny.

I tested that the code still seems to work. I didn't actually reproduce the race condition manually or anything though.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
