### PR TITLE
Random UI changes

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -109,6 +109,8 @@ local function clear_gui_captain_mode()
 			if playergui.top[gui] then playergui.top[gui].destroy() end
 		end
 		for _, gui in pairs(center_guis) do
+			-- This is a bit of a hack, but I don't want to figure out which ones are center and which ones are screen.
+			if playergui.center[gui] then playergui.center[gui].destroy() end
 			if playergui.screen[gui] then playergui.screen[gui].destroy() end
 		end
 	end

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1009,7 +1009,7 @@ function Public.draw_captain_player_gui(player)
 	l.style.single_line = false
 	local textbox = frame.add({type = "textfield", name = "captain_player_info", text = special["player_info"][player.name] or "", tooltip = "Enter any info you want the captains to see when picking players."})
 	textbox.style.horizontally_stretchable = true
-	textbox.style.minimal_width = 400
+	textbox.style.width = 0
 
 	frame.add({type = "line", name = "player_table_line"})
 	local scroll = frame.add({type = "scroll-pane", name = "player_table_scroll", direction = "vertical"})

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1429,6 +1429,10 @@ local function on_gui_text_changed(event)
 	local special = global.special_games_variables["captain_mode"]
 	if not special then return end
 	if element.name == "captain_player_info" then
+		if #element.text > 200 then
+			player.print("Info must be 200 characters or less", Color.warning)
+			element.text = string.sub(element.text, 1, 200)
+		end
 		special["player_info"][player.name] = element.text
 	end
 end

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -972,7 +972,7 @@ end
 function Public.draw_captain_player_gui(player)
 	if is_test_player(player) then return end
 	if player.gui.screen["captain_player_gui"] then player.gui.screen["captain_player_gui"].destroy() end
-	local frame = closable_frame.create_main_closable_frame(player, "captain_player_gui", "Join Info")
+	local frame = closable_frame.create_draggable_frame(player, "captain_player_gui", "Join Info")
 	frame.style.maximal_width = 800
 
 	local prepa_flow = frame.add({type = "flow", name = "prepa_flow", direction = "vertical"})

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -98,6 +98,24 @@ local function clock(frame, player)
 	frame.add { type = "line" }
 end
 
+---@param frame LuaGuiElement
+---@param force string
+local function add_player_list_element(frame, force)
+	local players_with_sort_keys = {}
+	for _, p in pairs(game.forces[force].connected_players) do
+		table.insert(players_with_sort_keys, { player = p, sort_key = string.lower(p.name) })
+	end
+	table.sort(players_with_sort_keys, function(a, b) return a.sort_key < b.sort_key end)
+	local players_with_colors = {}
+	for _, pair in ipairs(players_with_sort_keys) do
+		local p = pair.player
+		table.insert(players_with_colors, string.format("[color=%.2f,%.2f,%.2f]%s[/color]", p.color.r * 0.6 + 0.4, p.color.g * 0.6 + 0.4, p.color.b * 0.6 + 0.4, p.name))
+	end
+	local l = frame.add { type = "label", caption = table.concat(players_with_colors, "    ") }
+	l.style.single_line = false
+	l.style.maximal_width = 350
+end
+
 local function create_first_join_gui(player)
 	if not global.game_lobby_timeout then global.game_lobby_timeout = 5999940 end
 	if global.game_lobby_timeout - game.tick < 0 then global.game_lobby_active = false end
@@ -136,12 +154,7 @@ local function create_first_join_gui(player)
 			c = c .. math_ceil((global.game_lobby_timeout - game.tick) / 60)
 			c = c .. ")"
 		end
-		local t = frame.add { type = "table", column_count = 4 }
-		for _, p in pairs(game.forces[gui_value.force].connected_players) do
-			local l = t.add({ type = "label", caption = p.name })
-			l.style.font_color = { r = p.color.r * 0.6 + 0.4, g = p.color.g * 0.6 + 0.4, b = p.color.b * 0.6 + 0.4, a = 1 }
-			l.style.font = "heading-2"
-		end
+		add_player_list_element(frame, gui_value.force)
 		local b = frame.add { type = "sprite-button", name = gui_value.n1, caption = c }
 		b.style.font = "default-large-bold"
 		b.style.font_color = font_color
@@ -233,11 +246,7 @@ function Public.create_main_gui(player)
 
 		-- Player list
 		if global.bb_view_players[player.name] == true then
-			local t = frame.add { type = "table", column_count = 4 }
-			for _, p in pairs(game.forces[gui_value.force].connected_players) do
-				local l = t.add { type = "label", caption = p.name }
-				l.style.font_color = { r = p.color.r * 0.6 + 0.4, g = p.color.g * 0.6 + 0.4, b = p.color.b * 0.6 + 0.4, a = 1 }
-			end
+			add_player_list_element(frame, gui_value.force)
 		end
 
 		-- Statistics


### PR DESCRIPTION
### Brief description of the changes:
Make the "Join Info" window harder to miss in captains games.

Fix a bug in captains games where the pick-player UI could be stuck open forever after a captains event finished.

Change "playerlist" in the top-left to no longer be a table, which should handle very long player names a bit better. It is also now sorted in alphabetical order.

Captains games: add a textbox where players can give info to captains to see during the picking phase

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
