### PR TITLE
Fix reply ping

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -277,7 +277,6 @@ local function on_console_command(event)
 		if to_player then
 			do_ping(player.name, to_player, player.name .. " (whisper): " .. rest_of_message)
 			global.reply_target[to_player_name] = player.name
-			global.reply_target[player.name] = to_player_name
 		end
 	elseif cmd == "r" or cmd == "reply" then
 		local to_player_name = global.reply_target[player.name]

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -277,10 +277,12 @@ local function on_console_command(event)
 		if to_player then
 			do_ping(player.name, to_player, player.name .. " (whisper): " .. rest_of_message)
 			global.reply_target[to_player_name] = player.name
+			global.reply_target[player.name] = to_player_name
 		end
 	elseif cmd == "r" or cmd == "reply" then
 		local to_player_name = global.reply_target[player.name]
 		if to_player_name then
+			global.reply_target[to_player_name] = player.name
 			local to_player = game.get_player(to_player_name)
 			if to_player then
 				do_ping(player.name, to_player, player.name .. " (whisper): " .. param)


### PR DESCRIPTION
Fix a bug where the wrong player was getting pinged.

To repeat the bug, 3 players run commands in the following sequence:
plater2: `/w player1`
player1: `/r`
plater3: `/w player1`
plater2: `/r` --- no ping happens for player1, only message
player1: `/r` --- ping for player3 and chat message for player2

Basically when you /whisper and then /reply to /reply, you not receive ping

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
