### PR TITLE
/close-difficulty-vote: add logging if difficulty changes

### DIFF
--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -40,7 +40,8 @@ function Public.comfy_panel_refresh_active_tab(player)
     comfy_panel_tabs[frame.name].gui(player, frame)
 end
 
-local function top_button(player)
+---@param player LuaPlayer
+function Public.comfy_panel_add_top_button(player)
     if player.gui.top['comfy_panel_top_button'] then
         return
     end

--- a/comfy_panel/main.lua
+++ b/comfy_panel/main.lua
@@ -86,10 +86,6 @@ local function main_frame(player)
     Public.comfy_panel_refresh_active_tab(player)
 end
 
-local function on_player_joined_game(event)
-    top_button(game.get_player(event.player_index))
-end
-
 local function on_gui_click(event)
     if not event.element then
         return
@@ -119,7 +115,6 @@ local function on_gui_click(event)
     Public.comfy_panel_refresh_active_tab(player)
 end
 
-event.add(defines.events.on_player_joined_game, on_player_joined_game)
 event.add(defines.events.on_gui_click, on_gui_click)
 
 return Public

--- a/comfy_panel/poll.lua
+++ b/comfy_panel/poll.lua
@@ -820,6 +820,17 @@ local function vote(event)
     end
 end
 
+function Class.create_top_button(player)
+    if player.gui.top[main_button_name] ~= nil then return end
+    local button = player.gui.top.add {
+        type = 'sprite-button',
+        name = main_button_name,
+        sprite = 'item/programmable-speaker',
+        tooltip = 'Let your question be heard!'
+    }
+    gui_style(button, {width = 38, height = 38, padding = -2})
+end
+
 local function player_joined(event)
     local player = game.get_player(event.player_index)
     if not player or not player.valid then
@@ -832,14 +843,6 @@ local function player_joined(event)
             local data = Gui.get_data(frame)
             update_poll_viewer(data)
         end
-    else
-        local button = player.gui.top.add {
-            type = 'sprite-button',
-            name = main_button_name,
-            sprite = 'item/programmable-speaker',
-            tooltip = 'Let your question be heard!'
-        }
-        gui_style(button, {width = 38, height = 38, padding = -2})
     end
 end
 

--- a/commands/difficulty_voting_commands.lua
+++ b/commands/difficulty_voting_commands.lua
@@ -1,6 +1,7 @@
 local Server = require 'utils.server'
 local Color = require 'utils.color_presets'
 local tables = require 'maps.biter_battles_v2.tables'
+local difficulty_vote = require 'maps.biter_battles_v2.difficulty_vote'
 
 local function revote()
     local player = game.player
@@ -41,6 +42,13 @@ local function close_difficulty_votes(cmd)
             player.print("Invalid difficulty parameter. Please provide either a difficulty name/abbreviation or mutagen effectiveness as a percentage, i.e. `33%'.")
             return
         end
+        local difficulty_name = difficulty_vote.difficulty_name()
+        if not global.difficulty_vote_index then
+            difficulty_name = string.format("%s (%d%%)", difficulty_name, global.difficulty_vote_value * 100)
+        end
+        local message = table.concat({">> Map difficulty has changed to ", difficulty_name, " difficulty!"})
+        game.print(message, difficulty_vote.difficulty_print_color())
+        Server.to_discord_embed(message)
     end
     global.difficulty_votes_timeout = game.ticks_played
     local msg = player.name .. " closed difficulty voting"

--- a/commands/difficulty_voting_commands.lua
+++ b/commands/difficulty_voting_commands.lua
@@ -42,11 +42,7 @@ local function close_difficulty_votes(cmd)
             player.print("Invalid difficulty parameter. Please provide either a difficulty name/abbreviation or mutagen effectiveness as a percentage, i.e. `33%'.")
             return
         end
-        local difficulty_name = difficulty_vote.difficulty_name()
-        if not global.difficulty_vote_index then
-            difficulty_name = string.format("%s (%d%%)", difficulty_name, global.difficulty_vote_value * 100)
-        end
-        local message = table.concat({">> Map difficulty has changed to ", difficulty_name, " difficulty!"})
+        local message = table.concat({">> Map difficulty has changed to ", difficulty_vote.difficulty_name(), " difficulty!"})
         game.print(message, difficulty_vote.difficulty_print_color())
         Server.to_discord_embed(message)
     end

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -14,7 +14,7 @@ function Public.difficulty_name()
 	if index then
 		return difficulties[global.difficulty_vote_index].name
 	else
-		return "Custom"
+		return string.format("Custom (%d%%)", global.difficulty_vote_value * 100)
 	end
 end
 

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -33,11 +33,7 @@ end
 
 local function difficulty_gui(player)
 	local b = player.gui.top["difficulty_gui"]
-	if not b then
-		b = player.gui.top.add { type = "sprite-button", name = "difficulty_gui" }
-		b.style.font = "heading-2"
-		gui_style(b, {width = 114, height = 38, padding = -2})
-	end
+	if not b then return end
 	b.style.font_color = Public.difficulty_print_color()
 	local value = math.floor(global.difficulty_vote_value*100)
 	local name = Public.difficulty_name()
@@ -52,6 +48,16 @@ local function difficulty_gui_all()
 	end
 end
 
+---@param player LuaPlayer
+local function add_difficulty_gui_top_button(player)
+	local b = player.gui.top["difficulty_gui"]
+	if not b then
+		b = player.gui.top.add { type = "sprite-button", name = "difficulty_gui" }
+		b.style.font = "heading-2"
+		gui_style(b, {width = 114, height = 38, padding = -2})
+	end
+	difficulty_gui(player)
+end
 
 local function is_captain_enabled()
 	return global.special_games_variables["captain_mode"] ~= nil
@@ -267,5 +273,6 @@ event.add(defines.events.on_player_joined_game, on_player_joined_game)
 Public.difficulties = difficulties
 Public.difficulty_gui = difficulty_gui
 Public.difficulty_gui_all = difficulty_gui_all
+Public.add_difficulty_gui_top_button = add_difficulty_gui_top_button
 
 return Public

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -70,7 +70,7 @@ function Public.reset_tables_gui()
 	global.player_data_afk = {}
 end
 
-local function create_sprite_button(player)
+function Public.create_biter_button(player)
 	if player.gui.top["bb_toggle_button"] then return end
 	local button = player.gui.top.add({ type = "sprite-button", name = "bb_toggle_button", sprite = "entity/big-biter" })
 	gui_style(button, { width = 38, height = 38, padding = -2, font = "default-bold" })
@@ -750,7 +750,6 @@ local function on_player_joined_game(event)
 	--	end
 	--end
 
-	create_sprite_button(player)
 	Public.create_main_gui(player)
 end
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -20,6 +20,9 @@ local Task = require 'utils.task'
 local Token = require 'utils.token'
 local Color = require 'utils.color_presets'
 local ResearchInfo = require 'maps.biter_battles_v2.research_info'
+local DifficultyVote = require 'maps.biter_battles_v2.difficulty_vote'
+local ComfyMain = require 'comfy_panel.main'
+local ComfyPoll = require 'comfy_panel.poll'
 local autoTagWestOutpost = "[West]"
 local autoTagEastOutpost = "[East]"
 local autoTagDistance = 600
@@ -34,10 +37,15 @@ require "modules.spawners_contain_biters"
 local function on_player_joined_game(event)
 	local surface = game.surfaces[global.bb_surface_name]
 	local player = game.get_player(event.player_index)
+	if not player then return end
 	if player.online_time == 0 or player.force.name == "player" then
 		Functions.init_player(player)
 	end
 	Gui.clear_copy_history(player)
+	ComfyMain.comfy_panel_add_top_button(player)
+	ComfyPoll.create_top_button(player)
+	DifficultyVote.add_difficulty_gui_top_button(player)
+	Gui.create_biter_button(player)
 	Functions.create_map_intro_button(player)
 	--ResearchInfo.create_research_info_button(player)
 	Team_manager.draw_top_toggle_button(player)


### PR DESCRIPTION
This both makes it clearer in game, and gives the website an update about what happened.

Presumably the "Custom (222%)" difficulty messages will break the website slightly in some ways, but I don't really see a good way around that.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
