### PR TITLE
feat(captains): revert captains join info panel player list sort logic

### DIFF
--- a/comfy_panel/special_games/captain_utils.lua
+++ b/comfy_panel/special_games/captain_utils.lua
@@ -26,7 +26,7 @@ end
 ---@param names string[]
 ---@return string
 function CaptainUtils.pretty_print_player_list(names)
-	return table.concat(player_utils.get_sorted_colored_player_list(player_utils.get_lua_players_from_player_names(names)), ", ")
+	return table.concat(player_utils.get_colored_player_list(player_utils.get_lua_players_from_player_names(names)), ", ")
 end
 
 return CaptainUtils

--- a/utils/player.lua
+++ b/utils/player.lua
@@ -2,6 +2,17 @@ local Public = {}
 
 ---@param player_list LuaPlayer[]
 ---@return string[]
+function Public.get_colored_player_list(player_list)
+	local players_with_colors = {}
+	for _, player in pairs(player_list) do
+		table.insert(players_with_colors, string.format("[color=%.2f,%.2f,%.2f]%s[/color]", player.color.r * 0.6 + 0.4, player.color.g * 0.6 + 0.4, player.color.b * 0.6 + 0.4, player.name))
+	end
+
+	return players_with_colors
+end
+
+---@param player_list LuaPlayer[]
+---@return string[]
 function Public.get_sorted_colored_player_list(player_list)
 	local players_with_sort_keys = {}
 	for _, p in pairs(player_list) do
@@ -9,13 +20,12 @@ function Public.get_sorted_colored_player_list(player_list)
 	end
 	table.sort(players_with_sort_keys, function(a, b) return a.sort_key < b.sort_key end)
 
-	local players_with_colors = {}
+	local sorted_player_list = {}
 	for _, pair in ipairs(players_with_sort_keys) do
-		local p = pair.player
-		table.insert(players_with_colors, string.format("[color=%.2f,%.2f,%.2f]%s[/color]", p.color.r * 0.6 + 0.4, p.color.g * 0.6 + 0.4, p.color.b * 0.6 + 0.4, p.name))
+		table.insert(sorted_player_list, pair.player)
 	end
 
-	return players_with_colors
+	return Public.get_colored_player_list(player_list)
 end
 
 ---@param names string[]


### PR DESCRIPTION
### Brief description of the changes:
carl raised this issue to me
the player list was being sorted by player play time (on insert to player list)
in an earlier PR I updated the player list to be sorted by name (on render)
this PR reverts the sorting change

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
