### PR TITLE
End game stats UI

### DIFF
--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -1,4 +1,5 @@
 local ItemCosts = require 'maps.biter_battles_v2.item_costs'
+local safe_wrap_with_player_print = require 'utils.utils'.safe_wrap_with_player_print
 
 local function inventory_cost(player)
     local inventory = player.get_inventory(defines.inventory.character_main)
@@ -50,8 +51,14 @@ local function inventory_costs(cmd)
     end
 end
 
+local function inventory_costs_command(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player then return end
+    safe_wrap_with_player_print(player, inventory_costs, cmd)
+end
+
 commands.add_command(
 	"inventory-costs",
 	"Print out the top players by inventory values. Pass 'all' to see it for both forces.",
-	inventory_costs
+	inventory_costs_command
 )

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -9,6 +9,7 @@ local force_translation = tables.force_translation
 local enemy_team_of = tables.enemy_team_of
 local math_floor = math.floor
 local math_round = math.round
+local safe_wrap_with_player_print = require "utils.utils".safe_wrap_with_player_print
 
 local Public = {}
 
@@ -310,10 +311,8 @@ local function calc_send(cmd)
 		player = game.get_player(cmd.player_index)
 	end
 	local player_count = #game.forces.north.connected_players + #game.forces.south.connected_players
-	local call_succeeded, result = pcall(FeedingCalculations.calc_send_command, cmd.parameter, global.difficulty_vote_value, global.bb_evolution, global.max_reanim_thresh, global.training_mode, player_count, player)
-	if not call_succeeded then
-		log(string.format("Error in calc_send: %q  parameter: %q", result, cmd.parameter))
-	end
+	local result = safe_wrap_with_player_print(player, FeedingCalculations.calc_send_command, cmd.parameter, global.difficulty_vote_value, global.bb_evolution, global.max_reanim_thresh, global.training_mode, player_count, player)
+	if not result then return end
 	if player then
 		player.print(result)
 	else

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -10,6 +10,7 @@ local Event = require 'utils.event'
 local Tables = require 'maps.biter_battles_v2.tables'
 local Token = require 'utils.token'
 local Task = require 'utils.task'
+local team_stats_compare = require 'maps.biter_battles_v2.team_stats_compare'
 local math_random = math.random
 local gui_style = require 'utils.utils'.gui_style
 
@@ -409,16 +410,16 @@ function Public.silo_death(event)
     if entity.name ~= "rocket-silo" then return end
     if global.bb_game_won_by_team then return end
     if entity == global.rocket_silo.south or entity == global.rocket_silo.north then
-
         -- Respawn Silo in case of friendly fire
-	if not biter_killed_the_silo(event) then
-	    respawn_silo(event)
+        if not biter_killed_the_silo(event) then
+            respawn_silo(event)
             return
         end
 
         global.bb_game_won_by_team = enemy_team_of[entity.force.name]
 
         set_victory_time()
+        team_stats_compare.game_over()
 		north_players = "NORTH PLAYERS: \\n"
 		south_players = "SOUTH PLAYERS: \\n"
 		

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -8,6 +8,7 @@ local event = require "utils.event"
 local Functions = require "maps.biter_battles_v2.functions"
 local Feeding = require "maps.biter_battles_v2.feeding"
 local ResearchInfo = require "maps.biter_battles_v2.research_info"
+local TeamStatsCompare = require "maps.biter_battles_v2.team_stats_compare"
 local Tables = require "maps.biter_battles_v2.tables"
 local Captain_event = require "comfy_panel.special_games.captain"
 local player_utils = require "utils.player"
@@ -114,8 +115,9 @@ local function get_player_list_caption(frame, force)
 	return table.concat(players_with_colors, "    ")
 end
 
-local function show_pretty_threat(forceName)
-	local threat_value = global.bb_threat[forceName]
+---@param threat_value number
+---@return string
+function threat_to_pretty_string(threat_value)
 	if math_abs(threat_value) >= 1000000 then
 		return string.format("%.2fM", threat_value / 1000000)
 	elseif math_abs(threat_value) >= 100000 then
@@ -192,7 +194,7 @@ function Public.create_main_gui(player)
 		local l = t.add { type = "label", name = "threat_label_" .. gui_value.force, caption = "Threat: " }
 		l.style.minimal_width = 25
 
-		local threat_value = show_pretty_threat(gui_value.biter_force)
+		local threat_value = threat_to_pretty_string(global.bb_threat[gui_value.biter_force])
 		local l = t.add { type = "label", name = "threat_" .. gui_value.force, caption = threat_value }
 		l.style.font_color = gui_value.color2
 		l.style.font = "default-bold"
@@ -313,7 +315,7 @@ function Public.refresh_main_gui(player)
 		t["threat_label_" .. gui_value.force].tooltip = gui_value.t2
 
 		local l = t["threat_" .. gui_value.force]
-		local threat_value = show_pretty_threat(gui_value.biter_force)
+		local threat_value = threat_to_pretty_string(global.bb_threat[gui_value.biter_force])
 		l.caption = threat_value
 		l.tooltip = gui_value.t2
 
@@ -342,8 +344,8 @@ end
 
 function Public.refresh_threat()
 	if global.gui_refresh_delay > game.tick then return end
-	local north_threat_text = show_pretty_threat("north_biters")
-	local south_threat_text = show_pretty_threat("south_biters")
+	local north_threat_text = threat_to_pretty_string(global.bb_threat["north_biters"])
+	local south_threat_text = threat_to_pretty_string(global.bb_threat["south_biters"])
 	for _, player in pairs(game.connected_players) do
 		if player.gui.left["bb_main_gui"] then
 			if player.gui.left["bb_main_gui"].stats_north then

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -219,6 +219,8 @@ function Public.tables()
 	global.science_logs_text = nil
 	global.science_logs_total_north = nil
 	global.science_logs_total_south = nil
+	---@type TeamStats
+	global.team_stats = {forces = {north = {items = {}, food = {}, damage_types = {}}, south = {items = {}, food = {}, damage_types = {}}}}
 	-- Name of main BB surface within game.surfaces
 	-- We hot-swap here between 2 surfaces.
 	if global.bb_surface_name == 'bb0' then

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -138,13 +138,13 @@ Public.spawn_ore = {
 
 Public.difficulties = {
 	
-	[1] = {name = "I'm Too Young to Die", str = "25%", value = 0.25, color = {r=0.00, g=0.45, b=0.00}, print_color = {r=0.00, g=0.9, b=0.00}},
-	[2] = {name = "Piece of Cake", str = "50%", value = 0.5, color = {r=0.00, g=0.35, b=0.00}, print_color = {r=0.00, g=0.7, b=0.00}},
-	[3] = {name = "Easy", str = "75%", value = 0.75, color = {r=0.00, g=0.25, b=0.00}, print_color = {r=0.00, g=0.5, b=0.00}},
-	[4] = {name = "Normal", str = "100%", value = 1, color = {r=0.00, g=0.00, b=0.25}, print_color = {r=0.0, g=0.0, b=0.7}},
-	[5] = {name = "Hard", str = "150%", value = 1.5, color = {r=0.25, g=0.00, b=0.00}, print_color = {r=0.5, g=0.0, b=0.00}},
-	[6] = {name = "Nightmare", str = "300%", value = 3, color = {r=0.35, g=0.00, b=0.00}, print_color = {r=0.7, g=0.0, b=0.00}},
-	[7] = {name = "Fun and Fast", str = "500%", value = 5, color = {r=0.55, g=0.00, b=0.00}, print_color = {r=0.9, g=0.0, b=0.00}}
+	[1] = {name = "I'm Too Young to Die", short_name = "ITYTD", str = "25%", value = 0.25, color = {r=0.00, g=0.45, b=0.00}, print_color = {r=0.00, g=0.9, b=0.00}},
+	[2] = {name = "Piece of Cake", short_name = "PoC", str = "50%", value = 0.5, color = {r=0.00, g=0.35, b=0.00}, print_color = {r=0.00, g=0.7, b=0.00}},
+	[3] = {name = "Easy", short_name = "Easy", str = "75%", value = 0.75, color = {r=0.00, g=0.25, b=0.00}, print_color = {r=0.00, g=0.5, b=0.00}},
+	[4] = {name = "Normal", short_name = "Normal", str = "100%", value = 1, color = {r=0.00, g=0.00, b=0.25}, print_color = {r=0.0, g=0.0, b=0.7}},
+	[5] = {name = "Hard", short_name = "Hard", str = "150%", value = 1.5, color = {r=0.25, g=0.00, b=0.00}, print_color = {r=0.5, g=0.0, b=0.00}},
+	[6] = {name = "Nightmare", short_name = "Nightmare", str = "300%", value = 3, color = {r=0.35, g=0.00, b=0.00}, print_color = {r=0.7, g=0.0, b=0.00}},
+	[7] = {name = "Fun and Fast", short_name = "FnF", str = "500%", value = 5, color = {r=0.55, g=0.00, b=0.00}, print_color = {r=0.9, g=0.0, b=0.00}}
 }
 
 Public.forces_list = { "all teams", "north", "south" }

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -27,18 +27,19 @@ TeamStatsCollect.items_to_show_summaries_of = {
     {item = "stone"},
     {item = "iron-plate"},
     {item = "copper-plate"},
-    {item = "steel-plate"},
+    {item = "steel-plate", space_after = true},
 
     {item = "electronic-circuit"},
     {item = "advanced-circuit"},
-    {item = "processing-unit"},
+    {item = "processing-unit", space_after = true},
 
     {item = "transport-belt", placed = true},
-    {item = "fast-transport-belt", placed = true},
+    {item = "fast-transport-belt", placed = true, space_after = true},
 
     {item = "roboport", placed = true},
     {item = "construction-robot"},
-    {item = "nuclear-reactor", placed = true},
+    {item = "nuclear-reactor", placed = true, space_after = true},
+
     {item = "stone-wall", placed = true},
     {item = "gun-turret", placed = true},
     {item = "flamethrower-turret", placed = true},

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -1,0 +1,217 @@
+
+local TeamStatsCollect = {}
+
+local functions = require 'maps.biter_battles_v2.functions'
+local tables = require 'maps.biter_battles_v2.tables'
+local event = require 'utils.event'
+
+---@class ForceStats
+---@field final_evo? number
+---@field peak_threat? number
+---@field lowest_threat? number
+-- player_ticks / ticks = average players
+---@field player_ticks? integer
+---@field total_players? integer
+---@field max_players? integer
+---@field food table<string, {first_at?: integer, produced: number, consumed: number, sent: number}>
+---@field items table<string, {first_at?: integer, produced?: number, placed?: number, lost?: number}>
+---@field damage_types table<string, {kills?: integer, damage?: number}>
+
+---@class TeamStats
+---@field forces table<string, ForceStats>
+---@field ticks integer?
+---@field won_by_team string?
+
+TeamStatsCollect.items_to_show_summaries_of = {
+    {item = "coal"},
+    {item = "stone"},
+    {item = "iron-plate"},
+    {item = "copper-plate"},
+    {item = "steel-plate"},
+
+    {item = "electronic-circuit"},
+    {item = "advanced-circuit"},
+    {item = "processing-unit"},
+
+    {item = "transport-belt", placed = true},
+    {item = "fast-transport-belt", placed = true},
+
+    {item = "roboport", placed = true},
+    {item = "construction-robot"},
+    {item = "nuclear-reactor", placed = true},
+    {item = "stone-wall", placed = true},
+    {item = "gun-turret", placed = true},
+    {item = "flamethrower-turret", placed = true},
+    {item = "laser-turret", placed = true},
+}
+
+TeamStatsCollect.damage_render_info = {
+    {"physical", "Physical [item=gun-turret][item=submachine-gun][item=defender-capsule]", "Also [item=shotgun-shell][item=cannon-shell] etc"},
+    {"explosion", "Explosion [item=grenade]", "Also [item=explosive-cannon-shell][item=explosive-rocket][item=cluster-grenade] etc"},
+    {"laser", "Laser [item=laser-turret]"},
+    {"fire", "Fire [item=flamethrower-turret]", "Also [item=flamethrower]"},
+    {"electric", "Electric [item=discharge-defense-equipment][item=destroyer-capsule]"},
+    {"poison", "Poison [item=poison-capsule]"},
+    {"impact", "Impact [item=locomotive][item=car][item=tank]"},
+}
+
+local function update_teamstats()
+    local team_stats = global.team_stats
+    local tick = functions.get_ticks_since_game_start()
+    if team_stats.won_by_team then return end
+    team_stats.won_by_team = global.bb_game_won_by_team
+    local prev_ticks = team_stats.ticks or 0
+    team_stats.ticks = tick
+    local total_players = {north = 0, south = 0}
+    for _, force_name in pairs(global.chosen_team) do
+        total_players[force_name] = (total_players[force_name] or 0) + 1
+    end
+    for _, force_name in ipairs({"north", "south"}) do
+        local force = game.forces[force_name]
+        local biter_force_name = force_name .. "_biters"
+        local force_stats = team_stats.forces[force_name]
+        local threat = global.bb_threat[biter_force_name]
+        force_stats.final_evo = global.bb_evolution[biter_force_name]
+        force_stats.peak_threat = (force_stats.peak_threat and math.max(threat, force_stats.peak_threat) or threat)
+        force_stats.lowest_threat = (force_stats.lowest_threat and math.min(threat, force_stats.lowest_threat) or threat)
+        force_stats.total_players = total_players[force_name]
+        force_stats.player_ticks = (force_stats.player_ticks or 0) + #force.connected_players * (tick - prev_ticks)
+        force_stats.max_players = math.max(force_stats.max_players or 0, #force.connected_players)
+        local item_prod = force.item_production_statistics
+        --local item_prod_inputs = item_prod.input_counts
+        --log(serpent.line(item_prod_inputs))
+        local build_stat = force.entity_build_count_statistics
+        local kill_stat = force.kill_count_statistics
+        for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
+            local item_stat = force_stats.items[item_info.item]
+            if not item_stat then
+                item_stat = {}
+                force_stats.items[item_info.item] = item_stat
+            end
+            item_stat.produced = item_prod.get_input_count(item_info.item)
+            if not item_stat.first_at and item_stat.produced and item_stat.produced > 0 then
+                item_stat.first_at = tick
+            end
+            if item_info.placed then
+                local item_build_stat = build_stat.get_input_count(item_info.item)
+                if (item_build_stat or 0) > 0 then
+                    -- we subtract out the number deconstructed, so this is really a max-net-placed-over-time
+                    local net_built = item_build_stat - build_stat.get_output_count(item_info.item)
+                    item_stat.placed = math.max(0, item_stat.placed or 0, net_built)
+                end
+                local kill_count = kill_stat.get_output_count(item_info.item)
+                if (kill_count or 0) > 0 then
+                    item_stat.lost = kill_count
+                end
+            end
+        end
+        local science_logs = global["science_logs_total_" .. force_name]
+        for idx, info in ipairs(tables.food_long_and_short) do
+            local food_stat = force_stats.food[info.long_name]
+            if not food_stat then
+                food_stat = {}
+                force_stats.food[info.long_name] = food_stat
+            end
+            food_stat.sent = science_logs and science_logs[idx] or 0
+            food_stat.produced = item_prod.get_input_count(info.long_name)
+            food_stat.consumed = item_prod.get_output_count(info.long_name)
+            if not food_stat.first_at and (food_stat.produced or 0) > 0 then
+                food_stat.first_at = tick
+            end
+        end
+    end
+end
+
+---@return TeamStats
+function TeamStatsCollect.compute_stats()
+    if not global.team_stats_use_fake_data then
+        update_teamstats()
+        return global.team_stats
+    end
+    local teams = {"north", "south"}
+    ---@type TeamStats
+    local stats = { ticks = 110*3600, won_by_team = teams[math.random(1, 3)], forces = {} }
+    for idx, force_name in ipairs({"north", "south"}) do
+        ---@type ForceStats
+        local force_stats = {
+            final_evo = idx * 0.55,
+            peak_threat = idx * 100000,
+            lowest_threat = idx * -10000,
+            total_players = idx * 20,
+            max_players = idx * 10,
+            player_ticks = math.random() * stats.ticks * 10,
+            food = {
+                ["automation-science-pack"] = {first_at = idx * 10*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+                ["logistic-science-pack"] = {first_at = idx * 20*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+                ["military-science-pack"] = {first_at = idx * 30*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+                ["chemical-science-pack"] = {first_at = idx * 40*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+                ["production-science-pack"] = {first_at = idx * 50*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+                ["utility-science-pack"] = {first_at = idx * 60*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+                ["space-science-pack"] = {first_at = idx * 70*3600, produced = idx * 1000, consumed = idx * 500, sent = idx * 200},
+            },
+            items = {},
+            damage_types = {},
+        }
+        for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
+            force_stats.items[item_info.item] = {
+                first_at = math.floor(math.random() * 100*3600),
+                produced = math.random(1, 10000000),
+            }
+            if item_info.placed then
+                force_stats.items[item_info.item].placed = math.random(1, force_stats.items[item_info.item].produced)
+            end
+        end
+        for _, damage_info in ipairs(TeamStatsCollect.damage_render_info) do
+            if math.random() < 0.5 then
+                force_stats.damage_types[damage_info[1]] = {
+                    kills = math.random(1, 1000),
+                    damage = math.random(1, 10000000),
+                }
+            end
+        end
+        stats.forces[force_name] = force_stats
+    end
+    return stats
+end
+
+---@param event EventData.on_entity_died
+local function on_entity_died(event)
+    local entity = event.entity
+    if not entity.valid then return end
+    if not event.damage_type then return end
+    local force_name, biter_force_name
+    local health_factor = 1
+    if entity.force.name == "north_biters" or entity.force.name == "north_biters_boss" then
+        force_name = "north"
+        biter_force_name = "north_biters"
+        if entity.force.name == "north_biters_boss" then health_factor = health_factor * 20 end
+    elseif entity.force.name == "south_biters" or entity.force.name == "south_biters_boss" then
+        force_name = "south"
+        biter_force_name = "south_biters"
+        if entity.force.name == "south_biters_boss" then health_factor = health_factor * 20 end
+    else
+        return
+    end
+    health_factor = health_factor / (1 - global.reanim_chance[game.forces[biter_force_name].index] / 100)
+
+    local force_stats = global.team_stats.forces[force_name]
+    local damage_stats = force_stats.damage_types[event.damage_type.name]
+    if not damage_stats then
+        damage_stats = {kills = 0, damage = 0}
+        force_stats.damage_types[event.damage_type.name] = damage_stats
+    end
+    damage_stats.kills = damage_stats.kills + 1
+    -- This is somewhat inaccurate, because revive% might be different
+    -- now than when the biter was spawned, but it is close enough for me.
+    damage_stats.damage = damage_stats.damage + entity.prototype.max_health * health_factor
+end
+
+-- We could theoretically collect just once per minute, but this collection will not be
+-- aligned to game time.  Thus we collect every 16 seconds instead, which will make the
+-- numbers a bit more accurate (i.e. off by at most 16 seconds, instead of off by at
+-- most 60 seconds).
+event.on_nth_tick(60 * 16, update_teamstats)
+
+event.add(defines.events.on_entity_died, on_entity_died)
+
+return TeamStatsCollect

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -130,6 +130,9 @@ function TeamStatsCollect.compute_stats()
         update_teamstats()
         return global.team_stats
     end
+
+    -- In the (very uncommon) case of team_stats_use_fake_data being set, we will generate fake data for
+    -- testing the UI.
     local teams = {"north", "south"}
     ---@type TeamStats
     local stats = { ticks = 110*3600, won_by_team = teams[math.random(1, 3)], forces = {} }
@@ -212,7 +215,9 @@ end
 -- aligned to game time.  Thus we collect every 16 seconds instead, which will make the
 -- numbers a bit more accurate (i.e. off by at most 16 seconds, instead of off by at
 -- most 60 seconds).
-event.on_nth_tick(60 * 16, update_teamstats)
+-- I use (60*16-1) rather than 60*16 just to avoid doing extra work on per-second boundaries,
+-- which are quite common in our code.
+event.on_nth_tick(60 * 16 - 1, update_teamstats)
 
 event.add(defines.events.on_entity_died, on_entity_died)
 

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -59,6 +59,7 @@ TeamStatsCollect.damage_render_info = {
 local function update_teamstats()
     local team_stats = global.team_stats
     local tick = functions.get_ticks_since_game_start()
+    if tick == 0 then return end
     if team_stats.won_by_team then return end
     team_stats.won_by_team = global.bb_game_won_by_team
     local prev_ticks = team_stats.ticks or 0

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -6,21 +6,24 @@ local closable_frame = require "utils.ui.closable_frame"
 local TeamStatsCollect = require 'maps.biter_battles_v2.team_stats_collect'
 local safe_wrap_with_player_print = require 'utils.utils'.safe_wrap_with_player_print
 local gui_style = require 'utils.utils'.gui_style
-local tables    = require 'maps.biter_battles_v2.tables'
+local tables = require 'maps.biter_battles_v2.tables'
+
+local math_floor = math.floor
+local string_format = string.format
 
 local TeamStatsCompare = {}
 
 local function ticks_to_hh_mm(ticks)
-    local total_minutes = math.floor(ticks / (60 * 60))
-    local total_hours = math.floor(total_minutes / 60)
+    local total_minutes = math_floor(ticks / (60 * 60))
+    local total_hours = math_floor(total_minutes / 60)
     local minutes = total_minutes - (total_hours * 60)
-    return string.format("%02d:%02d", total_hours, minutes)
+    return string_format("%02d:%02d", total_hours, minutes)
 end
 
 ---@param num number
 ---@return string
 local function format_with_thousands_sep(num)
-    num = math.floor(num)
+    num = math_floor(num)
     local str = tostring(num)
     local reversed = str:reverse()
     local formatted_reversed = reversed:gsub("(%d%d%d)", "%1,")
@@ -53,12 +56,12 @@ function TeamStatsCompare.show_stats(player, stats)
         local team_label = team_frame.add { type = "label", caption = Functions.team_name_with_color(force_name) }
         gui_style(team_label, { font = "heading-2" })
         local simple_stats = {
-            {"Final evo:", string.format("%d%%", (force_stats.final_evo or 0) * 100)},
+            {"Final evo:", string_format("%d%%", (force_stats.final_evo or 0) * 100)},
             {"Peak threat:", threat_to_pretty_string(force_stats.peak_threat or 0)},
             {"Lowest threat:", threat_to_pretty_string(force_stats.lowest_threat or 0)},
         }
         if stats.ticks and stats.ticks > 0 then
-            table.insert(simple_stats, {"Average players:", string.format("%.1f [img=info]", (force_stats.player_ticks or 0) / (stats.ticks or 1)), string.format("Total players: %d, Max players: %d", force_stats.total_players, force_stats.max_players)})
+            table.insert(simple_stats, {"Average players:", string_format("%.1f [img=info]", (force_stats.player_ticks or 0) / (stats.ticks or 1)), string_format("Total players: %d, Max players: %d", force_stats.total_players, force_stats.max_players)})
         end
         local top_simple_table = team_frame.add { type = "table", name = "top_simple_table", column_count = 2 }
         for _, stat in ipairs(simple_stats) do
@@ -78,12 +81,12 @@ function TeamStatsCompare.show_stats(player, stats)
         local centering_table = shared_frame.add { type = "table", name = "centering_table", column_count = 1 }
         centering_table.style.column_alignments[1] = "center"
         local l
-        l = centering_table.add { type = "label", caption = string.format("Difficulty: %s (%d%%)", tables.difficulties[global.difficulty_vote_index].short_name, global.difficulty_vote_value * 100) }
+        l = centering_table.add { type = "label", caption = string_format("Difficulty: %s (%d%%)", tables.difficulties[global.difficulty_vote_index].short_name, global.difficulty_vote_value * 100) }
         l.style.font = "default-small"
-        l = centering_table.add { type = "label", caption = string.format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) }
+        l = centering_table.add { type = "label", caption = string_format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) }
         l.style.font = "default-small"
         if stats.won_by_team then
-            l = centering_table.add { type = "label", caption = string.format("Winner: %s", stats.won_by_team == "north" and "North" or "South") }
+            l = centering_table.add { type = "label", caption = string_format("Winner: %s", stats.won_by_team == "north" and "North" or "South") }
             l.style.font = "default-small"
         end
     end
@@ -113,7 +116,7 @@ function TeamStatsCompare.show_stats(player, stats)
             local force_stats = stats.forces[force_name]
             local food_stats = force_stats.food[food.long_name] or {}
             local l
-            l = science_table.add { type = "label", caption = string.format("[item=%s]", food.long_name) }
+            l = science_table.add { type = "label", caption = string_format("[item=%s]", food.long_name) }
             l.style.font = font
             l = science_table.add { type = "label", caption = (food_stats.first_at and ticks_to_hh_mm(food_stats.first_at) or "") }
             l.style.font = font
@@ -125,7 +128,7 @@ function TeamStatsCompare.show_stats(player, stats)
             l.style.font = font
             total_sent_mutagen = total_sent_mutagen + (food_stats.sent or 0) * Tables.food_values[food.long_name].value
         end
-        local l = science_flow.add { type = "label", caption = string.format("[item=space-science-pack] equivalent %d", total_sent_mutagen / Tables.food_values["space-science-pack"].value) }
+        local l = science_flow.add { type = "label", caption = string_format("[item=space-science-pack] equivalent %d", total_sent_mutagen / Tables.food_values["space-science-pack"].value) }
         l.style.font = font
     end
 
@@ -151,7 +154,7 @@ function TeamStatsCompare.show_stats(player, stats)
             local force_stats = stats.forces[force_name]
             local item_stats = force_stats.items[item_info.item] or {}
             local l
-            l = item_table.add { type = "label", caption = string.format("[item=%s]", item_info.item) }
+            l = item_table.add { type = "label", caption = string_format("[item=%s]", item_info.item) }
             l.style.font = font
             if item_info.space_after then
                 l.style.bottom_padding = 12

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -1,12 +1,9 @@
 local gui_style = require 'utils.utils'.gui_style
-local Event = require 'utils.event'
 local Functions = require 'maps.biter_battles_v2.functions'
 local Tables = require 'maps.biter_battles_v2.tables'
 local closable_frame = require "utils.ui.closable_frame"
 local TeamStatsCollect = require 'maps.biter_battles_v2.team_stats_collect'
 local safe_wrap_with_player_print = require 'utils.utils'.safe_wrap_with_player_print
-local gui_style = require 'utils.utils'.gui_style
-local tables = require 'maps.biter_battles_v2.tables'
 
 local math_floor = math.floor
 local string_format = string.format
@@ -81,7 +78,7 @@ function TeamStatsCompare.show_stats(player, stats)
         local centering_table = shared_frame.add { type = "table", name = "centering_table", column_count = 1 }
         centering_table.style.column_alignments[1] = "center"
         local l
-        l = centering_table.add { type = "label", caption = string_format("Difficulty: %s (%d%%)", tables.difficulties[global.difficulty_vote_index].short_name, global.difficulty_vote_value * 100) }
+        l = centering_table.add { type = "label", caption = string_format("Difficulty: %s (%d%%)", Tables.difficulties[global.difficulty_vote_index].short_name, global.difficulty_vote_value * 100) }
         l.style.font = "default-small"
         l = centering_table.add { type = "label", caption = string_format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) }
         l.style.font = "default-small"

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -53,12 +53,12 @@ function TeamStatsCompare.show_stats(player, stats)
         local team_label = team_frame.add { type = "label", caption = Functions.team_name_with_color(force_name) }
         gui_style(team_label, { font = "heading-2" })
         local simple_stats = {
-            {"Final evo:", string.format("%d%%", force_stats.final_evo * 100)},
+            {"Final evo:", string.format("%d%%", (force_stats.final_evo or 0) * 100)},
             {"Peak threat:", threat_to_pretty_string(force_stats.peak_threat or 0)},
             {"Lowest threat:", threat_to_pretty_string(force_stats.lowest_threat or 0)},
         }
         if stats.ticks and stats.ticks > 0 then
-            table.insert(simple_stats, {"Average players:", string.format("%.1f [img=info]", (force_stats.player_ticks or 0) / stats.ticks), string.format("Total players: %d, Max players: %d", force_stats.total_players, force_stats.max_players)})
+            table.insert(simple_stats, {"Average players:", string.format("%.1f [img=info]", (force_stats.player_ticks or 0) / (stats.ticks or 1)), string.format("Total players: %d, Max players: %d", force_stats.total_players, force_stats.max_players)})
         end
         local top_simple_table = team_frame.add { type = "table", name = "top_simple_table", column_count = 2 }
         for _, stat in ipairs(simple_stats) do
@@ -80,7 +80,7 @@ function TeamStatsCompare.show_stats(player, stats)
         local l
         l = centering_table.add { type = "label", caption = string.format("Difficulty: %s (%d%%)", tables.difficulties[global.difficulty_vote_index].short_name, global.difficulty_vote_value * 100) }
         l.style.font = "default-small"
-        l = centering_table.add { type = "label", caption = string.format("Duration: %s", ticks_to_hh_mm(stats.ticks)) }
+        l = centering_table.add { type = "label", caption = string.format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) }
         l.style.font = "default-small"
         if stats.won_by_team then
             l = centering_table.add { type = "label", caption = string.format("Winner: %s", stats.won_by_team == "north" and "North" or "South") }
@@ -111,7 +111,7 @@ function TeamStatsCompare.show_stats(player, stats)
         local total_sent_mutagen = 0
         for _, food in ipairs(Tables.food_long_and_short) do
             local force_stats = stats.forces[force_name]
-            local food_stats = force_stats.food[food.long_name]
+            local food_stats = force_stats.food[food.long_name] or {}
             local l
             l = science_table.add { type = "label", caption = string.format("[item=%s]", food.long_name) }
             l.style.font = font
@@ -123,7 +123,7 @@ function TeamStatsCompare.show_stats(player, stats)
             l.style.font = font
             l = science_table.add { type = "label", caption = food_stats.sent and format_with_thousands_sep(food_stats.sent) or "0" }
             l.style.font = font
-            total_sent_mutagen = total_sent_mutagen + food_stats.sent * Tables.food_values[food.long_name].value
+            total_sent_mutagen = total_sent_mutagen + (food_stats.sent or 0) * Tables.food_values[food.long_name].value
         end
         local l = science_flow.add { type = "label", caption = string.format("[item=space-science-pack] equivalent %d", total_sent_mutagen / Tables.food_values["space-science-pack"].value) }
         l.style.font = font
@@ -149,7 +149,7 @@ function TeamStatsCompare.show_stats(player, stats)
 
         for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
             local force_stats = stats.forces[force_name]
-            local item_stats = force_stats.items[item_info.item]
+            local item_stats = force_stats.items[item_info.item] or {}
             local l
             l = item_table.add { type = "label", caption = string.format("[item=%s]", item_info.item) }
             l.style.font = font

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -36,11 +36,10 @@ function TeamStatsCompare.show_stats(player, stats)
     ---@type LuaGuiElement
     local frame = player.gui.screen["teamstats_frame"]
     if frame then
-        frame.clear()
-    else
-        frame = closable_frame.create_main_closable_frame(player, "teamstats_frame", "Team statistics")
-        gui_style(frame, { padding = 8 })
+        frame.destroy()
     end
+    frame = closable_frame.create_main_closable_frame(player, "teamstats_frame", "Team statistics")
+    gui_style(frame, { padding = 8 })
     local scrollpanel = frame.add { type = "scroll-pane", name = "scroll_pane", direction = "vertical", horizontal_scroll_policy = "never", vertical_scroll_policy = "auto" }
 
     ---@param force_name string

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -132,7 +132,7 @@ function TeamStatsCompare.show_stats(player, stats)
     two_table.add { type = "line" }
     two_table.add { type = "line" }
     for _, force_name in ipairs({"north", "south"}) do
-        local item_table = two_table.add { type = "table", name = "item_table_" .. force_name, column_count = 5 }
+        local item_table = two_table.add { type = "table", name = "item_table_" .. force_name, column_count = 5, vertical_centering = false }
         gui_style(item_table, { left_cell_padding = 3, right_cell_padding = 3, vertical_spacing = 0})
         local cols = {
             {""},
@@ -147,12 +147,15 @@ function TeamStatsCompare.show_stats(player, stats)
             l.style.font = font
         end
 
-        for _, item_name in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
+        for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
             local force_stats = stats.forces[force_name]
-            local item_stats = force_stats.items[item_name.item]
+            local item_stats = force_stats.items[item_info.item]
             local l
-            l = item_table.add { type = "label", caption = string.format("[item=%s]", item_name.item) }
+            l = item_table.add { type = "label", caption = string.format("[item=%s]", item_info.item) }
             l.style.font = font
+            if item_info.space_after then
+                l.style.bottom_padding = 12
+            end
             l = item_table.add { type = "label", caption = (item_stats.first_at and ticks_to_hh_mm(item_stats.first_at) or "") }
             l.style.font = font
             l = item_table.add { type = "label", caption = format_with_thousands_sep(item_stats.produced or 0) }

--- a/utils/utils.lua
+++ b/utils/utils.lua
@@ -98,6 +98,18 @@ Module.ternary = function(c, t, f)
     end
 end
 
+function Module.safe_wrap_with_player_print(player, func, ...)
+	local function error_handler(err)
+		local print_target = player or game
+		log("Error caught: " .. err)
+		print_target.print("Error caught: " .. err)
+		-- Print the full stack trace to the log
+		log(debug.traceback())
+	end
+	local call_succeeded, result = xpcall(func, error_handler, ...)
+	return result
+end
+
 
 local minutes_to_ticks = 60 * 60
 local hours_to_ticks = 60 * 60 * 60


### PR DESCRIPTION
Here is a screenshot of (a slightly out-of-date version of the code) the screen from a game earlier today
![image](https://github.com/user-attachments/assets/f83a927e-0825-4d17-bccd-8de72ae46834)

This displays many stats that are useful to understand how the game went. By default, it is displayed for all users at game end. You can also see stats for the previous game with `/teamstats prev`

This change was enabled by proxc, who built awesome mock-ups of what the information should look like.

This should have almost no performance overhead, as we are just looking at production statistics once per 16 seconds, and running a little bit of extra code in the on_entity_died handler.

This also has better crash-protection code that can be used for commands (like `/teamstats`) to make them not crash the server on error.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
