### PR TITLE
Add a new Patches type for mixed ore map special

### DIFF
--- a/comfy_panel/special_games/mixed_ore_map.lua
+++ b/comfy_panel/special_games/mixed_ore_map.lua
@@ -8,6 +8,8 @@ local function generate_mixed_ore_map(type, size)
                 size = 9
             elseif type == 2 then
                 size = 5
+            elseif type == 4 then
+                size = 4
             end
         end
         if type == 1 and size > 10 then
@@ -27,11 +29,12 @@ local Public = {
     name = {type = "label", caption = "Mixed ore map", tooltip = "Covers the entire map with mixed ore. Takes effect after map restart"},
     config = {
         [1] = {name = "label1", type = "label", caption = "Type"},
-        [2] = {name = "type1", type = "drop-down", items = {"Mixed ore", "Checkerboard", "Vertical lines"}},
+        [2] = {name = "type1", type = "drop-down", items = {"Mixed ore", "Checkerboard", "Vertical lines", "Patches"}},
         [3] = {name = "label2", type = "label", caption = "Size"},
         [4] = {name = "size", type = "textfield", text = "", numeric = true, width = 40, tooltip = "Live empty for default"
             .. "\nFor a Mixed ore, a higher value means lower features. Value range from 1 to 10, Default 9."
             .. "\nFor Checkerboard its the size of the cell. Default 5"
+            .. "\nFor Patches its the size of the patches. Value range from 1 to 10, Default 4."
         },
     },
     button = {name = "apply", type = "button", caption = "Apply"},

--- a/maps/biter_battles_v2/mixed_ore_map.lua
+++ b/maps/biter_battles_v2/mixed_ore_map.lua
@@ -118,6 +118,31 @@ local function vertical_lines(surface, left_top_x, left_top_y)
 	end
 end
 
+local function mixed_patches(surface, left_top_x, left_top_y)
+	local size = 10 - global.special_games_variables['mixed_ore_map']['size']
+	local ores = {"iron-ore", "copper-ore", "iron-ore", "stone", "copper-ore", "iron-ore", "copper-ore", "iron-ore", "coal", "iron-ore", "copper-ore",  "iron-ore", "stone", "copper-ore", "coal"}
+	local mixed_ore_multiplier = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	local seed = game.surfaces[global.bb_surface_name].map_gen_settings.seed
+	clear_ores(surface, left_top_x, left_top_y, {"coal", "stone", "copper-ore","iron-ore"})
+	for x = 0, 31, 1 do
+		for y = 0, 31, 1 do
+			local pos = {x = left_top_x + x, y = left_top_y + y}
+			if surface.can_place_entity({name = "iron-ore", position = pos}) then
+				local noise = GetNoise("bb_ore", pos, seed)
+				if noise > 0.1 * size or noise < -0.1 * size then
+					local i = math_floor(noise * 25 + math_abs(pos.x) * 0.05) % 15 + 1
+					local amount = (global.random_generator(800, 1000) + math_sqrt(pos.x ^ 2 + pos.y ^ 2) * 3) * mixed_ore_multiplier[i]
+					surface.create_entity({name = ores[i], position = pos, amount = amount})
+				end
+			end
+		end
+	end
+
+	if left_top_y == -32 and math_abs(left_top_x) <= 32 then
+		for _, e in pairs(surface.find_entities_filtered({name = 'character', invert = true, area = {{-12, -12},{12, 12}}})) do e.destroy() end
+	end
+end
+
 -- generate ore on entire map for special game
 local function mixed_ore_map(surface, left_top_x, left_top_y)
 	if Functions.is_biter_area({x = left_top_x, y = left_top_y + 96}, true) then return end
@@ -129,6 +154,8 @@ local function mixed_ore_map(surface, left_top_x, left_top_y)
 		checkerboard(surface, left_top_x, left_top_y)
 	elseif type == 3 then
 		vertical_lines(surface, left_top_x, left_top_y)
+	elseif type == 4 then
+		mixed_patches(surface, left_top_x, left_top_y)
 	end
 
 	if left_top_y == -32 and math_abs(left_top_x) <= 32 then

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -435,7 +435,7 @@ function Public.generate(event)
 		mixed_ore(surface, left_top_x, left_top_y)
 	end
 	generate_river(surface, left_top_x, left_top_y)
-	draw_biter_area(surface, left_top_x, left_top_y)		
+	draw_biter_area(surface, left_top_x, left_top_y)
 	generate_extra_worm_turrets(surface, left_top)
 end
 


### PR DESCRIPTION
An option to partially cover map in mixed ore

image of before|after
![Screenshot from 2024-05-26 17-57-45](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/88335092/9e922303-cb09-43c3-b06e-89129f98335a)

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
