### PR TITLE
add /inventory-costs comand

### DIFF
--- a/comfy_panel/special_games/infinity_chest.lua
+++ b/comfy_panel/special_games/infinity_chest.lua
@@ -48,6 +48,14 @@ local function generate_infinity_chest(separate_chests, operable, gap, eq)
         end
     end
     global.active_special_games["infinity_chest"] = true
+    local special = global.special_games_variables["infinity_chest"]
+    if not special then
+        special = { freebies = {} }
+        global.special_games_variables["infinity_chest"] = special
+    end
+    for i, v in ipairs(eq) do
+        special.freebies[v] = true
+    end
 end
 
 local Public = {

--- a/commands.lua
+++ b/commands.lua
@@ -1,6 +1,7 @@
 require 'commands.chat_commands'
 require 'commands.difficulty_voting_commands'
 require 'commands.instant_map_reset'
+require 'commands.inventory_costs'
 require 'commands.current_map_seed'
 require 'commands.suspend'
 require 'commands.where'

--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -3,8 +3,18 @@ local ItemCosts = require 'maps.biter_battles_v2.item_costs'
 local function inventory_cost(player)
     local inventory = player.get_inventory(defines.inventory.character_main)
     local cost = 0
+    local freebies
+    if global.special_games_variables["infinity_chest"] then
+        freebies = global.special_games_variables["infinity_chest"].freebies
+    end
     for name, count in pairs(inventory.get_contents()) do
-        cost = cost + ItemCosts.get_cost(name) * count
+        local item_cost
+        if freebies and freebies[name] then
+            item_cost = 0
+        else
+            item_cost = ItemCosts.get_cost(name)
+        end
+        cost = cost + item_cost * count
     end
     return cost
 end

--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -1,0 +1,46 @@
+local ItemCosts = require 'maps.biter_battles_v2.item_costs'
+
+local function inventory_cost(player)
+    local inventory = player.get_inventory(defines.inventory.character_main)
+    local cost = 0
+    for name, count in pairs(inventory.get_contents()) do
+        cost = cost + ItemCosts.get_cost(name) * count
+    end
+    return cost
+end
+
+local function inventory_costs_for_force(force)
+    local players = {}
+    for _, player in pairs(force.players) do
+        table.insert(players, {player = player, cost = inventory_cost(player)})
+    end
+    table.sort(players, function(a, b) return a.cost > b.cost end)
+    return players
+end
+
+local function inventory_costs(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player then return end
+    local forces
+    if player.force.name == "spectator" or cmd.parameter == "all" then
+        forces = {game.forces.north, game.forces.south}
+    else
+        forces = {player.force}
+    end
+    for _, force in ipairs({game.forces.north, game.forces.south}) do
+        local players = inventory_costs_for_force(force)
+        if #forces > 1 then
+            player.print(force.name)
+        end
+        for index, entry in ipairs(players) do
+            if index > 10 then break end
+            player.print(string.format("%s: %.0f", entry.player.name, entry.cost / 10))
+        end
+    end
+end
+
+commands.add_command(
+	"inventory-costs",
+	"Print out the top players by inventory values. Pass 'all' to see it for both forces.",
+	inventory_costs
+)

--- a/maps/biter_battles_v2/feed_values_tab.lua
+++ b/maps/biter_battles_v2/feed_values_tab.lua
@@ -1,6 +1,7 @@
 -- feed values tab --
 
 local Tables = require "maps.biter_battles_v2.tables"
+local ItemCosts = require "maps.biter_battles_v2.item_costs"
 local food_values = Tables.food_values
 local food_long_and_short = Tables.food_long_and_short
 local Tabs = require 'comfy_panel.main'
@@ -10,32 +11,7 @@ local function get_science_text(food_name, food_short_name)
 end
 
 local debug = false
-
-local raw_costs = {
-    ["iron-ore"] = {cost = 10, crafting_time = 2, icon = "[item=iron-ore]"},
-    ["copper-ore"] = {cost = 10, crafting_time = 2, icon = "[item=copper-ore]"},
-    ["stone"] = {cost = 10, crafting_time = 2, icon = "[item=stone]"},
-    ["coal"] = {cost = 10, crafting_time = 2, icon = "[item=coal]"},
-
-    -- I am making uranium cost more, both because of the sulfuric acid, and
-    -- because the mining time is longer and the patches are rare.
-    ["uranium-ore"] = {cost = 20, crafting_time = 4, icon = "[item=uranium-ore]"},
-    -- Crafting time here is difficult. I am assuming a pumpjack on a 80%
-    -- yield oil spot.
-    -- The "cost" is even trickier. How to value one oil vs one ore? Most
-    -- pumpjacks will give ~8 oil/sec, vs a mining drill giving 0.5 ore/sec.
-    -- However, one oil patch can generally support at most 10-20 pumpjacks,
-    -- vs an ore patch supporting 60-100 mining drills. Also, setting up the
-    -- pumpjacks is harder than mining drills, and the pumpjacks are more
-    -- expensive than miners too.
-    --
-    -- So, all considered, I am treating a 1500% oil patch (requires ~20
-    -- pumpjacks, 8 refineries + 9 chem plants doing cracking) as cost
-    -- equivalent to 2 lanes of ore (30 miners, 48 steel furnaces).
-    -- So that is 150 oil/sec == 30 ore/sec.
-    ["crude-oil"] = {cost = 2, crafting_time = 0.1/0.8, icon = "[fluid=crude-oil]"},
-    ["water"] = {cost = 0, crafting_time = 1/1200, icon = "[fluid=water]"},
-}
+local raw_costs = ItemCosts.raw_costs
 
 local raw_cost_display_order = {
     "iron-ore",
@@ -47,181 +23,6 @@ local raw_cost_display_order = {
     -- We intentionally exclude "water" because it is very inaccurate due
     -- to not really properly estimating oil cracking
 }
-
-local recipe_productivity = {
-    ["rocket-part"] = 1.4,
-    ["processing-unit"] = 1.08,
-    ["rocket-control-unit"] = 1.08,
-    ["production-science-pack"] = 1.08,
-    ["utility-science-pack"] = 1.08,
-}
-
----@class ProductInfo
----@field raw_ingredients table<string, number>
----@field intermediates_union table<string, boolean>
----@field total_crafting_time number
-
----@return ProductInfo
-local function empty_product_info()
-    return {raw_ingredients = {}, intermediates_union = {}, total_crafting_time = 0}
-end
-
----@param a ProductInfo
----@param b ProductInfo
----@return ProductInfo
-local function add_product_infos(a, b)
-    local result = empty_product_info()
-    for k, v in pairs(a.raw_ingredients) do
-        result.raw_ingredients[k] = v
-    end
-    for k, v in pairs(b.raw_ingredients) do
-        result.raw_ingredients[k] = (result.raw_ingredients[k] or 0) + v
-    end
-    for k, _ in pairs(a.intermediates_union) do
-        result.intermediates_union[k] = true
-    end
-    for k, _ in pairs(b.intermediates_union) do
-        result.intermediates_union[k] = true
-    end
-    result.total_crafting_time = a.total_crafting_time + b.total_crafting_time
-    return result
-end
-
----@param a ProductInfo
----@param scale number
----@return ProductInfo
-local function scale_product_info(a, scale)
-    local result = empty_product_info()
-    for k, v in pairs(a.raw_ingredients) do
-        result.raw_ingredients[k] = v * scale
-    end
-    for k, _ in pairs(a.intermediates_union) do
-        result.intermediates_union[k] = true
-    end
-    result.total_crafting_time = a.total_crafting_time * scale
-    return result
-end
-
----@return table<string, ProductInfo>
-local function initial_product_infos()
-    local crude_craft_time = raw_costs["crude-oil"].crafting_time
-    local result = {
-        -- This is a bit of a hack, but for oil processing recipes, I sortof
-        -- assume that advanced oil processing is used, and that all of the
-        -- other outputs are useful, in order to come up with these costs.
-        -- Technically, the costs for each one depend on how much cracking is
-        -- needed/etc, but this is a reasonable approximation.
-        -- The total_crafting_time field is even more of a joke.
-        ["light-oil"] = {raw_ingredients = {["crude-oil"] = 1, ["water"] = 0.5}, intermediates_union = {}, total_crafting_time = 5/100 + crude_craft_time},
-        ["heavy-oil"] = {raw_ingredients = {["crude-oil"] = 1, ["water"] = 0.5}, intermediates_union = {}, total_crafting_time = 5/100 + crude_craft_time},
-        ["petroleum-gas"] = {raw_ingredients = {["crude-oil"] = 1, ["water"] = 0.5}, intermediates_union = {}, total_crafting_time = 5/100 + crude_craft_time},
-        ["steam"] = {raw_ingredients = {["water"] = 1}, intermediates_union = {}, total_crafting_time = 1/60 + raw_costs["water"].crafting_time},
-
-        -- This is assuming that light oil cracking can be used and that there
-        -- is a use for the petro.
-        ["solid-fuel"] = {raw_ingredients = {["crude-oil"] = 10}, intermediates_union = {}, total_crafting_time = 2 + 10 * crude_craft_time},
-
-        ["uranium-235"] = {raw_ingredients = {["uranium-ore"] = 30}, intermediates_union = {}, total_crafting_time = 60 + 30 * raw_costs["uranium-ore"].crafting_time},
-        ["uranium-238"] = {raw_ingredients = {["uranium-ore"] = 10}, intermediates_union = {}, total_crafting_time = 12 + 10 * raw_costs["uranium-ore"].crafting_time},
-    }
-    for raw_thing, info in pairs(raw_costs) do
-        result[raw_thing] = {raw_ingredients = {[raw_thing] = 1}, intermediates_union = {}, total_crafting_time = info.crafting_time}
-    end
-    return result
-end
-
-local get_product_info, get_product_info_uncached
-
----@param product string
----@param recipes table<string, table>
----@param cache table<string, ProductInfo>
----@return ProductInfo
-function get_product_info(product, recipes, cache)
-    if cache[product] then
-        return cache[product]
-    end
-    cache[product] = get_product_info_uncached(product, recipes, cache)
-    return cache[product]
-end
-
----@param product string
----@param recipes table<string, table>
----@param cache table<string, ProductInfo>
----@return ProductInfo
-function get_product_info_uncached(product, recipes, cache)
-    local raw_cost = raw_costs[product]
-    if raw_cost ~= nil then
-        return raw_cost
-    end
-    local recipe = recipes[product]
-    if not recipe then
-        game.print("No simple recipe for " .. product .. " assuming zero cost")
-        log("No simple recipe for " .. product .. " assuming zero cost")
-        return empty_product_info()
-    end
-    local info = empty_product_info()
-    for _, ingredient in pairs(recipe.ingredients) do
-        info = add_product_infos(info, scale_product_info(get_product_info(ingredient.name, recipes, cache), ingredient.amount))
-        if not raw_costs[ingredient.name] then
-            info.intermediates_union[ingredient.name] = true
-        end
-    end
-    local productivity = recipe_productivity[product]
-    local crafting_speed = 1
-    local category = recipe.category
-    if category == "crafting" or category == "basic-crafting" or category == "crafting-with-fluid" or category == "advanced-crafting" then
-        -- Assume Asm2
-        crafting_speed = 0.75
-    elseif category == "smelting" then
-        -- Assume steel furnaces
-        crafting_speed = 2
-        -- Assuming using coal to power the furnaces
-        info.raw_ingredients["coal"] = (info.raw_ingredients["coal"] or 0) + 0.036
-    end
-    if productivity then
-        -- Assume 2x prod1 is slowing it down
-        crafting_speed = crafting_speed * 0.9
-        info = scale_product_info(info, 1 / productivity)
-    end
-    info.total_crafting_time = info.total_crafting_time + recipe.energy / crafting_speed
-    if recipe.products[1].amount ~= 1 then
-        info = scale_product_info(info, 1 / recipe.products[1].amount)
-    end
-    if debug then
-        log("Cost of " .. product .. " is " .. serpent.block(info))
-    end
-    return info
-end
-
----@param food_names table<string, boolean>
----@return table<string, ProductInfo>
-local function find_costs(food_names)
-    local force = game.forces["spectator"]
-    local recipes = force.recipes
-    local simple_recipes = {}
-    for _, recipe in pairs(recipes) do
-        local products = recipe.products
-        if #products == 1 and products[1].name == recipe.name then
-            simple_recipes[recipe.name] = recipe
-        end
-    end
-    simple_recipes["space-science-pack"] = {
-        ingredients = {{name = "rocket-part", amount = 100}, {name = "satellite", amount = 1}},
-        products = {{name = "space-science-pack", amount = 1000}},
-        energy = 14.833 + 19.367 + 6.133 -- Time to launch rocket
-    }
-    simple_recipes["rocket-part"] = {
-        ingredients = {{name = "low-density-structure", amount = 10}, {name = "rocket-fuel", amount = 10}, {name = "rocket-control-unit", amount = 10}},
-        products = {{name = "rocket-part", amount = 1}},
-        energy = 3  -- Time to craft one rocket part
-    }
-    local result = {}
-    local cache = initial_product_infos()
-    for food_name, _ in pairs(food_names) do
-        result[food_name] = get_product_info(food_name, simple_recipes, cache)
-    end
-    return result
-end
 
 ---@param player LuaPlayer
 ---@param element LuaGuiElement
@@ -268,7 +69,7 @@ local function add_feed_values(player, element, food_product_info)
         end
         local scale = 1000/(40*60) * Tables.food_values["space-science-pack"].value / mutagen_val
         resource_efficiency_tooltip = resource_efficiency_tooltip .. string.format("\n[img=item/%s] %.2f/s       %.0f/min", food_long_and_short[i].long_name, scale, scale*60)
-        local normalized_info = scale_product_info(info, scale)
+        local normalized_info = ItemCosts.scale_product_info(info, scale)
         for _, k in ipairs(raw_cost_display_order) do
             if info.raw_ingredients[k] then
                 if resources_tooltip ~= "" then
@@ -299,10 +100,9 @@ local function build_config_gui(player, frame)
     end
     frame_feed_values.clear()
 
-    local food_product_info = global.bb_food_product_info
-    if not food_product_info then
-        food_product_info = find_costs(Tables.food_names)
-        global.bb_food_product_info = food_product_info
+    local food_product_info = {}
+    for food, _ in pairs(Tables.food_names) do
+        food_product_info[food] = ItemCosts.get_info(food)
     end
 
     add_feed_values(player, frame_feed_values, food_product_info)

--- a/maps/biter_battles_v2/item_costs.lua
+++ b/maps/biter_battles_v2/item_costs.lua
@@ -1,0 +1,251 @@
+-- feed values tab --
+
+local Tables = require "maps.biter_battles_v2.tables"
+local food_values = Tables.food_values
+local food_long_and_short = Tables.food_long_and_short
+local Tabs = require 'comfy_panel.main'
+
+local debug = false
+
+local ItemCosts = {}
+
+ItemCosts.raw_costs = {
+    ["iron-ore"] = {cost = 10, crafting_time = 2, icon = "[item=iron-ore]"},
+    ["copper-ore"] = {cost = 10, crafting_time = 2, icon = "[item=copper-ore]"},
+    ["stone"] = {cost = 10, crafting_time = 2, icon = "[item=stone]"},
+    ["coal"] = {cost = 10, crafting_time = 2, icon = "[item=coal]"},
+
+    -- I am making uranium cost more, both because of the sulfuric acid, and
+    -- because the mining time is longer and the patches are rare.
+    ["uranium-ore"] = {cost = 20, crafting_time = 4, icon = "[item=uranium-ore]"},
+    -- Crafting time here is difficult. I am assuming a pumpjack on a 80%
+    -- yield oil spot.
+    -- The "cost" is even trickier. How to value one oil vs one ore? Most
+    -- pumpjacks will give ~8 oil/sec, vs a mining drill giving 0.5 ore/sec.
+    -- However, one oil patch can generally support at most 10-20 pumpjacks,
+    -- vs an ore patch supporting 60-100 mining drills. Also, setting up the
+    -- pumpjacks is harder than mining drills, and the pumpjacks are more
+    -- expensive than miners too.
+    --
+    -- So, all considered, I am treating a 1500% oil patch (requires ~20
+    -- pumpjacks, 8 refineries + 9 chem plants doing cracking) as cost
+    -- equivalent to 2 lanes of ore (30 miners, 48 steel furnaces).
+    -- So that is 150 oil/sec == 30 ore/sec.
+    ["crude-oil"] = {cost = 2, crafting_time = 0.1/0.8, icon = "[fluid=crude-oil]"},
+    ["water"] = {cost = 0, crafting_time = 1/1200, icon = "[fluid=water]"},
+}
+
+local raw_costs = ItemCosts.raw_costs
+
+local recipe_productivity = {
+    ["rocket-part"] = 1.4,
+    ["processing-unit"] = 1.08,
+    ["rocket-control-unit"] = 1.08,
+    ["production-science-pack"] = 1.08,
+    ["utility-science-pack"] = 1.08,
+}
+
+---@class ProductInfo
+---@field raw_ingredients table<string, number>
+---@field intermediates_union table<string, boolean>
+---@field total_crafting_time number
+
+---@return ProductInfo
+local function empty_product_info()
+    return {raw_ingredients = {}, intermediates_union = {}, total_crafting_time = 0}
+end
+
+---@param a ProductInfo
+---@param b ProductInfo
+---@return ProductInfo
+local function add_product_infos(a, b)
+    local result = empty_product_info()
+    for k, v in pairs(a.raw_ingredients) do
+        result.raw_ingredients[k] = v
+    end
+    for k, v in pairs(b.raw_ingredients) do
+        result.raw_ingredients[k] = (result.raw_ingredients[k] or 0) + v
+    end
+    for k, _ in pairs(a.intermediates_union) do
+        result.intermediates_union[k] = true
+    end
+    for k, _ in pairs(b.intermediates_union) do
+        result.intermediates_union[k] = true
+    end
+    result.total_crafting_time = a.total_crafting_time + b.total_crafting_time
+    return result
+end
+
+---@param a ProductInfo
+---@param scale number
+---@return ProductInfo
+function ItemCosts.scale_product_info(a, scale)
+    local result = empty_product_info()
+    for k, v in pairs(a.raw_ingredients) do
+        result.raw_ingredients[k] = v * scale
+    end
+    for k, _ in pairs(a.intermediates_union) do
+        result.intermediates_union[k] = true
+    end
+    result.total_crafting_time = a.total_crafting_time * scale
+    return result
+end
+
+local scale_product_info = ItemCosts.scale_product_info
+
+---@return table<string, ProductInfo>
+local function initial_product_infos()
+    local crude_craft_time = raw_costs["crude-oil"].crafting_time
+    local result = {
+        -- This is a bit of a hack, but for oil processing recipes, I sortof
+        -- assume that advanced oil processing is used, and that all of the
+        -- other outputs are useful, in order to come up with these costs.
+        -- Technically, the costs for each one depend on how much cracking is
+        -- needed/etc, but this is a reasonable approximation.
+        -- The total_crafting_time field is even more of a joke.
+        ["light-oil"] = {raw_ingredients = {["crude-oil"] = 1, ["water"] = 0.5}, intermediates_union = {}, total_crafting_time = 5/100 + crude_craft_time},
+        ["heavy-oil"] = {raw_ingredients = {["crude-oil"] = 1, ["water"] = 0.5}, intermediates_union = {}, total_crafting_time = 5/100 + crude_craft_time},
+        ["petroleum-gas"] = {raw_ingredients = {["crude-oil"] = 1, ["water"] = 0.5}, intermediates_union = {}, total_crafting_time = 5/100 + crude_craft_time},
+        ["steam"] = {raw_ingredients = {["water"] = 1}, intermediates_union = {}, total_crafting_time = 1/60 + raw_costs["water"].crafting_time},
+
+        -- This is assuming that light oil cracking can be used and that there
+        -- is a use for the petro.
+        ["solid-fuel"] = {raw_ingredients = {["crude-oil"] = 10}, intermediates_union = {}, total_crafting_time = 2 + 10 * crude_craft_time},
+
+        ["uranium-235"] = {raw_ingredients = {["uranium-ore"] = 30}, intermediates_union = {}, total_crafting_time = 60 + 30 * raw_costs["uranium-ore"].crafting_time},
+        ["uranium-238"] = {raw_ingredients = {["uranium-ore"] = 10}, intermediates_union = {}, total_crafting_time = 12 + 10 * raw_costs["uranium-ore"].crafting_time},
+    }
+    for raw_thing, info in pairs(raw_costs) do
+        result[raw_thing] = {raw_ingredients = {[raw_thing] = 1}, intermediates_union = {}, total_crafting_time = info.crafting_time}
+    end
+    return result
+end
+
+local get_product_info, get_product_info_uncached
+
+---@param product string
+---@param recipes table<string, table>
+---@param cache table<string, ProductInfo>
+---@return ProductInfo
+function get_product_info(product, recipes, cache)
+    if cache[product] then
+        return cache[product]
+    end
+    cache[product] = get_product_info_uncached(product, recipes, cache)
+    return cache[product]
+end
+
+---@param product string
+---@param recipes table<string, table>
+---@param cache table<string, ProductInfo>
+---@return ProductInfo
+function get_product_info_uncached(product, recipes, cache)
+    local raw_cost = raw_costs[product]
+    if raw_cost ~= nil then
+        return raw_cost
+    end
+    local recipe = recipes[product]
+    if not recipe then
+        if product ~= "wood" and product ~= "raw-fish" then
+            game.print("No simple recipe for " .. product .. " assuming zero cost")
+            log("No simple recipe for " .. product .. " assuming zero cost")
+        end
+        return empty_product_info()
+    end
+    local info = empty_product_info()
+    for _, ingredient in pairs(recipe.ingredients) do
+        info = add_product_infos(info, scale_product_info(get_product_info(ingredient.name, recipes, cache), ingredient.amount))
+        if not raw_costs[ingredient.name] then
+            info.intermediates_union[ingredient.name] = true
+        end
+    end
+    local productivity = recipe_productivity[product]
+    local crafting_speed = 1
+    local category = recipe.category
+    if category == "crafting" or category == "basic-crafting" or category == "crafting-with-fluid" or category == "advanced-crafting" then
+        -- Assume Asm2
+        crafting_speed = 0.75
+    elseif category == "smelting" then
+        -- Assume steel furnaces
+        crafting_speed = 2
+        -- Assuming using coal to power the furnaces
+        info.raw_ingredients["coal"] = (info.raw_ingredients["coal"] or 0) + 0.036
+    end
+    if productivity then
+        -- Assume 2x prod1 is slowing it down
+        crafting_speed = crafting_speed * 0.9
+        info = scale_product_info(info, 1 / productivity)
+    end
+    info.total_crafting_time = info.total_crafting_time + recipe.energy / crafting_speed
+    if recipe.products[1].amount ~= 1 then
+        info = scale_product_info(info, 1 / recipe.products[1].amount)
+    end
+    if debug then
+        log("Cost of " .. product .. " is " .. serpent.block(info))
+    end
+    return info
+end
+
+---@return table<string, ProductInfo>
+local function find_all_costs()
+    local force = game.forces["spectator"]
+    local recipes = force.recipes
+    local simple_recipes = {}
+    local all_items = {}
+    for _, recipe in pairs(recipes) do
+        local products = recipe.products
+        if #products == 1 and (products[1].name == recipe.name or not simple_recipes[products[1].name]) then
+            simple_recipes[products[1].name] = recipe
+        end
+        for _, product in pairs(products) do
+            all_items[product.name] = true
+        end
+    end
+    simple_recipes["space-science-pack"] = {
+        ingredients = {{name = "rocket-part", amount = 100}, {name = "satellite", amount = 1}},
+        products = {{name = "space-science-pack", amount = 1000}},
+        energy = 14.833 + 19.367 + 6.133 -- Time to launch rocket
+    }
+    all_items["space-science-pack"] = true
+    simple_recipes["rocket-part"] = {
+        ingredients = {{name = "low-density-structure", amount = 10}, {name = "rocket-fuel", amount = 10}, {name = "rocket-control-unit", amount = 10}},
+        products = {{name = "rocket-part", amount = 1}},
+        energy = 3  -- Time to craft one rocket part
+    }
+    local result = {}
+    local cache = initial_product_infos()
+    for item, _ in pairs(all_items) do
+        result[item] = get_product_info(item, simple_recipes, cache)
+    end
+    for item, raw_cost in pairs(raw_costs) do
+        result[item] = {raw_ingredients = {[item] = 1}, intermediates_union = {}, total_crafting_time = raw_cost.crafting_time}
+    end
+    return result
+end
+
+---@param item_name string
+---@return ProductInfo
+function ItemCosts.get_info(item_name)
+    local item_costs = global.bb_item_costs
+    if not item_costs then
+        item_costs = find_all_costs()
+        global.bb_item_costs = item_costs
+    end
+
+    return item_costs[item_name]
+end
+
+---@param item_name string
+---@return number
+function ItemCosts.get_cost(item_name)
+    local cost = 0
+    local info = ItemCosts.get_info(item_name)
+    if info then
+        for k, v in pairs(info.raw_ingredients) do
+            cost = cost + v * raw_costs[k].cost
+        end
+    end
+    return cost
+end
+
+return ItemCosts


### PR DESCRIPTION
This should help identify people who are hoarding resources early in the game.

This also changes the infinity_chest special game to exclude items from /inventory-costs.

Note that this will only work when the infinity chests are created via this special-game codepath. Lots of snippets that admins use to create infinity chests will not do this, and thus the items will still be counted in /inventory-costs.

There is a large code refactor that is actually very simple (moving data from one file to another). It might be easiest to review this change one-commit-at-a-time, rather than all together.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
