### PR TITLE
teamstats: add a bit more info

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -146,6 +146,9 @@ function Public.initial_setup()
 
 	global.total_time_online_players = {}
 	global.already_logged_current_session_time_online_players = {}
+	---@type table<string, {show_hidden: boolean?}>
+	global.teamstats_preferences = {}
+	global.allow_teamstats = "always"
 	--Disable Nauvis
 	local surface = game.surfaces[1]
 	local map_gen_settings = surface.map_gen_settings

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -4,8 +4,10 @@ local Tables = require 'maps.biter_battles_v2.tables'
 local closable_frame = require "utils.ui.closable_frame"
 local TeamStatsCollect = require 'maps.biter_battles_v2.team_stats_collect'
 local safe_wrap_with_player_print = require 'utils.utils'.safe_wrap_with_player_print
+local Event = require 'utils.event'
 
 local math_floor = math.floor
+local math_max = math.max
 local string_format = string.format
 
 local TeamStatsCompare = {}
@@ -17,14 +19,26 @@ local function ticks_to_hh_mm(ticks)
     return string_format("%02d:%02d", total_hours, minutes)
 end
 
----@param num number
+---@param num number?
 ---@return string
 local function format_with_thousands_sep(num)
-    num = math_floor(num)
+    num = math_floor(num or 0)
     local str = tostring(num)
     local reversed = str:reverse()
     local formatted_reversed = reversed:gsub("(%d%d%d)", "%1,")
     return (formatted_reversed:reverse():gsub("^,", ""))
+end
+
+---@param num number
+---@return string
+local function format_one_sig_fig(num)
+    if num < 0.1 then
+        return string_format("%.2f", num)
+    elseif num < 1 then
+        return string_format("%.1f", num)
+    else
+        return format_with_thousands_sep(num)
+    end
 end
 
 ---@param player LuaPlayer
@@ -33,6 +47,7 @@ function TeamStatsCompare.show_stats(player, stats)
     if stats == nil then
         stats = TeamStatsCollect.compute_stats()
     end
+    local show_hidden = global.teamstats_preferences[player.name] and global.teamstats_preferences[player.name].show_hidden or false
     ---@type LuaGuiElement
     local frame = player.gui.screen["teamstats_frame"]
     if frame then
@@ -72,6 +87,7 @@ function TeamStatsCompare.show_stats(player, stats)
     top_table.style.column_alignments[2] = "center"
     top_table.style.column_alignments[3] = "left"
     add_simple_force_stats("north", top_table)
+    local space_sci_mutagen = Tables.food_values["space-science-pack"].value
     if true then
         local shared_frame = top_table.add { type = "frame", name = "summary_shared", direction = "vertical" }
         local centering_table = shared_frame.add { type = "table", name = "centering_table", column_count = 1 }
@@ -89,6 +105,9 @@ function TeamStatsCompare.show_stats(player, stats)
     add_simple_force_stats("south", top_table)
 
     local two_table = top_centering_table.add { type = "table", name = "two_table", column_count = 2, vertical_centering = true }
+    two_table.style.column_alignments[1] = "right"
+    two_table.style.left_cell_padding = 4
+    two_table.style.right_cell_padding = 4
     local font = "default-small"
     for _, force_name in ipairs({"north", "south"}) do
         local science_flow = two_table.add { type = "flow", name = "science_flow_" .. force_name, direction = "vertical" }
@@ -108,38 +127,48 @@ function TeamStatsCompare.show_stats(player, stats)
             l.style.font = font
         end
         local total_sent_mutagen = 0
+        local total_produced_mutagen = 0
         for _, food in ipairs(Tables.food_long_and_short) do
             local force_stats = stats.forces[force_name]
             local food_stats = force_stats.food[food.long_name] or {}
+            local food_mutagen = Tables.food_values[food.long_name].value
+            local produced = food_stats.produced or 0
+            local consumed = food_stats.consumed or 0
+            local sent = food_stats.sent or 0
             local l
             l = science_table.add { type = "label", caption = string_format("[item=%s]", food.long_name) }
             l.style.font = font
             l = science_table.add { type = "label", caption = (food_stats.first_at and ticks_to_hh_mm(food_stats.first_at) or "") }
             l.style.font = font
-            l = science_table.add { type = "label", caption = format_with_thousands_sep(food_stats.produced or 0) }
+            l = science_table.add { type = "label", caption = format_with_thousands_sep(produced), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(produced * food_mutagen / space_sci_mutagen) }
             l.style.font = font
-            l = science_table.add { type = "label", caption = format_with_thousands_sep(food_stats.consumed or 0) }
+            l = science_table.add { type = "label", caption = format_with_thousands_sep(consumed), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(consumed * food_mutagen / space_sci_mutagen) }
             l.style.font = font
-            l = science_table.add { type = "label", caption = food_stats.sent and format_with_thousands_sep(food_stats.sent) or "0" }
+            l = science_table.add { type = "label", caption = format_with_thousands_sep(sent), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(sent * food_mutagen / space_sci_mutagen) }
             l.style.font = font
-            total_sent_mutagen = total_sent_mutagen + (food_stats.sent or 0) * Tables.food_values[food.long_name].value
+            total_sent_mutagen = total_sent_mutagen + (food_stats.sent or 0) * food_mutagen
+            total_produced_mutagen = total_produced_mutagen + (food_stats.produced or 0) * food_mutagen
         end
-        local l = science_flow.add { type = "label", caption = string_format("[item=space-science-pack] equivalent %d", total_sent_mutagen / Tables.food_values["space-science-pack"].value) }
+        local l = science_flow.add { type = "label", caption = string_format("[item=space-science-pack] equivalent produced: %s sent: %s", format_one_sig_fig(total_produced_mutagen/space_sci_mutagen), format_one_sig_fig(total_sent_mutagen / space_sci_mutagen)) }
         l.style.font = font
     end
 
     two_table.add { type = "line" }
     two_table.add { type = "line" }
     for _, force_name in ipairs({"north", "south"}) do
-        local item_table = two_table.add { type = "table", name = "item_table_" .. force_name, column_count = 5, vertical_centering = false }
-        gui_style(item_table, { left_cell_padding = 3, right_cell_padding = 3, vertical_spacing = 0})
+        local force_stats = stats.forces[force_name]
         local cols = {
-            {""},
+            {"[img=info]", "Hover over icons for full details"},
             {"First [img=info]", "The time that the first item was produced."},
             {"Produced"},
             {"Placed [img=info]", "The highest value of (constructed-deconstructed) over time."},
             {"Lost"},
         }
+        if show_hidden then
+            table.insert(cols, 4, {"Buffered [img=info]", "Produced - Consumed - Placed - Lost. This can double-count placed+lost, so might be too low."})
+        end
+        local item_table = two_table.add { type = "table", name = "item_table_" .. force_name, column_count = #cols, vertical_centering = false }
+        gui_style(item_table, { left_cell_padding = 3, right_cell_padding = 3, vertical_spacing = 0})
         for idx, col_info in ipairs(cols) do
             item_table.style.column_alignments[idx] = "right"
             local l = item_table.add { type = "label", caption = col_info[1], tooltip = col_info[2] }
@@ -147,24 +176,36 @@ function TeamStatsCompare.show_stats(player, stats)
         end
 
         for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
-            local force_stats = stats.forces[force_name]
-            local item_stats = force_stats.items[item_info.item] or {}
-            local killed_or_lost = (item_stats.kill_count or 0) + (item_stats.lost or 0)
-            if killed_or_lost == 0 then killed_or_lost = nil end
-            local l
-            l = item_table.add { type = "label", caption = string_format("[item=%s]", item_info.item) }
-            l.style.font = font
-            if item_info.space_after then
-                l.style.bottom_padding = 12
+            if show_hidden or not item_info.hide_by_default then
+                local item_stats = force_stats.items[item_info.item] or {}
+                ---@type number?
+                local killed_or_lost = (item_stats.kill_count or 0) + (item_stats.lost or 0)
+                if killed_or_lost == 0 then killed_or_lost = nil end
+                local buffered = math_max(0, (item_stats.produced or 0) - (item_stats.consumed or 0) - (item_stats.placed or 0) - (item_stats.lost or 0))
+                local tooltip = string_format("Produced: %s, Consumed: %s, Lost: %s, Buffered: %s",
+                    format_with_thousands_sep(item_stats.produced or 0),
+                    format_with_thousands_sep(item_stats.consumed or 0),
+                    format_with_thousands_sep(item_stats.lost or 0),
+                    format_with_thousands_sep(buffered))
+                local l
+                l = item_table.add { type = "label", caption = string_format("[item=%s]", item_info.item), tooltip = tooltip}
+                l.style.font = font
+                if item_info.space_after then
+                    l.style.bottom_padding = 12
+                end
+                l = item_table.add { type = "label", caption = (item_stats.first_at and ticks_to_hh_mm(item_stats.first_at) or "") }
+                l.style.font = font
+                l = item_table.add { type = "label", caption = format_with_thousands_sep(item_stats.produced or 0) }
+                l.style.font = font
+                if show_hidden then
+                    l = item_table.add { type = "label", caption = format_with_thousands_sep(buffered) }
+                    l.style.font = font
+                end
+                l = item_table.add { type = "label", caption = item_stats.placed and format_with_thousands_sep(item_stats.placed) or "" }
+                l.style.font = font
+                l = item_table.add { type = "label", caption = killed_or_lost and format_with_thousands_sep(killed_or_lost) or "" }
+                l.style.font = font
             end
-            l = item_table.add { type = "label", caption = (item_stats.first_at and ticks_to_hh_mm(item_stats.first_at) or "") }
-            l.style.font = font
-            l = item_table.add { type = "label", caption = format_with_thousands_sep(item_stats.produced or 0) }
-            l.style.font = font
-            l = item_table.add { type = "label", caption = item_stats.placed and format_with_thousands_sep(item_stats.placed) or "" }
-            l.style.font = font
-            l = item_table.add { type = "label", caption = killed_or_lost and format_with_thousands_sep(killed_or_lost) or "" }
-            l.style.font = font
         end
     end
 
@@ -225,6 +266,8 @@ function TeamStatsCompare.show_stats(player, stats)
             l.style.font = font
         end
     end
+    top_centering_table.add { type = "line" }
+    top_centering_table.add { type = "checkbox", name = "teamstats_show_hidden", caption = "Show more items", state = show_hidden }
 end
 
 function TeamStatsCompare.game_over()
@@ -266,5 +309,19 @@ commands.add_command("teamstats", "Show team stats", function (cmd)
     end
     safe_wrap_with_player_print(player, TeamStatsCompare.show_stats, player, stats)
 end)
+
+---@param event EventData.on_gui_checked_state_changed
+local function on_gui_checked_state_changed(event)
+    local player = game.get_player(event.player_index)
+    if not player then return end
+    if not event.element.valid then return end
+    if event.element.name == "teamstats_show_hidden" then
+        global.teamstats_preferences[player.name] = global.teamstats_preferences[player.name] or {}
+        global.teamstats_preferences[player.name].show_hidden = event.element.state
+        safe_wrap_with_player_print(player, TeamStatsCompare.show_stats, player)
+    end
+end
+
+Event.add(defines.events.on_gui_checked_state_changed, on_gui_checked_state_changed)
 
 return TeamStatsCompare

--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -12,6 +12,16 @@ local string_format = string.format
 
 local TeamStatsCompare = {}
 
+---@param parent LuaGuiElement
+---@param a LuaGuiElement.add_param
+---@return LuaGuiElement
+local function add_small_label(parent, a)
+    a.type = "label"
+    local l = parent.add(a)
+    l.style.font = "default-small"
+    return l
+end
+
 local function ticks_to_hh_mm(ticks)
     local total_minutes = math_floor(ticks / (60 * 60))
     local total_hours = math_floor(total_minutes / 60)
@@ -92,14 +102,10 @@ function TeamStatsCompare.show_stats(player, stats)
         local shared_frame = top_table.add { type = "frame", name = "summary_shared", direction = "vertical" }
         local centering_table = shared_frame.add { type = "table", name = "centering_table", column_count = 1 }
         centering_table.style.column_alignments[1] = "center"
-        local l
-        l = centering_table.add { type = "label", caption = string_format("Difficulty: %s (%d%%)", (stats.difficulty or ""), (stats.difficulty_value or 0) * 100) }
-        l.style.font = "default-small"
-        l = centering_table.add { type = "label", caption = string_format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) }
-        l.style.font = "default-small"
+        add_small_label(centering_table, { caption = string_format("Difficulty: %s (%d%%)", (stats.difficulty or ""), (stats.difficulty_value or 0) * 100) })
+        add_small_label(centering_table, { caption = string_format("Duration: %s", ticks_to_hh_mm(stats.ticks or 0)) })
         if stats.won_by_team then
-            l = centering_table.add { type = "label", caption = string_format("Winner: %s", stats.won_by_team == "north" and "North" or "South") }
-            l.style.font = "default-small"
+            add_small_label(centering_table, { caption = string_format("Winner: %s", stats.won_by_team == "north" and "North" or "South") })
         end
     end
     add_simple_force_stats("south", top_table)
@@ -108,7 +114,6 @@ function TeamStatsCompare.show_stats(player, stats)
     two_table.style.column_alignments[1] = "right"
     two_table.style.left_cell_padding = 4
     two_table.style.right_cell_padding = 4
-    local font = "default-small"
     for _, force_name in ipairs({"north", "south"}) do
         local science_flow = two_table.add { type = "flow", name = "science_flow_" .. force_name, direction = "vertical" }
         gui_style(science_flow, { horizontal_align = "center" })
@@ -123,8 +128,7 @@ function TeamStatsCompare.show_stats(player, stats)
         gui_style(science_table, { left_cell_padding = 3, right_cell_padding = 3, vertical_spacing = 0 })
         for idx, col_info in ipairs(cols) do
             science_table.style.column_alignments[idx] = "right"
-            local l = science_table.add { type = "label", caption = col_info[1], tooltip = col_info[2] }
-            l.style.font = font
+            add_small_label(science_table, { caption = col_info[1], tooltip = col_info[2] })
         end
         local total_sent_mutagen = 0
         local total_produced_mutagen = 0
@@ -135,22 +139,15 @@ function TeamStatsCompare.show_stats(player, stats)
             local produced = food_stats.produced or 0
             local consumed = food_stats.consumed or 0
             local sent = food_stats.sent or 0
-            local l
-            l = science_table.add { type = "label", caption = string_format("[item=%s]", food.long_name) }
-            l.style.font = font
-            l = science_table.add { type = "label", caption = (food_stats.first_at and ticks_to_hh_mm(food_stats.first_at) or "") }
-            l.style.font = font
-            l = science_table.add { type = "label", caption = format_with_thousands_sep(produced), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(produced * food_mutagen / space_sci_mutagen) }
-            l.style.font = font
-            l = science_table.add { type = "label", caption = format_with_thousands_sep(consumed), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(consumed * food_mutagen / space_sci_mutagen) }
-            l.style.font = font
-            l = science_table.add { type = "label", caption = format_with_thousands_sep(sent), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(sent * food_mutagen / space_sci_mutagen) }
-            l.style.font = font
+            add_small_label(science_table, { caption = string_format("[item=%s]", food.long_name) })
+            add_small_label(science_table, { caption = (food_stats.first_at and ticks_to_hh_mm(food_stats.first_at) or "") })
+            add_small_label(science_table, { caption = format_with_thousands_sep(produced), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(produced * food_mutagen / space_sci_mutagen) })
+            add_small_label(science_table, { caption = format_with_thousands_sep(consumed), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(consumed * food_mutagen / space_sci_mutagen) })
+            add_small_label(science_table, { caption = format_with_thousands_sep(sent), tooltip = "[item=space-science-pack] equivalent: " .. format_one_sig_fig(sent * food_mutagen / space_sci_mutagen) })
             total_sent_mutagen = total_sent_mutagen + (food_stats.sent or 0) * food_mutagen
             total_produced_mutagen = total_produced_mutagen + (food_stats.produced or 0) * food_mutagen
         end
-        local l = science_flow.add { type = "label", caption = string_format("[item=space-science-pack] equivalent produced: %s sent: %s", format_one_sig_fig(total_produced_mutagen/space_sci_mutagen), format_one_sig_fig(total_sent_mutagen / space_sci_mutagen)) }
-        l.style.font = font
+        add_small_label(science_flow, { caption = string_format("[item=space-science-pack] equivalent produced: %s sent: %s", format_one_sig_fig(total_produced_mutagen/space_sci_mutagen), format_one_sig_fig(total_sent_mutagen / space_sci_mutagen)) })
     end
 
     two_table.add { type = "line" }
@@ -171,8 +168,7 @@ function TeamStatsCompare.show_stats(player, stats)
         gui_style(item_table, { left_cell_padding = 3, right_cell_padding = 3, vertical_spacing = 0})
         for idx, col_info in ipairs(cols) do
             item_table.style.column_alignments[idx] = "right"
-            local l = item_table.add { type = "label", caption = col_info[1], tooltip = col_info[2] }
-            l.style.font = font
+            add_small_label(item_table, { caption = col_info[1], tooltip = col_info[2] })
         end
 
         for _, item_info in ipairs(TeamStatsCollect.items_to_show_summaries_of) do
@@ -187,24 +183,17 @@ function TeamStatsCompare.show_stats(player, stats)
                     format_with_thousands_sep(item_stats.consumed or 0),
                     format_with_thousands_sep(item_stats.lost or 0),
                     format_with_thousands_sep(buffered))
-                local l
-                l = item_table.add { type = "label", caption = string_format("[item=%s]", item_info.item), tooltip = tooltip}
-                l.style.font = font
+                local l = add_small_label(item_table, { caption = string_format("[item=%s]", item_info.item), tooltip = tooltip})
                 if item_info.space_after then
                     l.style.bottom_padding = 12
                 end
-                l = item_table.add { type = "label", caption = (item_stats.first_at and ticks_to_hh_mm(item_stats.first_at) or "") }
-                l.style.font = font
-                l = item_table.add { type = "label", caption = format_with_thousands_sep(item_stats.produced or 0) }
-                l.style.font = font
+                add_small_label(item_table, { caption = (item_stats.first_at and ticks_to_hh_mm(item_stats.first_at) or "") })
+                add_small_label(item_table, { caption = format_with_thousands_sep(item_stats.produced or 0) })
                 if show_hidden then
-                    l = item_table.add { type = "label", caption = format_with_thousands_sep(buffered) }
-                    l.style.font = font
+                    add_small_label(item_table, { caption = format_with_thousands_sep(buffered) })
                 end
-                l = item_table.add { type = "label", caption = item_stats.placed and format_with_thousands_sep(item_stats.placed) or "" }
-                l.style.font = font
-                l = item_table.add { type = "label", caption = killed_or_lost and format_with_thousands_sep(killed_or_lost) or "" }
-                l.style.font = font
+                add_small_label(item_table, { caption = item_stats.placed and format_with_thousands_sep(item_stats.placed) or "" })
+                add_small_label(item_table, { caption = killed_or_lost and format_with_thousands_sep(killed_or_lost) or "" })
             end
         end
     end
@@ -236,8 +225,7 @@ function TeamStatsCompare.show_stats(player, stats)
                 if idx > 1 then
                     damage_table.style.column_alignments[idx] = "right"
                 end
-                local l = damage_table.add { type = "label", caption = col_info[1], tooltip = col_info[2] }
-                l.style.font = font
+                add_small_label(damage_table, { caption = col_info[1], tooltip = col_info[2] })
             end
 
             local force_stats = stats.forces[force_name]
@@ -248,22 +236,14 @@ function TeamStatsCompare.show_stats(player, stats)
                     local damage_info = force_stats.damage_types[damage_render_info[1]] or {}
                     total_kills = total_kills + (damage_info.kills or 0)
                     total_damage = total_damage + (damage_info.damage or 0)
-                    local l
-                    l = damage_table.add { type = "label", caption = damage_render_info[2], tooltip = damage_render_info[3] }
-                    l.style.font = font
-                    l = damage_table.add { type = "label", caption = format_with_thousands_sep(damage_info.kills or 0) }
-                    l.style.font = font
-                    l = damage_table.add { type = "label", caption = format_with_thousands_sep(damage_info.damage or 0) }
-                    l.style.font = font
+                    add_small_label(damage_table, { caption = damage_render_info[2], tooltip = damage_render_info[3] })
+                    add_small_label(damage_table, { caption = format_with_thousands_sep(damage_info.kills or 0) })
+                    add_small_label(damage_table, { caption = format_with_thousands_sep(damage_info.damage or 0) })
                 end
             end
-            local l
-            l = damage_table.add { type = "label", caption = "Total" }
-            l.style.font = font
-            l = damage_table.add { type = "label", caption = format_with_thousands_sep(total_kills) }
-            l.style.font = font
-            l = damage_table.add { type = "label", caption = format_with_thousands_sep(total_damage) }
-            l.style.font = font
+            add_small_label(damage_table, { caption = "Total" })
+            add_small_label(damage_table, { caption = format_with_thousands_sep(total_kills) })
+            add_small_label(damage_table, { caption = format_with_thousands_sep(total_damage) })
         end
     end
     top_centering_table.add { type = "line" }


### PR DESCRIPTION
Specifically, this does the following things:

1. Adds a "Show more items" checkbox that displays rocket-components, rgb chips, redbelt, boilers+steam engines.
2. Adds science space-sci-equiv tooltips in a bunch of places
3. Adds a "buffered" column when "show more items" is checked that indicates how many of these items are buffered (i.e. items just sitting around).
4. Adds tooltips for each item-produced that include the "buffered" number.
5. Adds electric miners to the view all the time.
6. Some small display tweaks
7. When using `/c global.team_stats_use_fake_data = true`, the displayed numbers are chosen using `math.exp` so they should have a much more widely varying number of digits, much like real numbers in the game do, to make the display look a bit more realistic.
8. Puts in code that `/teamstats` is always enabled-by-default. I have been manually doing this on server restart.

Screenshot (using fake data) with "Show more items" checked:
![image](https://github.com/user-attachments/assets/6b8c791f-75dc-44f7-9bd0-810e0b5994a4)

### Tested Changes:
- [x] I've tested the changes locally
- [ ] I've not tested the changes.
