### PR TITLE
biter target behavior: attack silo on pathfinding error

### DIFF
--- a/maps/biter_battles_v2/ai_strikes.lua
+++ b/maps/biter_battles_v2/ai_strikes.lua
@@ -187,7 +187,9 @@ function Public.step(group_number, result)
                 global.ai_strikes[group_number] = nil
             end
         elseif result == defines.behavior_result.fail or result == defines.behavior_result.deleted then
-            global.ai_strikes[group_number] = nil
+            strike.phase = 3
+            local rocket_silo = global.rocket_silo[strike.target_force_name]
+            assassinate(strike.unit_group, rocket_silo)
         end
     end
 end


### PR DESCRIPTION
Before this change, if biters target something on an island, they would move to the intermediate target location and then just stay stuck there. After this change, they will just directly target the rocket silo (which should always be pathable, we hope).

This change is essentially done by Dr_Claw, but I tested it. My testing consisted of using /editor to create a large island, placing many stone furnaces on the island, turning on practice mode, sending 200 red science, and then waiting. Before this change, biters would just go to a location near the island, and then stay stuck there. After this change, they would go to a location near the island, and then go attack the silo.

If somehow a biter is unable to path to the silo, then this change might make things worse. Specifically, it might loop forever trying to path to the silo, instead of just stopping forever. However, that situation seems pretty broken either way.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
