### PR TITLE
Charting fixes

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -607,7 +607,7 @@ function Public.generate_new_map()
     Init.draw_structures()
     Gui.reset_tables_gui()
     Init.load_spawn()
-    Init.reveal_map()
+    Init.queue_reveal_map()
     for _, player in pairs(game.players) do
         Functions.init_player(player)
         for _, e in pairs(player.gui.left.children) do

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -201,11 +201,7 @@ function Public.draw_structures()
 	--Terrain.generate_spawn_goodies(surface)
 end
 
-function Public.reveal_map()
-	if not global.bb_settings["bb_map_reveal_toggle"] then
-		return
-	end
-
+function Public.queue_reveal_map()
 	local chart_queue = global.chart_queue
 	-- important to flush the queue upon resetting a map or chunk requests from previous maps could overlap
 	Queue.clear(chart_queue) 
@@ -368,6 +364,9 @@ end
 
 ---@param max_requests number
 function Public.pop_chunk_request(max_requests)
+	if not global.bb_settings.bb_map_reveal_toggle then
+		return
+	end
 	max_requests = max_requests or 1
 	local chart_queue = global.chart_queue
 	local surface = game.surfaces[global.bb_surface_name]

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -220,6 +220,22 @@ function Public.queue_reveal_map()
 	end
 end
 
+---@param max_requests number
+function Public.pop_chunk_request(max_requests)
+	if not global.bb_settings.bb_map_reveal_toggle then
+		return
+	end
+	max_requests = max_requests or 1
+	local chart_queue = global.chart_queue
+	local surface = game.surfaces[global.bb_surface_name]
+	local spectator = game.forces.spectator
+
+	while max_requests > 0 and q_size(chart_queue) > 0 do
+		spectator.chart(surface, q_pop(chart_queue))
+		max_requests = max_requests - 1
+	end
+end
+
 function Public.tables()
 	local get_score = Score.get_table()
 	get_score.score_table = {}
@@ -359,22 +375,6 @@ function Public.load_spawn()
 		surface.request_to_generate_chunks({x = -16, y = y * -1 - 16}, 0)
 		surface.request_to_generate_chunks({x = -48, y = y * -1 - 16}, 0)
 		surface.request_to_generate_chunks({x = -80, y = y * -1 - 16}, 0)
-	end
-end
-
----@param max_requests number
-function Public.pop_chunk_request(max_requests)
-	if not global.bb_settings.bb_map_reveal_toggle then
-		return
-	end
-	max_requests = max_requests or 1
-	local chart_queue = global.chart_queue
-	local surface = game.surfaces[global.bb_surface_name]
-	local spectator = game.forces.spectator
-
-	while max_requests > 0 and q_size(chart_queue) > 0 do
-		spectator.chart(surface, q_pop(chart_queue))
-		max_requests = max_requests - 1
 	end
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -216,8 +216,12 @@ function Public.queue_reveal_map()
 			q_push(chart_queue, {{-x,  y}, {-x,  y}})
 			q_push(chart_queue, {{ x,  y}, { x,  y}})
 		end
+		-- spectator island (guarantees sounds to be played during map reveal)
 		q_push(chart_queue, {{-16, -16}, {16, 16}})
 	end
+
+	-- request whole starting area at the end again to clear any charting hiccup
+	q_push(chart_queue, {{-height, -height}, {height, height}})
 end
 
 ---@param max_requests number

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -207,7 +207,8 @@ function Public.reveal_map()
 	end
 
 	local chart_queue = global.chart_queue
-	Queue.clear(chart_queue)
+	-- important to flush the queue upon resetting a map or chunk requests from previous maps could overlap
+	Queue.clear(chart_queue) 
 
 	local width = 2000 -- for one side
 	local height = 500 -- for one side
@@ -365,8 +366,9 @@ function Public.load_spawn()
 	end
 end
 
-function Public.pop_chunk_requests()
-	local max_requests = 65 -- 16 chunks * 4 + 1 starting area
+---@param max_requests number
+function Public.pop_chunk_request(max_requests)
+	max_requests = max_requests or 1
 	local chart_queue = global.chart_queue
 	local surface = game.surfaces[global.bb_surface_name]
 	local spectator = game.forces.spectator

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -432,8 +432,18 @@ local function on_tick()
 		ResearchInfo.update_research_info_ui()
 	end
 
+	--[[
+		Map width: 2000 tiles (~64 chunks) each direction
+		Map height: 500 tiles (~16 chunks) each direction
+		Estimated time for complete reveal: 90s (5400 ticks)
+
+		pop_chunk_request will chart the queued chunk requests issued during a new map reveal.
+		We chart 65 chunks each iteration because of 16-chunks-tall zones NE, NW, SE, SW, + 1 bonus chunk which is the starting area.
+		To fully reveal the new map within the time window, the time interval between requests should be ~84 ticks (5400 / 64-chunks-length),
+		plus + 24 ticks as offset to avoid tick_0
+	]]
 	if (tick+24) % 84 == 0 then
-		Init.pop_chunk_requests()
+		Init.pop_chunk_request(65)
 	end
 end
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -613,7 +613,7 @@ local function on_init()
 	Init.forces()
 	Init.draw_structures()
 	Init.load_spawn()
-	Init.reveal_map()
+	Init.queue_reveal_map()
 end
 
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -137,7 +137,7 @@ function do_ping(from_player_name, to_player, message)
 	if to_player.character and to_player.character.get_health_ratio() > 0.99 then
 		to_player.character.damage(0.001, "player")
 	end
-	Sounds.notify_player(tp_player, "utility/blueprint_selection_ended")
+	Sounds.notify_player(to_player, "utility/blueprint_selection_ended")
 	-- to_player.play_sound({path = "utility/new_objective", volume_modifier = 0.6})
 	-- to_player.surface.create_entity({name = 'big-explosion', position = to_player.position})
 	local ping_header = to_player.gui.screen["ping_header"]
@@ -430,6 +430,10 @@ local function on_tick()
 	if (tick+5) % 180 == 0 then
 		Gui.refresh()
 		ResearchInfo.update_research_info_ui()
+	end
+
+	if (tick+24) % 84 == 0 then
+		Init.pop_chunk_requests()
 	end
 end
 

--- a/utils/queue.lua
+++ b/utils/queue.lua
@@ -84,4 +84,11 @@ function Queue.pairs(queue)
     end
 end
 
+function Queue.clear(queue)
+    for k, _ in pairs(queue) do
+        queue[k] = nil
+    end
+    queue._head, queue._tail = 1, 1
+end
+
 return Queue


### PR DESCRIPTION
### Brief description of the changes:
Follow up PR from https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/568

- [x] Fixed map reveal not obeying to "Config > Reveal map" switch
> It is now possible for admins to switch ON/OFF map reveal at ANY time, and not just before a new map. Which means, admins can interrupt/carry on map reveal at any time during the evolution of the map.

- [x] Fixed visual bugs on map view while charting
> "Big starting square" of 500 tiles each side will be requested once again at the end of map reveal (again, if map reveal switch is ON) to clear any visual bugs in hiccups/inconsistency of initial map reveal (see attachment)

![Screenshot from 2024-07-18 11-51-27](https://github.com/user-attachments/assets/34cd378f-6eeb-43b1-9f3f-bc02b7cf43ae)


### Tested Changes:
- [x] I've tested the changes locally in SP
- [ ] I've not tested the changes in MP
