### PR TITLE
Charting fixes

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -607,7 +607,7 @@ function Public.generate_new_map()
     Init.draw_structures()
     Gui.reset_tables_gui()
     Init.load_spawn()
-    Init.reveal_map()
+    Init.queue_reveal_map()
     for _, player in pairs(game.players) do
         Functions.init_player(player)
         for _, e in pairs(player.gui.left.children) do

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -219,7 +219,6 @@ function Public.queue_reveal_map()
 		-- spectator island (guarantees sounds to be played during map reveal)
 		q_push(chart_queue, {{-16, -16}, {16, 16}})
 	end
-
 	-- request whole starting area at the end again to clear any charting hiccup
 	q_push(chart_queue, {{-height, -height}, {height, height}})
 end
@@ -379,19 +378,6 @@ function Public.load_spawn()
 		surface.request_to_generate_chunks({x = -16, y = y * -1 - 16}, 0)
 		surface.request_to_generate_chunks({x = -48, y = y * -1 - 16}, 0)
 		surface.request_to_generate_chunks({x = -80, y = y * -1 - 16}, 0)
-	end
-end
-
----@param max_requests number
-function Public.pop_chunk_request(max_requests)
-	max_requests = max_requests or 1
-	local chart_queue = global.chart_queue
-	local surface = game.surfaces[global.bb_surface_name]
-	local spectator = game.forces.spectator
-
-	while max_requests > 0 and q_size(chart_queue) > 0 do
-		spectator.chart(surface, q_pop(chart_queue))
-		max_requests = max_requests - 1
 	end
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -215,12 +215,15 @@ function Public.queue_reveal_map()
 			q_push(chart_queue, {{ x, -y}, { x, -y}})
 			q_push(chart_queue, {{-x,  y}, {-x,  y}})
 			q_push(chart_queue, {{ x,  y}, { x,  y}})
+
+			if x == 496 and y == 496 then
+				-- request whole starting area at the end again to clear any charting hiccup
+				q_push(chart_queue, {{-height, -height}, {height, height}})
+			end
 		end
 		-- spectator island (guarantees sounds to be played during map reveal)
 		q_push(chart_queue, {{-16, -16}, {16, 16}})
 	end
-	-- request whole starting area at the end again to clear any charting hiccup
-	q_push(chart_queue, {{-height, -height}, {height, height}})
 end
 
 ---@param max_requests number

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -613,7 +613,7 @@ local function on_init()
 	Init.forces()
 	Init.draw_structures()
 	Init.load_spawn()
-	Init.reveal_map()
+	Init.queue_reveal_map()
 end
 
 


### PR DESCRIPTION
## Brief description of the changes:
Follow up PR from https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/568

- [x] Fixed map reveal not obeying to "Config > Reveal map" switch
> It is now possible for admins to switch ON/OFF map reveal at ANY time, and not just before a new map. Which means, admins can interrupt/carry on map reveal at any time during the evolution of the map.

- [x] Fixed visual bugs on map view while charting
> "Big starting square" of 500 tiles each side will be requested once again at the end of map reveal (again, if map reveal switch is ON) to clear any visual bugs in hiccups/inconsistency of initial map reveal (see attachment)

![Screenshot from 2024-07-18 11-51-27](https://github.com/user-attachments/assets/34cd378f-6eeb-43b1-9f3f-bc02b7cf43ae)


## Tested Changes:
- [x] I've tested the changes locally in SP
- [ ] I've not tested the changes in MP