### PR TITLE
/difficulty-revote no longer resets evo after teams have fed

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -314,7 +314,8 @@ end
 
 Public.reset_evo = function()
 	-- Shouldn't reset evo if any of the teams fed. Feeding is blocked when voting is in progress.
-	if game.ticks_played >= global.difficulty_votes_timeout then return end
+	-- However, if /difficulty-revote is done late in a game, we don't want to reset evo.
+	if global.science_logs_text then return end
 
 	local amount = global.total_passive_feed_redpotion
 	if amount < 1 then return end


### PR DESCRIPTION
This means that if /difficulty-revote is run after one team has already fed, it will not reset evo of both teams (effectively undoing the feed).

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
