### PR TITLE
/close-difficulty-vote: add optional param to force difficulty

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -11,6 +11,7 @@ local gui_style = require 'utils.utils'.gui_style
 local ternary = require 'utils.utils'.ternary
 local ComfyPanelGroup = require 'comfy_panel.group'
 local CaptainRandomPick = require 'comfy_panel.special_games.captain_random_pick'
+local difficulty_vote = require 'maps.biter_battles_v2.difficulty_vote'
 local math_random = math.random
 local closable_frame = require "utils.ui.closable_frame"
 local bb_diff = require "maps.biter_battles_v2.difficulty_vote"
@@ -525,7 +526,7 @@ local function start_captain_event()
 	global.special_games_variables["captain_mode"]["stats"]["NorthInitialCaptain"] = global.special_games_variables["captain_mode"]["captainList"][1]
 	global.special_games_variables["captain_mode"]["stats"]["SouthInitialCaptain"] = global.special_games_variables["captain_mode"]["captainList"][2]
 	global.special_games_variables["captain_mode"]["stats"]["InitialReferee"] = global.special_games_variables["captain_mode"]["refereeName"]
-	local difficulty = Tables.difficulties[global.difficulty_vote_index].name;
+	local difficulty = difficulty_vote.difficulty_name()
 	if "difficulty" == "I'm Too Young to Die" then difficulty = "ITYTD"
 	elseif "difficulty" == "Fun and Fast" then difficulty = "FNF"
 	elseif "difficulty" == "Piece of Cake" then difficulty = "POC" end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -290,7 +290,7 @@ Public.raise_evo = function()
 	if global.freeze_players then return end
 	if not global.training_mode and (#game.forces.north.connected_players == 0 or #game.forces.south.connected_players == 0) then return end
 	if Functions.get_ticks_since_game_start() < 7200 then return end
-	if ( 1 <= global.difficulty_vote_index) and ( 3 >= global.difficulty_vote_index) then
+	if global.difficulty_vote_index and 1 <= global.difficulty_vote_index and 3 >= global.difficulty_vote_index then
 		local x = game.ticks_played/3600 -- current length of the match in minutes
 		global.difficulty_vote_value = ((x / 470) ^ 3.7) + Tables.difficulties[global.difficulty_vote_index].value
 	end

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -9,6 +9,28 @@ local Public = {}
 
 local difficulties = Tables.difficulties
 
+function Public.difficulty_name()
+	local index = global.difficulty_vote_index
+	if index then
+		return difficulties[global.difficulty_vote_index].name
+	else
+		return "Custom"
+	end
+end
+
+function Public.short_difficulty_name()
+	local index = global.difficulty_vote_index
+	if index then
+		return difficulties[global.difficulty_vote_index].short_name
+	else
+		return "Custom"
+	end
+end
+
+function Public.difficulty_color()
+	return difficulties[global.difficulty_vote_index or 3].color
+end
+
 local function difficulty_gui(player)
 	local b = player.gui.top["difficulty_gui"]
 	if not b then
@@ -16,10 +38,11 @@ local function difficulty_gui(player)
 		b.style.font = "heading-2"
 		gui_style(b, {width = 114, height = 38, padding = -2})
 	end
-	b.style.font_color = difficulties[global.difficulty_vote_index].print_color
+	b.style.font_color = Public.difficulty_color()
 	local value = math.floor(global.difficulty_vote_value*100)
-	local str = table.concat({"Global map difficulty is ", difficulties[global.difficulty_vote_index].name, ". Mutagen has ", value, "% effectiveness."})
-	b.caption = difficulties[global.difficulty_vote_index].name
+	local name = Public.difficulty_name()
+	local str = table.concat({"Global map difficulty is ", name, ". Mutagen has ", value, "% effectiveness."})
+	b.caption = name
 	b.tooltip = str
 end
 
@@ -126,10 +149,6 @@ local function set_difficulty()
 end
 
 local function on_player_joined_game(event)
-	if not global.difficulty_vote_value then global.difficulty_vote_value = 1 end
-	if not global.difficulty_vote_index then global.difficulty_vote_index = 4 end
-	if not global.difficulty_player_votes then global.difficulty_player_votes = {} end
-	
 	local player = game.get_player(event.player_index)
 	if game.ticks_played < global.difficulty_votes_timeout then
 		if not global.difficulty_player_votes[player.name] then

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -147,6 +147,19 @@ Public.difficulties = {
 	[7] = {name = "Fun and Fast", short_name = "FnF", str = "500%", value = 5, color = {r=0.55, g=0.00, b=0.00}, print_color = {r=0.9, g=0.0, b=0.00}}
 }
 
+Public.difficulty_lowered_names_to_index = {
+	["i'm too young to die"] = 1,
+	["itytd"] = 1,
+	["piece of cake"] = 2,
+	["poc"] = 2,
+	["easy"] = 3,
+	["normal"] = 4,
+	["hard"] = 5,
+	["nightmare"] = 6,
+	["fun and fast"] = 7,
+	["fnf"] = 7
+}
+
 Public.forces_list = { "all teams", "north", "south" }
 Public.science_list = { "all science", "very high tier (space, utility, production)", "high tier (space, utility, production, chemical)", "mid+ tier (space, utility, production, chemical, military)","space","utility","production","chemical","military", "logistic", "automation" }
 Public.evofilter_list = { "all evo jump", "no 0 evo jump", "10+ only","5+ only","4+ only","3+ only","2+ only","1+ only" }

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -4,6 +4,7 @@ local TeamStatsCollect = {}
 local functions = require 'maps.biter_battles_v2.functions'
 local tables = require 'maps.biter_battles_v2.tables'
 local event = require 'utils.event'
+local difficulty_vote = require 'maps.biter_battles_v2.difficulty_vote'
 
 ---@class ForceStats
 ---@field final_evo? number
@@ -21,6 +22,8 @@ local event = require 'utils.event'
 ---@field forces table<string, ForceStats>
 ---@field ticks integer?
 ---@field won_by_team string?
+---@field difficulty string?
+---@field difficulty_value number?
 
 TeamStatsCollect.items_to_show_summaries_of = {
     {item = "coal"},
@@ -59,9 +62,11 @@ TeamStatsCollect.damage_render_info = {
 local function update_teamstats()
     local team_stats = global.team_stats
     local tick = functions.get_ticks_since_game_start()
-    if tick == 0 then return end
     if team_stats.won_by_team then return end
     team_stats.won_by_team = global.bb_game_won_by_team
+    team_stats.difficulty = difficulty_vote.short_difficulty_name()
+    team_stats.difficulty_value = global.difficulty_vote_value
+    if tick == 0 then return end
     local prev_ticks = team_stats.ticks or 0
     team_stats.ticks = tick
     local total_players = {north = 0, south = 0}

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -50,7 +50,7 @@ function TeamStatsCompare.show_stats(player, stats)
         local team_frame = top_table.add { type = "frame", name = "summary_" .. force_name, direction = "vertical" }
         gui_style(team_frame, { padding = 8 })
         local team_label = team_frame.add { type = "label", caption = Functions.team_name_with_color(force_name) }
-        gui_style(team_label, { font = "heading-2" })
+        gui_style(team_label, { font = "heading-2", single_line = false, maximal_width = 150})
         local simple_stats = {
             {"Final evo:", string_format("%d%%", (force_stats.final_evo or 0) * 100)},
             {"Peak threat:", threat_to_pretty_string(force_stats.peak_threat or 0)},
@@ -77,7 +77,7 @@ function TeamStatsCompare.show_stats(player, stats)
         local centering_table = shared_frame.add { type = "table", name = "centering_table", column_count = 1 }
         centering_table.style.column_alignments[1] = "center"
         local l
-        l = centering_table.add { type = "label", caption = string_format("Difficulty: %s (%d%%)", Tables.difficulties[global.difficulty_vote_index].short_name, global.difficulty_vote_value * 100) }
+        l = centering_table.add { type = "label", caption = string_format("Difficulty: %s (%d%%)", (stats.difficulty or ""), (stats.difficulty_value or 0) * 100) }
         l.style.font = "default-small"
         l = centering_table.add { type = "label", caption = string_format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) }
         l.style.font = "default-small"


### PR DESCRIPTION
This gives a simpler option for admins to force the difficulty. Before this, it was necessary to first go Fish -> Config -> Admin-only-difficulty-voting-on, then run /difficulty-revote, then vote, then run /difficulty-close-vote.  Now you can just run one command.

This also fixes the difficulty-name/value listed in '/teamstats prev' which was previously broken, and improves some formating of long-team names in the /teamstats view.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
