### PR TITLE
Add inventory tracking for lost item teamstats

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -507,4 +507,20 @@ function Functions.format_ticks_as_time(ticks)
 	return string.format("%d:%02d:%02d", hours, minutes, seconds)
 end
 
+function Functions.get_entity_contents(entity)
+	local totals = {}
+	if not (entity and entity.valid and entity.get_max_inventory_index() > 0) then
+		return totals
+	end
+	for i_id = 1, entity.get_max_inventory_index() do
+		local inventory = entity.get_inventory(i_id)
+		if inventory and inventory.valid and not inventory.is_empty() then
+			for item, amount in pairs(inventory.get_contents()) do
+				totals[item] = (totals[item] or 0) + amount
+			end
+		end
+	end
+	return totals
+end
+
 return Functions

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -509,7 +509,7 @@ end
 
 function Functions.get_entity_contents(entity)
 	local totals = {}
-	if not (entity and entity.valid and entity.get_max_inventory_index() > 0) then
+	if not (entity and entity.valid) then
 		return totals
 	end
 	for i_id = 1, entity.get_max_inventory_index() do

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -56,6 +56,23 @@ TeamStatsCollect.damage_render_info = {
     {"impact", "Impact [item=locomotive][item=car][item=tank]"},
 }
 
+TeamStatsCollect.tracked_inventories = {
+    ['assembling-machine'] = true,
+    ['boiler'] = true,
+    ['car'] = true,
+    ['cargo-wagon'] = true,
+    ['character-corpse'] = true,
+    ['container'] = true,
+    ['furnace'] = true,
+    ['inserter'] = true,
+    ['lab'] = true,
+    ['logistic-container'] = true,
+    ['reactor'] = true,
+    ['roboport'] = true,
+    ['rocket-silo'] = true,
+    ['spider-vehicle'] = true,
+}
+
 local function update_teamstats()
     local team_stats = global.team_stats
     local tick = functions.get_ticks_since_game_start()
@@ -194,6 +211,16 @@ local function on_entity_died(event)
         force_name = "south"
         biter_force_name = "south_biters"
         if entity.force.name == "south_biters_boss" then health_factor = health_factor * 20 end
+    elseif entity.force.name == "north" or entity.force.name == "south" then
+        if TeamStatsCollect.tracked_inventories[entity.type] then
+            global.team_stats.forces[entity.force.name].items = global.team_stats.forces[entity.force.name].items or {}
+            local item_stats = global.team_stats.forces[entity.force.name].items
+            for item, amount in pairs(functions.get_entity_contents(entity)) do
+                item_stats[item] = item_stats[item] or {}
+                item_stats[item].lost = (item_stats[item].lost or 0) + amount
+            end
+        end
+        return
     else
         return
     end

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -36,8 +36,8 @@ TeamStatsCollect.items_to_show_summaries_of = {
     {item = "transport-belt", placed = true},
     {item = "fast-transport-belt", placed = true, space_after = true},
 
-    {item = "roboport"},
-    {item = "construction-robot", placed = true},
+    {item = "roboport", placed = true},
+    {item = "construction-robot"},
     {item = "nuclear-reactor", placed = true, space_after = true},
 
     {item = "stone-wall", placed = true},

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -37,7 +37,7 @@ TeamStatsCollect.items_to_show_summaries_of = {
     {item = "fast-transport-belt", placed = true, space_after = true},
 
     {item = "roboport", placed = true},
-    {item = "construction-robot"},
+    {item = "construction-robot", placed = true},
     {item = "nuclear-reactor", placed = true, space_after = true},
 
     {item = "stone-wall", placed = true},
@@ -56,17 +56,19 @@ TeamStatsCollect.damage_render_info = {
     {"impact", "Impact [item=locomotive][item=car][item=tank]"},
 }
 
-TeamStatsCollect.tracked_inventories = {
+local tracked_inventories = {
     ['assembling-machine'] = true,
     ['boiler'] = true,
     ['car'] = true,
     ['cargo-wagon'] = true,
     ['character-corpse'] = true,
+    ['construction-robot'] = true,
     ['container'] = true,
     ['furnace'] = true,
     ['inserter'] = true,
     ['lab'] = true,
     ['logistic-container'] = true,
+    ['logistic-robot'] = true,
     ['reactor'] = true,
     ['roboport'] = true,
     ['rocket-silo'] = true,
@@ -219,9 +221,16 @@ local function on_entity_died(event)
 
     -- North/South entities
     if entity_force_name == 'north' or entity_force_name == 'south' then
-        if TeamStatsCollect.tracked_inventories[entity.type] then
-            global.team_stats.forces[entity_force_name].items = global.team_stats.forces[entity_force_name].items or {}
-            local item_stats = global.team_stats.forces[entity_force_name].items
+        local item_stats = global.team_stats.forces[entity_force_name].items
+        if not item_stats then
+            item_stats = {}
+            global.team_stats.forces[entity_force_name].items = item_stats
+        end
+        if entity.type == 'construction-robot' or entity.type == 'logistic-robot' then
+            item_stats[entity.name] = item_stats[entity.name] or {}
+            item_stats[entity.name].kill_count = (item_stats[entity.name].kill_count or 0) + 1
+        end
+        if tracked_inventories[entity.type] then
             for item, amount in pairs(functions.get_entity_contents(entity)) do
                 item_stats[item] = item_stats[item] or {}
                 item_stats[item].lost = (item_stats[item].lost or 0) + amount

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -36,7 +36,7 @@ TeamStatsCollect.items_to_show_summaries_of = {
     {item = "transport-belt", placed = true},
     {item = "fast-transport-belt", placed = true, space_after = true},
 
-    {item = "roboport", placed = true},
+    {item = "roboport"},
     {item = "construction-robot", placed = true},
     {item = "nuclear-reactor", placed = true, space_after = true},
 

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -14,7 +14,7 @@ local event = require 'utils.event'
 ---@field total_players? integer
 ---@field max_players? integer
 ---@field food table<string, {first_at?: integer, produced: number, consumed: number, sent: number}>
----@field items table<string, {first_at?: integer, produced?: number, placed?: number, lost?: number}>
+---@field items table<string, {first_at?: integer, produced?: number, placed?: number, lost?: number, kill_count?: number}>
 ---@field damage_types table<string, {kills?: integer, damage?: number}>
 
 ---@class TeamStats
@@ -73,14 +73,14 @@ TeamStatsCollect.tracked_inventories = {
     ['spider-vehicle'] = true,
 }
 
-TeamStatsCollect.force_name_map = {
+local force_name_map = {
     north_biters = 'north',
     north_biters_boss = 'north',
     south_biters = 'south',
     south_biters_boss = 'south',
 }
 
-TeamStatsCollect.health_factor_map = {
+local health_factor_map = {
     north_biters = 1,
     north_biters_boss = 20,
     south_biters = 1,
@@ -232,8 +232,8 @@ local function on_entity_died(event)
 
     -- North/South biters
     if not event.damage_type then return end
-    local health_factor = TeamStatsCollect.health_factor_map[entity_force_name]
-    local force_name = TeamStatsCollect.force_name_map[entity_force_name]
+    local health_factor = health_factor_map[entity_force_name]
+    local force_name = force_name_map[entity_force_name]
     if not health_factor or not force_name then return end
 
     health_factor = health_factor / (1 - global.reanim_chance[game.forces[force_name .. '_biters'].index] / 100)

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -149,6 +149,8 @@ function TeamStatsCompare.show_stats(player, stats)
         for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
             local force_stats = stats.forces[force_name]
             local item_stats = force_stats.items[item_info.item] or {}
+            local killed_or_lost = (item_stats.kill_count or 0) + (item_stats.lost or 0)
+            if killed_or_lost == 0 then killed_or_lost = nil end
             local l
             l = item_table.add { type = "label", caption = string_format("[item=%s]", item_info.item) }
             l.style.font = font
@@ -161,7 +163,7 @@ function TeamStatsCompare.show_stats(player, stats)
             l.style.font = font
             l = item_table.add { type = "label", caption = item_stats.placed and format_with_thousands_sep(item_stats.placed) or "" }
             l.style.font = font
-            l = item_table.add { type = "label", caption = item_stats.lost and format_with_thousands_sep(item_stats.lost) or "" }
+            l = item_table.add { type = "label", caption = killed_or_lost and format_with_thousands_sep(killed_or_lost) or "" }
             l.style.font = font
         end
     end


### PR DESCRIPTION
### Brief description of the changes:
Follow up PR for https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/559

Add inventory tracking upon entity death to track lost items.

Entities are whitelisted to check their inventory upon death (whitelisted so we do even less unnecessary checks on frequent deaths such as walls, belts, poles which have no inventories). Works with chests, vehicles, machines, power structures...

### Tested Changes:
- [x] I've tested the changes locally in SP
- [ ] I've not tested the changes in MP
