### PR TITLE
Fix ping alert and map countdown sound bugs

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -207,7 +207,8 @@ function Public.reveal_map()
 	end
 
 	local chart_queue = global.chart_queue
-	Queue.clear(chart_queue)
+	-- important to flush the queue upon resetting a map or chunk requests from previous maps could overlap
+	Queue.clear(chart_queue) 
 
 	local width = 2000 -- for one side
 	local height = 500 -- for one side
@@ -365,8 +366,9 @@ function Public.load_spawn()
 	end
 end
 
-function Public.pop_chunk_requests()
-	local max_requests = 65 -- 16 chunks * 4 + 1 starting area
+---@param max_requests number
+function Public.pop_chunk_request(max_requests)
+	max_requests = max_requests or 1
 	local chart_queue = global.chart_queue
 	local surface = game.surfaces[global.bb_surface_name]
 	local spectator = game.forces.spectator

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -432,8 +432,18 @@ local function on_tick()
 		ResearchInfo.update_research_info_ui()
 	end
 
+	--[[
+		Map width: 2000 tiles (~64 chunks) each direction
+		Map height: 500 tiles (~16 chunks) each direction
+		Estimated time for complete reveal: 90s (5400 ticks)
+
+		pop_chunk_request will chart the queued chunk requests issued during a new map reveal.
+		We chart 65 chunks each iteration because of 16-chunks-tall zones NE, NW, SE, SW, + 1 bonus chunk which is the starting area.
+		To fully reveal the new map within the time window, the time interval between requests should be ~84 ticks (5400 / 64-chunks-length),
+		plus + 24 ticks as offset to avoid tick_0
+	]]
 	if (tick+24) % 84 == 0 then
-		Init.pop_chunk_requests()
+		Init.pop_chunk_request(65)
 	end
 end
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -137,7 +137,7 @@ function do_ping(from_player_name, to_player, message)
 	if to_player.character and to_player.character.get_health_ratio() > 0.99 then
 		to_player.character.damage(0.001, "player")
 	end
-	Sounds.notify_player(tp_player, "utility/blueprint_selection_ended")
+	Sounds.notify_player(to_player, "utility/blueprint_selection_ended")
 	-- to_player.play_sound({path = "utility/new_objective", volume_modifier = 0.6})
 	-- to_player.surface.create_entity({name = 'big-explosion', position = to_player.position})
 	local ping_header = to_player.gui.screen["ping_header"]
@@ -430,6 +430,10 @@ local function on_tick()
 	if (tick+5) % 180 == 0 then
 		Gui.refresh()
 		ResearchInfo.update_research_info_ui()
+	end
+
+	if (tick+24) % 84 == 0 then
+		Init.pop_chunk_requests()
 	end
 end
 

--- a/utils/queue.lua
+++ b/utils/queue.lua
@@ -84,4 +84,11 @@ function Queue.pairs(queue)
     end
 end
 
+function Queue.clear(queue)
+    for k, _ in pairs(queue) do
+        queue[k] = nil
+    end
+    queue._head, queue._tail = 1, 1
+end
+
 return Queue


### PR DESCRIPTION
### Brief description of the changes:
- [x] Fixed typo for sound Fx on pings ~~`tp_player`~~ `to_player`
- [x] Fixed sound countdown not being audible while revealing whole map on init: a queue for chunk requests has been added for this purpose specifically. I computed the interval to reveal the whole map in the same time, so every 84 ticks it will request 65 chunks to be charted (16 on the 4 side, + starting area) resulting in same 90s to reveal whole map as before. When instant-resetting to a new map, the queue gets flushed anew so no chunk requests overlap between maps.

I believe there is a slight performance improvement on init since whole map is not requested to be charted on that event, but the workload is spread over multiple ticks. On the other hand, there is the small overhead of running that function in background, but I think it only does the very minimal work needed (see `..init.lua` `Public.pop_chunk_request()`)

### Tested Changes:
- [x] I've tested the changes locally in SP
- [ ] I've not tested the changes in MP
