### PR TITLE
implement burners balance.

### DIFF
--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -192,6 +192,16 @@ local functions = {
 			game.print("Map Reroll is disabled!")
 		end
 	end,
+
+    ["bb_burners_balance_toggle"] = function(event)
+		if event.element.switch_state == "left" then
+			global.bb_settings.burners_balance = true
+			game.print("Burners balance is enabled!")
+		else
+			global.bb_settings.burners_balance = false
+			game.print("Burners balance is disabled!")
+		end
+	end,
 }
 
 local poll_function = {
@@ -544,6 +554,13 @@ local build_config_gui = (function(player, frame)
 			local switch_state = "right"	
             if global.bb_settings.map_reroll then switch_state = "left" end
 			local switch = add_switch(scroll_pane, switch_state, "bb_map_reroll_toggle", "Map Reroll", "Enables map reroll feature.")
+			if not admin then switch.ignored_by_interaction = true end
+			
+			scroll_pane.add({type = 'line'})
+
+			local switch_state = "right"	
+            if global.bb_settings.burners_balance then switch_state = "left" end
+			local switch = add_switch(scroll_pane, switch_state, "bb_burners_balance_toggle", "Burners balance", "Enables Burners balance.")
 			if not admin then switch.ignored_by_interaction = true end
 			
 			scroll_pane.add({type = 'line'})

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -374,6 +374,33 @@ local get_player_data = function (player, remove)
 	return global.player_data_afk[player.name]
 end
 
+function burners_balance(player)
+	if global.got_burners[player.name] then 
+		return
+	end	
+	local force = "north"
+	if player.force.name == "north" then 
+		force = "south" 
+	end
+	if #game.forces[force].connected_players == 0 then
+		return
+	end
+	local player2
+	for _, p in pairs(game.forces[force].connected_players) do
+		if not global.got_burners[p.name] then
+			player2 = p
+			break
+		end
+	end
+	if not player2 then
+		return 
+	end	
+	global.got_burners[player.name] = true
+	player.insert { name = "burner-mining-drill", count = 10 }
+	global.got_burners[player2.name] = true
+	player2.insert { name = "burner-mining-drill", count = 10 }
+end
+
 function join_team(player, force_name, forced_join, auto_join)
 	if not player.character then return end
 	if not player.spectator then return end
@@ -451,6 +478,7 @@ function join_team(player, force_name, forced_join, auto_join)
 		Server.to_discord_bold(msg)
 		global.spectator_rejoin_delay[player.name] = game.tick
 		player.spectator = false
+		burners_balance(player)
 		return
 	end
 	local pos = surface.find_non_colliding_position("character", game.forces[force_name].get_spawn_position(surface), 8,
@@ -476,11 +504,11 @@ function join_team(player, force_name, forced_join, auto_join)
 	player.insert { name = "firearm-magazine", count = 32 }
 	player.insert { name = "iron-gear-wheel", count = 8 }
 	player.insert { name = "iron-plate", count = 16 }
-	player.insert { name = "burner-mining-drill", count = 10 }
 	player.insert { name = "wood", count = 2 }
 	global.chosen_team[player.name] = force_name
 	global.spectator_rejoin_delay[player.name] = game.tick
 	player.spectator = false
+	burners_balance(player)
 	Public.clear_copy_history(player)
 	Public.refresh()
 

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -401,12 +401,12 @@ function Public.burners_balance(player)
 	if not player2 then
 		global.got_burners[player.name] = false
 		return 		
-	end			
-	local inserted
+	end				
 	local burners_to_insert = 10
 	for i = 1 , 0, -1 do
+		local inserted
 		global.got_burners[player.name] = true		
-		inserted = game.players[player.name].insert { name = "burner-mining-drill", count = burners_to_insert }	
+		inserted = player.insert { name = "burner-mining-drill", count = burners_to_insert }	
 		if inserted < burners_to_insert then
 			local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = burners_to_insert - inserted}, false, nil, false )
 		end

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -401,25 +401,19 @@ function Public.burners_balance(player)
 	if not player2 then
 		global.got_burners[player.name] = false
 		return 		
-	end		
-	local can_insert
-	global.got_burners[player.name] = true
-	can_insert = player.get_inventory(defines.inventory.character_main).get_insertable_count("burner-mining-drill")
-	player.insert { name = "burner-mining-drill", count = 10 }		
-	if can_insert < 10 then
-		local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = 10 - can_insert}, false, nil, false )
+	end			
+	local inserted
+	local burners_to_insert = 10
+	for i = 1 , 0, -1 do
+		global.got_burners[player.name] = true		
+		inserted = game.players[player.name].insert { name = "burner-mining-drill", count = burners_to_insert }	
+		if inserted < burners_to_insert then
+			local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = burners_to_insert - inserted}, false, nil, false )
+		end
+		player.print("You have received ".. burners_to_insert .. " x [item=burner-mining-drill] check inventory",{ r = 1, g = 1, b = 0 })
+		player.create_local_flying_text({text = "You have received ".. burners_to_insert .. " x [item=burner-mining-drill] check inventory", position = player.position})
+		player=player2
 	end
-	player.print("You have recived 10 burners, check inventory",{ r = 1, g = 1, b = 0 })
-	player.create_local_flying_text({text = "You have recived 10 burners, check inventory", position = player.position})
-
-	global.got_burners[player2.name] = true		
-	can_insert = player2.get_inventory(defines.inventory.character_main).get_insertable_count("burner-mining-drill")	
-	player2.insert { name = "burner-mining-drill", count = 10 }
-	if can_insert < 10 then
-		local items = player2.surface.spill_item_stack(player2.position,{name="burner-mining-drill", count = 10 - can_insert}, false, nil, false )
-	end
-	player2.print("You have recived 10 burners, check inventory",{ r = 1, g = 1, b = 0 })
-	player2.create_local_flying_text({text = "You have recived 10 burners, check inventory", position = player2.position})
 end
 
 function join_team(player, force_name, forced_join, auto_join)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -386,25 +386,40 @@ function Public.burners_balance(player)
 		player.insert { name = "burner-mining-drill", count = 10 }
 		return
 	end
-	local force = "north"
+	local enemy_force = "north"
 	if player.force.name == "north" then 
-		force = "south" 
+		enemy_force = "south" 
 	end
 	local player2
+	-- factorio Lua promises that pairs() iterates in insertion order
 	for enemy_player_name, _ in pairs(global.got_burners) do 
-		if not (global.got_burners[enemy_player_name]) and (game.get_player(enemy_player_name).force.name == force) and game.get_player(enemy_player_name).connected then
+		if not (global.got_burners[enemy_player_name]) and (game.get_player(enemy_player_name).force.name == enemy_force) and game.get_player(enemy_player_name).connected then
 			player2 = game.get_player(enemy_player_name)
 			break
 		end
 	end
 	if not player2 then
 		global.got_burners[player.name] = false
-		return 
+		return 		
 	end		
+	local can_insert
 	global.got_burners[player.name] = true
-	player.insert { name = "burner-mining-drill", count = 10 }
-	global.got_burners[player2.name] = true
+	can_insert = player.get_inventory(defines.inventory.character_main).get_insertable_count("burner-mining-drill")
+	player.insert { name = "burner-mining-drill", count = 10 }		
+	if can_insert < 10 then
+		local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = 10 - can_insert}, false, nil, false )
+	end
+	player.print("You have recived 10 burners, check inventory",{ r = 1, g = 1, b = 0 })
+	player.create_local_flying_text({text = "You have recived 10 burners, check inventory", position = player.position})
+
+	global.got_burners[player2.name] = true		
+	can_insert = player2.get_inventory(defines.inventory.character_main).get_insertable_count("burner-mining-drill")	
 	player2.insert { name = "burner-mining-drill", count = 10 }
+	if can_insert < 10 then
+		local items = player2.surface.spill_item_stack(player2.position,{name="burner-mining-drill", count = 10 - can_insert}, false, nil, false )
+	end
+	player2.print("You have recived 10 burners, check inventory",{ r = 1, g = 1, b = 0 })
+	player2.create_local_flying_text({text = "You have recived 10 burners, check inventory", position = player2.position})
 end
 
 function join_team(player, force_name, forced_join, auto_join)

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -133,6 +133,7 @@ function Public.initial_setup()
 		["new_year_island"] = false,
 		["bb_map_reveal_toggle"] = true,
 		["map_reroll"] = true,
+		["burners_balance"] = true,
 	}
 	global.want_pings = {}
 	global.want_pings_default_value = true

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -259,6 +259,7 @@ function Public.tables()
 	global.bb_threat = {}
 	global.bb_threat_income = {}
 	global.chosen_team = {}
+	global.got_burners = {}
 	global.combat_balance = {}
 	global.difficulty_player_votes = {}
 	global.evo_raise_counter = 1

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -46,6 +46,8 @@ local function on_player_joined_game(event)
 	if ping_messages then ping_messages.destroy() end
 	local ping_header = player.gui.screen.ping_header
 	if ping_header then ping_header.destroy() end
+
+	Gui.burners_balance(player)
 end
 
 local function on_gui_click(event)


### PR DESCRIPTION
### Brief description of the changes:
implementing game-vote.
https://discord.com/channels/823696400797138974/823771211421974579/1248907791087960068

how it is done.
on join or rejoin team function checks if u haven't got burners then check if in enemy team is connected player that also didn't get burners. if yes then insert 10 burners to both of you

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
