### PR TITLE
Main gui: make buttons much more responsive

### DIFF
--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -9,13 +9,17 @@ local closable_frame = require "utils.ui.closable_frame"
 local difficulties = Tables.difficulties
 
 local function difficulty_gui(player)
+	local b = player.gui.top["difficulty_gui"]
+	if not b then
+		b = player.gui.top.add { type = "sprite-button", name = "difficulty_gui" }
+		b.style.font = "heading-2"
+		b.style.font_color = difficulties[global.difficulty_vote_index].print_color
+		gui_style(b, {width = 114, height = 38, padding = -2})
+	end
 	local value = math.floor(global.difficulty_vote_value*100)
-	if player.gui.top["difficulty_gui"] then player.gui.top["difficulty_gui"].destroy() end
 	local str = table.concat({"Global map difficulty is ", difficulties[global.difficulty_vote_index].name, ". Mutagen has ", value, "% effectiveness."})
-	local b = player.gui.top.add { type = "sprite-button", caption = difficulties[global.difficulty_vote_index].name, tooltip = str, name = "difficulty_gui" }
-	b.style.font = "heading-2"
-	b.style.font_color = difficulties[global.difficulty_vote_index].print_color
-	gui_style(b, {width = 114, height = 38, padding = -2})
+	b.caption = difficulties[global.difficulty_vote_index].name
+	b.tooltip = str
 end
 
 local function difficulty_gui_all()


### PR DESCRIPTION
Specifically, before this change, the buttons would be destroyed + recreated every few seconds. If this destroy+recreate happened between the click of a button, and the actual tick that the click is recognized by the server, then the button click would have been lost before, and now it will not be. Thus, for users with high latency connections, it was very unreliable to click "join team" or "send science" buttons. After this change, the buttons should no longer be unreliable.

Note that this means that we potentially need to deal with double-clicks of buttons like the join button. Before, this was impossible, as the button was destroyed when it was clicked, and so the game engine would ignore any subsequent clicks. Now, we only hide the button (rather than destroy it), and so the game will still potentially process multiple clicks. Thus we change join_team() to no-op if the player has already joined a team.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
