### PR TITLE
captains on_player_left_game: fix bugs hopefully

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1808,8 +1808,12 @@ local function on_player_left_game(event)
 	local special = global.special_games_variables["captain_mode"]
 	if not special or not player then return end
 	bb_diff.remove_player_from_difficulty_vote(player)
-	removeStringFromTable(special["listPlayers"], player.name)
-	removeStringFromTable(special["captainList"], player.name)
+	if not special["pickingPhase"] then
+		removeStringFromTable(special["listPlayers"], player.name)
+		if special["prepaPhase"] then
+			removeStringFromTable(special["captainList"], player.name)
+		end
+	end
 
 	Public.captain_log_end_time_player(player)
 	Public.update_all_captain_player_guis()


### PR DESCRIPTION
Eagle reported that terrible things happened when he momentarily was disconnected, and looking at this more closely, it seems like it was super broken. Especially if a captain ever left the game.... could end up swapping captain of south to be captain of north and other terrible things...

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.
