### PR TITLE
captains: fix picking of offline players

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -75,11 +75,18 @@ local function add_to_trust(playerName)
 end
 
 local function switchTeamOfPlayer(playerName, playerForceName)
+	if global.chosen_team[playerName] then
+		if global.chosen_team[playerName] ~= playerForceName then
+			game.print(playerName .. ' is already on ' .. global.chosen_team[playerName] .. ' and thus was not switched to ' .. playerForceName, Color.red)
+		end
+		return
+	end
 	local special = global.special_games_variables["captain_mode"]
-	if not is_test_player_name(playerName) then
-		Team_manager.switch_force(playerName, playerForceName)
-	else
+	local player = cpt_get_player(playerName)
+	if is_test_player_name(playerName) or not player.connected then
 		global.chosen_team[playerName] = playerForceName
+	else
+		Team_manager.switch_force(playerName, playerForceName)
 	end
 	local forcePickName = playerForceName .. "Picks"
 	table.insert(special["stats"][forcePickName], playerName)
@@ -170,7 +177,7 @@ end
 local function addGuiShowPlayerInfo(_finalParentGui,_button1Name,_button1Text,_pl,_groupName,_playtimePlayer)
 	local special = global.special_games_variables["captain_mode"]
 	createButton(_finalParentGui,_button1Name,_button1Text,_pl)
-	b = _finalParentGui.add({type = "label", caption = _groupName})
+	local b = _finalParentGui.add({type = "label", caption = _groupName})
 	b.style.font_color = Color.antique_white
 	b.style.font = "heading-2"
 	b.style.minimal_width = 100
@@ -187,10 +194,9 @@ local function addGuiShowPlayerInfo(_finalParentGui,_button1Name,_button1Text,_p
 end
 
 local function pickPlayerGenerator(player,tableBeingLooped,frameName,questionText,button1Text,button1Name)
-	local frame = nil
-	local finalParentGui = nil
 	if player.gui.center[frameName] then player.gui.center[frameName].destroy() return end
-	frame = player.gui.center.add { type = "frame", caption = questionText, name = frameName, direction = "vertical" }
+	local frame = player.gui.center.add { type = "frame", caption = questionText, name = frameName, direction = "vertical" }
+	local finalParentGui
 	if global.special_games_variables["captain_mode"]["captainGroupAllowed"] then
 		finalParentGui = frame.add { type = "table", column_count = 4 }
 	else
@@ -1376,7 +1382,7 @@ local function get_dropdown_value(dropdown)
 end
 
 local function check_if_enough_playtime_to_play(player)
-	return global.total_time_online_players[player.name] ~= nil and global.total_time_online_players[player.name] >= global.special_games_variables["captain_mode"]["minTotalPlaytimeToPlay"]
+	return (global.total_time_online_players[player.name] or 0) >= global.special_games_variables["captain_mode"]["minTotalPlaytimeToPlay"]
 end
 
 if false then

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -419,7 +419,7 @@ function join_team(player, force_name, forced_join, auto_join)
 				)
 				return
 			end
-			if game.tick - global.spectator_rejoin_delay[player.name] < 3600 then
+			if global.spectator_rejoin_delay[player.name] and game.tick - global.spectator_rejoin_delay[player.name] < 3600 then
 				player.print(
 					"Not ready to return to your team yet. Please wait " ..
 					60 - (math.floor((game.tick - global.spectator_rejoin_delay[player.name]) / 60)) .. " seconds.",


### PR DESCRIPTION
### Brief description of the changes:
If a player is picked when they are offline, this should now make it so that they are still a spectator, but they can "rejoin team" after they reconnect.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
