### PR TITLE
Track player-stats for the end-game-screen - alpha version

### DIFF
--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -1,6 +1,8 @@
 local ItemCosts = require 'maps.biter_battles_v2.item_costs'
 local safe_wrap_with_player_print = require 'utils.utils'.safe_wrap_with_player_print
 
+---@param player LuaPlayer
+---@return number
 local function inventory_cost(player)
     local inventory = player.get_inventory(defines.inventory.character_main)
     if not inventory then return 0 end
@@ -62,3 +64,6 @@ commands.add_command(
 	"Print out the top players by inventory values. Pass 'all' to see it for both forces.",
 	inventory_costs_command
 )
+
+local Public = { inventory_cost = inventory_cost }
+return Public

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -359,6 +359,8 @@ function Functions.get_ticks_since_game_start()
 	return game.ticks_played - start_tick
 end
 
+---@param force_name string
+---@return string
 function Functions.team_name(force_name)
 	local name = global.tm_custom_name[force_name]
 	if name == nil then
@@ -371,12 +373,27 @@ function Functions.team_name(force_name)
 	return name or force_name
 end
 
+---@param force_name string
+---@return string
 function Functions.team_name_with_color(force_name)
 	local name = Functions.team_name(force_name)
 	if force_name == "north" then
 		return "[color=120, 120, 255]" .. name .. "[/color]"
 	elseif force_name == "south" then
 		return "[color=255, 65, 65]" .. name .. "[/color]"
+	else
+		return name
+	end
+end
+
+---@param force_name string
+---@return string
+function Functions.short_team_name_with_color(force_name)
+	local name = Functions.team_name(force_name)
+	if force_name == "north" then
+		return "[color=120, 120, 255]North[/color]"
+	elseif force_name == "south" then
+		return "[color=255, 65, 65]South[/color]"
 	else
 		return name
 	end

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -2,6 +2,7 @@ local Terrain = require "maps.biter_battles_v2.terrain"
 local Score = require "comfy_panel.score"
 local Tables = require "maps.biter_battles_v2.tables"
 local Blueprint = require 'maps.biter_battles_v2.blueprints'
+local TeamStatsCollect = require 'maps.biter_battles_v2.team_stats_collect'
 local Queue = require 'utils.queue'
 local q_size = Queue.size
 local q_push = Queue.push
@@ -232,7 +233,7 @@ function Public.tables()
 	global.science_logs_total_north = nil
 	global.science_logs_total_south = nil
 	---@type TeamStats
-	global.team_stats = {forces = {north = {items = {}, food = {}, damage_types = {}}, south = {items = {}, food = {}, damage_types = {}}}}
+	global.team_stats = TeamStatsCollect.initial_team_stats()
 	-- Name of main BB surface within game.surfaces
 	-- We hot-swap here between 2 surfaces.
 	if global.bb_surface_name == 'bb0' then

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -219,10 +219,12 @@ local function update_teamstats()
                 force_stats.players[player.name] = player_stats
             end
             player_stats.player_ticks = player_stats.player_ticks + update_teamstats_interval
-            local inv_value = inventory_costs.inventory_cost(player)
-            player_stats.inventory_value_cumulative = player_stats.inventory_value_cumulative + inv_value * update_teamstats_interval
-            if player.crafting_queue_size > 0 then
-                player_stats.crafting_ticks = player_stats.crafting_ticks + update_teamstats_interval
+            if player.character then
+                local inv_value = inventory_costs.inventory_cost(player)
+                player_stats.inventory_value_cumulative = player_stats.inventory_value_cumulative + inv_value * update_teamstats_interval
+                if player.crafting_queue_size > 0 then
+                    player_stats.crafting_ticks = player_stats.crafting_ticks + update_teamstats_interval
+                end
             end
         end
     end

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -121,7 +121,7 @@ function populate_player_stats(stats, frame)
         l = player_table.add { type = "label", caption = string_format("%d", entry.placed_val_per_min) }
         l.style.font = "default-small"
         -- add horizontal flow, with each of per_player_build_items_to_display as a sprite with number
-        local player_flow = player_table.add { type = "flow", name = "player_flow_" .. player_name, direction = "horizontal" }
+        local player_flow = player_table.add { type = "flow", name = "player_flow_" .. entry.force_name .. "_" .. player_name, direction = "horizontal" }
         for _, item_name in ipairs(TeamStatsCollect.per_player_build_items_to_display) do
             local item_info = entry.placed[item_name]
             local built = item_info and item_info.built or 0

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -376,9 +376,9 @@ commands.add_command("teamstats", "Show team stats", function (cmd)
     local show_playerstats = false
     local deny_reason
     for word in string.gmatch(cmd.parameter or "", "%S+") do
-        if cmd.parameter == "prev" then
+        if word == "prev" then
             prev = true
-        elseif cmd.parameter == "alpha_playerstats" then
+        elseif word == "alpha_playerstats" then
             show_playerstats = true
         else
             player.print("Unsupported argument to /teamstats. Run either just '/teamstats' or '/teamstats prev'")

--- a/utils/player.lua
+++ b/utils/player.lua
@@ -12,10 +12,16 @@ function Public.get_sorted_colored_player_list(player_list)
 	local players_with_colors = {}
 	for _, pair in ipairs(players_with_sort_keys) do
 		local p = pair.player
-		table.insert(players_with_colors, string.format("[color=%.2f,%.2f,%.2f]%s[/color]", p.color.r * 0.6 + 0.4, p.color.g * 0.6 + 0.4, p.color.b * 0.6 + 0.4, p.name))
+		table.insert(players_with_colors, Public.player_name_with_color(p))
 	end
 
 	return players_with_colors
+end
+
+---@param player LuaPlayer
+---@return string
+function Public.player_name_with_color(player)
+	return string.format("[color=%.2f,%.2f,%.2f]%s[/color]", player.color.r * 0.6 + 0.4, player.color.g * 0.6 + 0.4, player.color.b * 0.6 + 0.4, player.name)
 end
 
 ---@param names string[]


### PR DESCRIPTION
This can be accessed with '/teamstats alpha_playerstats', potentially after running '/c global.team_stats_use_fake_data = true`.

TODO: sorting, 30 mins / 1 hour cutoffs, filter to just one team.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
