### PR TITLE
fix: teams player list no longer sorted

### DIFF
--- a/utils/player.lua
+++ b/utils/player.lua
@@ -25,7 +25,7 @@ function Public.get_sorted_colored_player_list(player_list)
 		table.insert(sorted_player_list, pair.player)
 	end
 
-	return Public.get_colored_player_list(player_list)
+	return Public.get_colored_player_list(sorted_player_list)
 end
 
 ---@param names string[]


### PR DESCRIPTION
### Brief description of the changes:
there was a bug where the unsorted list was used instead of the sorted player list

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
