### PR TITLE
feat(captains): order and colorize player names in info panels

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -14,6 +14,7 @@ local CaptainRandomPick = require 'comfy_panel.special_games.captain_random_pick
 local math_random = math.random
 local closable_frame = require "utils.ui.closable_frame"
 local bb_diff = require "maps.biter_battles_v2.difficulty_vote"
+local player_utils = require "utils.player"
 
 local Public = {
     name = {type = "label", caption = "Captain event", tooltip = "Captain event"},
@@ -773,11 +774,11 @@ end
 
 local function get_player_list_with_groups()
 	local special = global.special_games_variables["captain_mode"]
-	local result = table.concat(special["listPlayers"], ", ")
+	local result = table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["listPlayers"])), ", ")
 	local groups = generate_groups(special["listPlayers"])
 	local group_strings = {}
 	for _, group in pairs(groups) do
-		table.insert(group_strings, "(" .. table.concat(group, ", ") .. ")")
+		table.insert(group_strings, "(" .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(group)), ", ") .. ")")
 	end
 	if #group_strings > 0 then
 		result = result .. "\nGroups: " .. table.concat(group_strings, ", ")
@@ -832,7 +833,7 @@ function Public.update_captain_referee_gui(player)
 	end
 
 	if special["prepaPhase"] and not special["initialPickingPhaseStarted"] then
-		scroll.add({type = "label", caption = "Captain volunteers: " .. table.concat(special["captainList"], ", ")})
+		scroll.add({type = "label", caption = "Captain volunteers: " .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["captainList"])), ", ")})
 		-- turn listPlayers into a map for efficiency
 		local players = {}
 		for _, player in pairs(special["listPlayers"]) do
@@ -958,7 +959,7 @@ function Public.draw_captain_player_gui(player)
 	l = frame.add({type = "label", name = "status_label"})
 	l.style.single_line = false
 
-	frame.add({type = "line"})
+	frame.add({type = "line", name = "captain_player_buttons_line"})
 	local want_to_play_row = frame.add({type = "table", name = "captain_player_want_to_play_row", column_count = 2})
 	local b = want_to_play_row.add({type = "button", name = "captain_player_want_to_play", caption = "I want to be a PLAYER!", style = "confirm_button", tooltip = "Yay"})
 	b.style.font = "heading-2"
@@ -1002,15 +1003,16 @@ function Public.update_captain_player_gui(player)
 			want_to_play.visible = true
 			want_to_play.caption = "Players (" .. #special["listPlayers"] .. "): " .. get_player_list_with_groups()
 			cpt_volunteers.visible = true
-			cpt_volunteers.caption = "Captain volunteers (" .. #special["captainList"] .. "): " .. table.concat(special["captainList"], ", ")
+			cpt_volunteers.caption = "Captain volunteers (" .. #special["captainList"] .. "): " .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["captainList"])), ", ")
 			rem.visible = false
 		else
 			want_to_play.visible = false
 			cpt_volunteers.visible = false
 			rem.visible = true
-			rem.caption = #special["listPlayers"] .. " " .. "Players remaining to be picked: " .. table.concat(special["listPlayers"], ", ")
+			rem.caption = "Players remaining to be picked (" .. #special["listPlayers"] .. "): " .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["listPlayers"])), ", ")
 		end
 	end
+	frame.captain_player_buttons_line.visible = false
 	frame.captain_player_want_to_play_row.captain_player_want_to_play.visible = false
 	frame.captain_player_want_to_play_row.captain_player_do_not_want_to_play.visible = false
 	frame.captain_player_want_to_be_captain_row.captain_player_want_to_be_captain.visible = false
@@ -1032,6 +1034,7 @@ function Public.update_captain_player_gui(player)
 		frame.captain_player_info_flow.visible = false
 	end
 	if not global.chosen_team[player.name] and not special["pickingPhase"] and not special["kickedPlayers"][player.name] then
+		frame.captain_player_buttons_line.visible = true
 		frame.captain_player_want_to_play_row.captain_player_want_to_play.visible = true
 		frame.captain_player_want_to_play_row.captain_player_want_to_play.enabled = not waiting_to_be_picked
 		frame.captain_player_want_to_play_row.captain_player_do_not_want_to_play.visible = true
@@ -1044,6 +1047,7 @@ function Public.update_captain_player_gui(player)
 				table.insert(status_strings, 'Groups of players: DISABLED')
 			end
 
+			frame.captain_player_buttons_line.visible = true
 			frame.captain_player_want_to_be_captain_row.captain_player_want_to_be_captain.visible = true
 			frame.captain_player_want_to_be_captain_row.captain_player_do_not_want_to_be_captain.visible = true
 			if isStringInTable(special["captainList"], player.name) then

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -68,6 +68,12 @@ local function removeStringFromTable(tab, str)
     end
 end
 
+---@param names string[]
+---@return string
+local function pretty_print_player_list(names)
+	return table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(names)), ", ")
+end
+
 local function add_to_trust(playerName)
 	if global.special_games_variables["captain_mode"]["autoTrust"] then
 		local trusted = session.get_trusted_table()
@@ -774,11 +780,11 @@ end
 
 local function get_player_list_with_groups()
 	local special = global.special_games_variables["captain_mode"]
-	local result = table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["listPlayers"])), ", ")
+	local result = pretty_print_player_list(special["listPlayers"])
 	local groups = generate_groups(special["listPlayers"])
 	local group_strings = {}
 	for _, group in pairs(groups) do
-		table.insert(group_strings, "(" .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(group)), ", ") .. ")")
+		table.insert(group_strings, "(" .. pretty_print_player_list(group) .. ")")
 	end
 	if #group_strings > 0 then
 		result = result .. "\nGroups: " .. table.concat(group_strings, ", ")
@@ -833,7 +839,7 @@ function Public.update_captain_referee_gui(player)
 	end
 
 	if special["prepaPhase"] and not special["initialPickingPhaseStarted"] then
-		scroll.add({type = "label", caption = "Captain volunteers: " .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["captainList"])), ", ")})
+		scroll.add({type = "label", caption = "Captain volunteers: " .. pretty_print_player_list(special["captainList"])})
 		-- turn listPlayers into a map for efficiency
 		local players = {}
 		for _, player in pairs(special["listPlayers"]) do
@@ -1003,13 +1009,13 @@ function Public.update_captain_player_gui(player)
 			want_to_play.visible = true
 			want_to_play.caption = "Players (" .. #special["listPlayers"] .. "): " .. get_player_list_with_groups()
 			cpt_volunteers.visible = true
-			cpt_volunteers.caption = "Captain volunteers (" .. #special["captainList"] .. "): " .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["captainList"])), ", ")
+			cpt_volunteers.caption = "Captain volunteers (" .. #special["captainList"] .. "): " .. pretty_print_player_list(special["captainList"])
 			rem.visible = false
 		else
 			want_to_play.visible = false
 			cpt_volunteers.visible = false
 			rem.visible = true
-			rem.caption = "Players remaining to be picked (" .. #special["listPlayers"] .. "): " .. table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(special["listPlayers"])), ", ")
+			rem.caption = "Players remaining to be picked (" .. #special["listPlayers"] .. "): " .. pretty_print_player_list(special["listPlayers"])
 		end
 	end
 	frame.captain_player_buttons_line.visible = false

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -10,6 +10,7 @@ local Feeding = require "maps.biter_battles_v2.feeding"
 local ResearchInfo = require "maps.biter_battles_v2.research_info"
 local Tables = require "maps.biter_battles_v2.tables"
 local Captain_event = require "comfy_panel.special_games.captain"
+local player_utils = require "utils.player"
 
 local wait_messages = Tables.wait_messages
 local food_names = Tables.gui_foods
@@ -109,16 +110,7 @@ end
 ---@param force string
 ---@return string
 local function get_player_list_caption(frame, force)
-	local players_with_sort_keys = {}
-	for _, p in pairs(game.forces[force].connected_players) do
-		table.insert(players_with_sort_keys, { player = p, sort_key = string.lower(p.name) })
-	end
-	table.sort(players_with_sort_keys, function(a, b) return a.sort_key < b.sort_key end)
-	local players_with_colors = {}
-	for _, pair in ipairs(players_with_sort_keys) do
-		local p = pair.player
-		table.insert(players_with_colors, string.format("[color=%.2f,%.2f,%.2f]%s[/color]", p.color.r * 0.6 + 0.4, p.color.g * 0.6 + 0.4, p.color.b * 0.6 + 0.4, p.name))
-	end
+	local players_with_colors = player_utils.get_sorted_colored_player_list(game.forces[force].connected_players)
 	return table.concat(players_with_colors, "    ")
 end
 

--- a/utils/player.lua
+++ b/utils/player.lua
@@ -1,6 +1,6 @@
 local Public = {}
 
----@param player_list LuaPlayer
+---@param player_list LuaPlayer[]
 ---@return string[]
 function Public.get_sorted_colored_player_list(player_list)
 	local players_with_sort_keys = {}
@@ -19,13 +19,13 @@ function Public.get_sorted_colored_player_list(player_list)
 end
 
 ---@param names string[]
----@return LuaPlayer
+---@return LuaPlayer[]
 function Public.get_lua_players_from_player_names(names)
-  local players = {}
-  for _, name in pairs(names) do
-    table.insert(players, game.players[name])
-  end
-  return players
+	local players = {}
+	for _, name in pairs(names) do
+		table.insert(players, game.players[name])
+	end
+	return players
 end
 
 return Public

--- a/utils/player.lua
+++ b/utils/player.lua
@@ -1,0 +1,31 @@
+local Public = {}
+
+---@param player_list LuaPlayer
+---@return string[]
+function Public.get_sorted_colored_player_list(player_list)
+	local players_with_sort_keys = {}
+	for _, p in pairs(player_list) do
+		table.insert(players_with_sort_keys, { player = p, sort_key = string.lower(p.name) })
+	end
+	table.sort(players_with_sort_keys, function(a, b) return a.sort_key < b.sort_key end)
+
+	local players_with_colors = {}
+	for _, pair in ipairs(players_with_sort_keys) do
+		local p = pair.player
+		table.insert(players_with_colors, string.format("[color=%.2f,%.2f,%.2f]%s[/color]", p.color.r * 0.6 + 0.4, p.color.g * 0.6 + 0.4, p.color.b * 0.6 + 0.4, p.name))
+	end
+
+	return players_with_colors
+end
+
+---@param names string[]
+---@return LuaPlayer
+function Public.get_lua_players_from_player_names(names)
+  local players = {}
+  for _, name in pairs(names) do
+    table.insert(players, game.players[name])
+  end
+  return players
+end
+
+return Public


### PR DESCRIPTION
### Brief description of the changes:
- extracted function from the main player list gui
- sort + colorize player names in captain game info panels

### Screenshots:
![Screenshot 2024-07-09 194856](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/assets/5616556/67633d28-e784-47c9-82b7-1db97d8a5c67)


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
