### PR TITLE
Captain event : show amount of players before the players list

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1038,7 +1038,7 @@ function Public.update_captain_player_gui(player)
 			want_to_play.visible = false
 			cpt_volunteers.visible = false
 			rem.visible = true
-			rem.caption = "Players remaining to be picked: " .. table.concat(special["listPlayers"], ", ")
+			rem.caption = #special["listPlayers"] .. " " .. "Players remaining to be picked: " .. table.concat(special["listPlayers"], ", ")
 		end
 	end
 	frame.captain_player_want_to_play.visible = false

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -864,7 +864,7 @@ function Public.update_captain_referee_gui(player)
 	else
 		caption = "Players waiting for next join poll"
 	end
-	local l = scroll.add({type = "label", caption = caption .. ": " .. get_player_list_with_groups(), ", "})
+	local l = scroll.add({type = "label", caption = #special["listPlayers"] .. " " .. caption .. ": " .. get_player_list_with_groups(), ", "})
 	l.style.single_line = false
 	scroll.add({type = "label", caption = string.format("Next auto picking phase in %ds", ticks_until_autopick / 60)})
 	if #special["listPlayers"] > 0 and not special["pickingPhase"] and not special["prepaPhase"] and ticks_until_autopick > 0 then
@@ -1030,7 +1030,7 @@ function Public.update_captain_player_gui(player)
 		local rem = prepa_flow.remaining_players_list
 		if not special["initialPickingPhaseStarted"] then
 			want_to_play.visible = true
-			want_to_play.caption = "Players: " .. get_player_list_with_groups()
+			want_to_play.caption = #special["listPlayers"] .. " Players: " .. get_player_list_with_groups()
 			cpt_volunteers.visible = true
 			cpt_volunteers.caption = "Captain volunteers: " .. table.concat(special["captainList"], ", ")
 			rem.visible = false


### PR DESCRIPTION
### Brief description of the changes:
Very small details but it would be nice to see the amount of players there are in the list to play, example : 
![image](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/95619848/ac1e4482-e7be-4bfb-a19b-21173f6c90d2)


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
