### PR TITLE
Special game desync fixes and change in removable functions

### DIFF
--- a/utils/event.lua
+++ b/utils/event.lua
@@ -1,99 +1,9 @@
--- luacheck: globals script
---- This Module allows for registering multiple handlers to the same event, overcoming the limitation of script.register.
---
--- ** Event.add(event_name, handler) **
---
--- Handlers added with Event.add must be added at the control stage or in Event.on_init or Event.on_load.
--- Remember that for each player, on_init or on_load is run, never both. So if you can't add the handler in the
--- control stage add the handler in both on_init and on_load.
--- Handlers added with Event.add cannot be removed.
--- For handlers that need to be removed or added at runtime use Event.add_removable.
--- @usage
--- local Event = require 'utils.event'
--- Event.add(
---     defines.events.on_built_entity,
---     function(event)
---         game.print(serpent.block(event)) -- prints the content of the event table to console.
---     end
--- )
---
--- ** Event.add_removable(event_name, token) **
---
--- For conditional event handlers. Event.add_removable can be safely called at runtime without desync risk.
--- Only use this if you need to add the handler at runtime or need to remove the handler, otherwise use Event.add
---
--- Event.add_removable can be safely used at the control stage or in Event.on_init. If used in on_init you don't
--- need to also add in on_load (unlike Event.add).
--- Event.add_removable cannot be called in on_load, doing so will crash the game on loading.
--- Token is used because it's a desync risk to store closures inside the global table.
---
--- @usage
--- local Token = require 'utils.token'
--- local Event = require 'utils.event'
---
--- Token.register must not be called inside an event handler.
--- local handler =
---     Token.register(
---     function(event)
---         game.print(serpent.block(event)) -- prints the content of the event table to console.
---     end
--- )
---
--- The below code would typically be inside another event or a custom command.
--- Event.add_removable(defines.events.on_built_entity, handler)
---
--- When you no longer need the handler.
--- Event.remove_removable(defines.events.on_built_entity, handler)
---
--- It's not an error to register the same token multiple times to the same event, however when
--- removing only the first occurrence is removed.
---
--- ** Event.add_removable_function(event_name, func) **
---
--- Only use this function if you can't use Event.add_removable. i.e you are registering the handler at the console.
--- The same restrictions that apply to Event.add_removable also apply to Event.add_removable_function.
--- func cannot be a closure in this case, as there is no safe way to store closures in the global table.
--- A closure is a function that uses a local variable not defined in the function.
---
--- @usage
--- local Event = require 'utils.event'
---
--- If you want to remove the handler you will need to keep a reference to it.
--- global.handler = function(event)
---     game.print(serpent.block(event)) -- prints the content of the event table to console.
--- end
---
--- The below code would typically be used at the command console.
--- Event.add_removable_function(defines.events.on_built_entity, global.handler)
---
--- When you no longer need the handler.
--- Event.remove_removable_function(defines.events.on_built_entity, global.handler)
---
--- ** Other Events **
---
--- Use Event.on_init(handler) for script.on_init(handler)
--- Use Event.on_load(handler) for script.on_load(handler)
---
--- Use Event.on_nth_tick(tick, handler) for script.on_nth_tick(tick, handler)
--- Favour this event over Event.add(defines.events.on_tick, handler)
--- There are also Event.add_removable_nth_tick(tick, token) and Event.add_removable_nth_tick_function(tick, func)
--- That work the same as above.
---
--- ** Custom Scenario Events **
---
--- local Event = require 'utils.event'
---
--- local event_id = script.generate_event_name()
---
--- Event.add(
---     event_id,
---     function(event)
---         game.print(serpent.block(event)) -- prints the content of the event table to console.
---     end
--- )
---
--- The table contains extra information that you want to pass to the handler.
--- script.raise_event(event_id, {extra = 'data'})
+---luacheck: globals script
+---
+---This Module allows for registering multiple handlers to the same event, overcoming the limitation of script.register.
+---
+---To create custom events, use script.generate_event_name and use its return value as an event name.
+---To raise that event, use script.raise_event
 
 local EventCore = require 'utils.event_core'
 local Global = require 'utils.global'
@@ -108,20 +18,38 @@ local stage_load = _STAGE.load
 local script_on_event = script.on_event
 local script_on_nth_tick = script.on_nth_tick
 local generate_event_name = script.generate_event_name
-local function_table = function_table
-local function_nth_tick_table = function_nth_tick_table
 
 local Event = {}
 
-local handlers_added = false -- set to true after the removeable event handlers have been added.
+local handlers_added = false -- set to true after the removable event handlers have been added.
 
+---@alias EventName defines.events | int
+
+---@type { [EventName]: fun()[] }
 local event_handlers = EventCore.get_event_handlers()
+
+---@type { [int]: fun()[] }
 local on_nth_tick_event_handlers = EventCore.get_on_nth_tick_event_handlers()
 
+---@type { [EventName]: int[] }
 local token_handlers = {}
+
+---@type { [int]: int[] }
 local token_nth_tick_handlers = {}
+
+---@type { [string]: { event_name: EventName, handler: string }[] }
 local function_handlers = {}
+---Do NOT register this table into the global module
+---@type { [string]: { event_name: EventName, handler: fun() }[] }
+local function_table = {}
+
+---@type { [string]: { tick: int, handler: string }[] }
 local function_nth_tick_handlers = {}
+---Do NOT register this table into the global module
+---@type { [string]: { tick: int, handler: fun() }[] }
+local function_nth_tick_table = {}
+
+---@type int
 local removable_function_uid = 0
 
 Global.register(
@@ -155,11 +83,12 @@ local function remove(tbl, handler)
     end
 end
 
---- Register a handler for the event_name event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load.
--- See documentation at top of file for details on using events.
--- @param event_name<number>
--- @param handler<function>
+
+---Register a handler for the event_name event, can only be used during control, init or load cycles.</br>
+---Handlers added with Event.add cannot be removed.</br>
+---For handlers that need to be removed or added at runtime use Event.add_removable.
+---@param event_name EventName
+---@param handler fun(event: EventData)
 function Event.add(event_name, handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.add after on_init() or on_load() has run is a desync risk.', 2)
@@ -168,10 +97,10 @@ function Event.add(event_name, handler)
     core_add(event_name, handler)
 end
 
---- Register a handler for the script.on_init event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load
--- See documentation at top of file for details on using events.
--- @param handler<function>
+---Register a handler for the on_init event, can only be used during control, init or load cycles.</br>
+---Remember that for each player, on_init or on_load is run, never both. So if you can't add the handler in the
+---control stage add the handler in both on_init and on_load.
+---@param handler fun()
 function Event.on_init(handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.on_init after on_init() or on_load() has run is a desync risk.', 2)
@@ -180,10 +109,10 @@ function Event.on_init(handler)
     core_on_init(handler)
 end
 
---- Register a handler for the script.on_load event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load
--- See documentation at top of file for details on using events.
--- @param handler<function>
+---Register a handler for the on_load event, can only be used during control, init or load cycles.</br>
+---Remember that for each player, on_init or on_load is run, never both. So if you can't add the handler in the
+---control stage add the handler in both on_init and on_load.
+---@param handler fun()
 function Event.on_load(handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.on_load after on_init() or on_load() has run is a desync risk.', 2)
@@ -192,11 +121,9 @@ function Event.on_load(handler)
     core_on_load(handler)
 end
 
---- Register a handler for the nth_tick event.
--- This function must be called in the control stage or in Event.on_init or Event.on_load.
--- See documentation at top of file for details on using events.
--- @param tick<number> The handler will be called every nth tick
--- @param handler<function>
+---Register a handler for the on_nth_tick event, can only be used during control, init or load cycles.</br>
+---@param tick int The handler will be called every nth tick
+---@param handler fun(event: NthTickEventData)
 function Event.on_nth_tick(tick, handler)
     if _LIFECYCLE == 8 then -- Runtime
         error('Calling Event.on_nth_tick after on_init() or on_load() has run is a desync risk.', 2)
@@ -205,11 +132,36 @@ function Event.on_nth_tick(tick, handler)
     core_on_nth_tick(tick, handler)
 end
 
---- Register a token handler that can be safely added and removed at runtime.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  token<number>
+---For conditional event handlers. Event.add_removable can be safely called at runtime without desync risk.
+---Only use this if you need to add the handler at runtime or need to remove the handler, otherwise use Event.add
+---
+---Event.add_removable can be safely used at the control stage or in Event.on_init.
+---If used in on_init you don't need to also add in on_load (unlike Event.add).
+---Event.add_removable cannot be called in on_load, doing so will crash the game on loading.
+---Token is used because it's a desync risk to store closures inside the global table.
+---
+---@usage
+---local Token = require 'utils.token'
+---local Event = require 'utils.event'
+---
+---Token.register must not be called inside an event handler.
+---local handler =
+---    Token.register(
+---    function(event)
+---        game.print(serpent.block(event)) -- prints the content of the event table to console.
+---    end
+---)
+---
+---The below code would typically be inside another event or a custom command.
+---Event.add_removable(defines.events.on_built_entity, handler)
+---
+---When you no longer need the handler.
+---Event.remove_removable(defines.events.on_built_entity, handler)
+---
+---It's not an error to register the same token multiple times to the same event, however when
+---removing only the first occurrence is removed.
+---@param event_name EventName
+---@param token int
 function Event.add_removable(event_name, token)
     if type(token) ~= 'number' then
         error('token must be a number', 2)
@@ -231,11 +183,10 @@ function Event.add_removable(event_name, token)
     end
 end
 
---- Removes a token handler for the given event_name.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  token<number>
+---Removes a token handler for the given event_name previously registered with Event.add_removable.
+---Do NOT call this method during on_load.
+---@param event_name EventName
+---@param token int
 function Event.remove_removable(event_name, token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -257,13 +208,15 @@ function Event.remove_removable(event_name, token)
     end
 end
 
----Register a handler that can be safely added and removed at runtime.
----The handler must not be a closure, as that is a desync risk.
----Do NOT call this method during on_load.
----See documentation at top of file for details on using events.
+
+---Only use this function if you can't use Event.add_removable. i.e you are registering the handler at the console.
+---Register a handler that can be safely added and removed at runtime, cannot be used during on_load.
+-- The same restrictions that apply to Event.add_removable also apply to Event.add_removable_function.
 ---
 ---The second parameter (func) has to be a function contained inside a string.
 ---This is necessary for the scenario to be multiplayer and save/load safe.
+---func cannot be a closure, as there is no safe way to store closures in the global table.
+---A closure is a function that uses a local variable not defined in the function.
 ---
 ---The third parameter is used to remove the function later.
 ---It can either be a string, in which case the function will be removed
@@ -274,23 +227,23 @@ end
 ---as the function may not be removed because of a coding mistake
 ---(for example because of a spelling mistake of the name), as it has already happened.
 ---Nevertheless I didn't removed this option so that we don't have to rewrite all current specials.
----@overload fun(event_name: number, func: string, name: string)
----@overload fun(event_name: number, func: string, remove_event_name: defines.events)
----@param event_name number
+---@overload fun(event_name: EventName, func: string, name: string)
+---@overload fun(event_name: EventName, func: string, remove_event_name: EventName)
+---@param event_name EventName
 ---@param func string
----@param overload1 string | defines.events
-function Event.add_removable_function(event_name, func, overload1)
+---@param remove_token string | EventName
+function Event.add_removable_function(event_name, func, remove_token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
     end
 
-    if not event_name or not func or not overload1 then
+    if not event_name or not func or not remove_token then
         return
     end
 
-    local name = overload1
-    if type(overload1) ~= "string" then
-        local remove_event_name = overload1
+    local name = remove_token
+    if type(remove_token) ~= "string" then
+        local remove_event_name = remove_token
         removable_function_uid = removable_function_uid + 1
         name = tostring(removable_function_uid)
 
@@ -330,11 +283,10 @@ function Event.add_removable_function(event_name, func, overload1)
     end
 end
 
---- Removes a handler for the given event_name.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  event_name<number>
--- @param  name<string>
+---Removes a handler previously registered with Event.add_removable_function for the given event_name and name.
+---Do NOT call this method during on_load.
+---@param event_name EventName
+---@param name string
 function Event.remove_removable_function(event_name, name)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -370,11 +322,9 @@ function Event.remove_removable_function(event_name, name)
     end
 end
 
---- Register a token handler for the nth tick that can be safely added and removed at runtime.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  token<number>
+---See Event.add_removable comments
+---@param tick int
+---@param token int
 function Event.add_removable_nth_tick(tick, token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -396,11 +346,9 @@ function Event.add_removable_nth_tick(tick, token)
     end
 end
 
---- Removes a token handler for the nth tick.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  token<number>
+---See Event.remove_removable comments
+---@param tick int
+---@param token int
 function Event.remove_removable_nth_tick(tick, token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -423,23 +371,23 @@ function Event.remove_removable_nth_tick(tick, token)
 end
 
 ---see Event.add_removable_function comment.
----@overload fun(event_name: number, func: string, name: string)
----@overload fun(event_name: number, func: string, remove_event_name: defines.events)
----@param tick number
+---@overload fun(event_name: EventName, func: string, name: string)
+---@overload fun(event_name: EventName, func: string, remove_event_name: EventName)
+---@param tick EventName
 ---@param func string
----@param overload1 string | defines.events
-function Event.add_removable_nth_tick_function(tick, func, overload1)
+---@param remove_token string | EventName
+function Event.add_removable_nth_tick_function(tick, func, remove_token)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
     end
 
-    if not tick or not func or not overload1 then
+    if not tick or not func or not remove_token then
         return
     end
 
-    local name = overload1
-    if type(overload1) ~= "string" then
-        local remove_event_name = overload1
+    local name = remove_token
+    if type(remove_token) ~= "string" then
+        local remove_event_name = remove_token
         removable_function_uid = removable_function_uid + 1
         name = tostring(removable_function_uid)
 
@@ -479,11 +427,9 @@ function Event.add_removable_nth_tick_function(tick, func, overload1)
     end
 end
 
---- Removes a handler for the nth tick.
--- Do NOT call this method during on_load.
--- See documentation at top of file for details on using events.
--- @param  tick<number>
--- @param  func<function>
+---See Event.remove_removable_function comments
+---@param tick int
+---@param name string
 function Event.remove_removable_nth_tick_function(tick, name)
     if _LIFECYCLE == stage_load then
         error('cannot call during on_load', 2)
@@ -554,13 +500,6 @@ function Event.add_event_filter(event, filter)
 end
 
 local function add_handlers()
-    if not function_table then
-        function_table = {}
-    end
-    if not function_nth_tick_table then
-        function_nth_tick_table = {}
-    end
-
     for event_name, tokens in pairs(token_handlers) do
         for i = 1, #tokens do
             local handler = Token.get(tokens[i])
@@ -612,7 +551,5 @@ end
 
 core_on_init(add_handlers)
 core_on_load(add_handlers)
-function_table = {}
-function_nth_tick_table = {}
 
 return Event


### PR DESCRIPTION
### Brief description of the changes:
- A solve to desyncs due to removable functions and removable nth tick functions
- A new way to remove removable functions that is more convenient and safer to coding mistake

First of all, the desyncs were due to the function that loads the registered functions when the game is loaded (add_handlers, event.lua:556). It used a normal for loop to go through the table that contains the functions instead of an in pairs for loop. This caused an error when the first elements of that table are nil, but the error was not actually raised because of xpcall, which caused the registering of events stop, which caused a desync.

This problem happened when multiple functions with the same name are not removed at the same time, this happened with the special "scavenger" where the name of a function and the name used to remove that function are not identical (probably because of a misspell). But it could probably have happened if 2 specials are ran at the same time and they are not compatible, or even within 1 special if it adds/removes functions during the game.

This encouraged me to do the second change of this PR. Currently the way to remove an function is to give it a name when registering it, and then use that name to remove it. This is really prone to misspell and is really annoying since to remove a special game when the map resets, you have to register another function on "on_surface_deleted" to clear itself and everything.
To fix this I just added the possibility of giving a second event name, on which the function will be removed. This simplify this:

```lua
local Event = require("utils.event")

Event.add_removable_function(defines.events.on_player_changed_position, '
    function(event)
        game.print("aaa")
    end
'
, "test")

Event.add_removable_function(defines.events.on_surface_deleted, '
    function(event)
        local Event = require("utils.event")
        Event.remove_removable_function(defines.events.on_player_changed_position, "test")
        Event.remove_removable_function(defines.events.on_surface_deleted, "test_remove")
    end
'
, "test_remove")
```

To this:

```lua
Event.add_removable_function(defines.events.on_player_changed_position, '
    function(event)
        game.print("aaa")
    end
'
, defines.events.on_surface_deleted)
```

Nevertheless, the old way to do it is still there so we don't have to rewrite existing specials.

### Tested Changes:
- [x] I've tested the changes locally or with people but I think it still needs more tests.
- [ ] I've not tested the changes.
