### PR TITLE
captains: fix some weird conditions with "I do not want to play/captain"

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1411,10 +1411,11 @@ local function on_gui_click(event)
 	elseif element.name == "captain_player_do_not_want_to_play" then
 		if not special["pickingPhase"] then
 			removeStringFromTable(special["listPlayers"], player.name)
+			removeStringFromTable(special["captainList"], player.name)
 			Public.update_all_captain_player_guis()
 		end
 	elseif element.name == "captain_player_want_to_be_captain" then
-		if not special["initialPickingPhaseStarted"] and not isStringInTable(special["captainList"], player.name) then
+		if not special["initialPickingPhaseStarted"] and not isStringInTable(special["captainList"], player.name) and isStringInTable(special["listPlayers"], player.name) then
 			table.insert(special["captainList"], player.name)
 			Public.update_all_captain_player_guis()
 		end


### PR DESCRIPTION
There are two fixes here. One is straightforward, where it was odd that if you volunteered to be captain, but then said "actually, I don't want to play", you would remain as a captain volunteer.

The other is that I think that on a high latency connection, it would have been possible to do weird things (like volunteer to be captain *after* you had stated that you don't want to play) to end up in the same state.

Specifically, because we only change the visibility of these buttons, without actually destroying/recreating them, it is possible for network latency to cause clicks to appear even when the button would otherwise be disabled. Perhaps these could be fixed by checking for element.enabled in all cases, but I'm not sure.

Anyhow, I think that this should fix the issue that sticklord produced where they were volunteering to be captain but not in the list of players wanting to play.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
