### PR TITLE
burners-balance. now player drop burners when left game

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -374,7 +374,7 @@ local get_player_data = function (player, remove)
 	return global.player_data_afk[player.name]
 end
 
-local function drop_burners(player,forced_join)
+local function drop_burners(player, forced_join)
 	if forced_join then 
 		global.got_burners[player.name] = nil
 		return
@@ -382,10 +382,10 @@ local function drop_burners(player,forced_join)
 	if global.training_mode or not (global.bb_settings.burners_balance) then 		
 		return
 	end			
-	local inventory = player.get_item_count("burner-mining-drill")	
-	if not (inventory == 0) then
-    	local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = inventory}, false, nil, false )
-		player.remove_item({name="burner-mining-drill", count = inventory})
+	local burners_to_drop = player.get_item_count("burner-mining-drill")	
+	if burners_to_drop ~= 0 then
+    	local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = burners_to_drop}, false, nil, false )
+		player.remove_item({name="burner-mining-drill", count = burners_to_drop})
 	end
 end
 
@@ -575,7 +575,7 @@ function spectate(player, forced_join, stored_position)
 
 	player.driving = false
 	player.clear_cursor()
-	drop_burners(player,forced_join)
+	drop_burners(player, forced_join)
 
 	if stored_position then
 		local p_data = get_player_data(player)

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -374,6 +374,18 @@ local get_player_data = function (player, remove)
 	return global.player_data_afk[player.name]
 end
 
+local function on_player_left_game(event)
+	if global.training_mode or not (global.bb_settings.burners_balance) then 		
+		return
+	end
+	local player = game.get_player(event.player_index)
+	local inventory = player.get_item_count("burner-mining-drill")	
+	if not (inventory == 0) then
+    	local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = inventory}, false, nil, false )
+		player.remove_item({name="burner-mining-drill", count = inventory})
+	end
+end
+
 function Public.burners_balance(player)
 	if player.force.name == "spectator" then 
 		return 
@@ -740,5 +752,6 @@ end
 
 event.add(defines.events.on_gui_click, on_gui_click)
 event.add(defines.events.on_player_joined_game, on_player_joined_game)
+event.add(defines.events.on_player_left_game, on_player_left_game)
 
 return Public

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -374,16 +374,24 @@ local get_player_data = function (player, remove)
 	return global.player_data_afk[player.name]
 end
 
-local function on_player_left_game(event)
-	if global.training_mode or not (global.bb_settings.burners_balance) then 		
+local function drop_burners(player,forced_join)
+	if forced_join then 
+		global.got_burners[player.name] = nil
 		return
 	end
-	local player = game.get_player(event.player_index)
+	if global.training_mode or not (global.bb_settings.burners_balance) then 		
+		return
+	end			
 	local inventory = player.get_item_count("burner-mining-drill")	
 	if not (inventory == 0) then
     	local items = player.surface.spill_item_stack(player.position,{name="burner-mining-drill", count = inventory}, false, nil, false )
 		player.remove_item({name="burner-mining-drill", count = inventory})
 	end
+end
+
+local function on_player_left_game(event)
+	local player = game.get_player(event.player_index)
+	drop_burners(player)
 end
 
 function Public.burners_balance(player)
@@ -567,6 +575,7 @@ function spectate(player, forced_join, stored_position)
 
 	player.driving = false
 	player.clear_cursor()
+	drop_burners(player,forced_join)
 
 	if stored_position then
 		local p_data = get_player_data(player)


### PR DESCRIPTION
### Brief description of the changes:
Player will spill all his burners on surface on_player_left_game

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
