### PR TITLE
ping messages: fix permanent-ping from message before map reset

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -315,6 +315,15 @@ function Public.tables()
 
 	global.next_attack = "north"
 	if global.random_generator(1,2) == 1 then global.next_attack = "south" end
+
+	-- Clear all ping UIs.  Otherwise, if a map reset happens when a ping is
+	-- visible, it will be permanently visible.
+	for _, player in pairs(game.connected_players) do
+		local ping_messages = player.gui.screen.ping_messages
+		if ping_messages then ping_messages.destroy() end
+		local ping_header = player.gui.screen.ping_header
+		if ping_header then ping_header.destroy() end
+	end
 end
 
 function Public.load_spawn()

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -40,6 +40,11 @@ local function on_player_joined_game(event)
 	Functions.create_map_intro_button(player)
 	--ResearchInfo.create_research_info_button(player)
 	Team_manager.draw_top_toggle_button(player)
+
+	local ping_messages = player.gui.screen.ping_messages
+	if ping_messages then ping_messages.destroy() end
+	local ping_header = player.gui.screen.ping_header
+	if ping_header then ping_header.destroy() end
 end
 
 local function on_gui_click(event)


### PR DESCRIPTION
Before this fix, if you got a message just before a map reset, then it would stay around permanently.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
