### PR TITLE
Reduce the majority required for a map reroll from 75% to 66%

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -571,7 +571,7 @@ decrement_timer_token = Token.register(
                     result = result + vote
                 end
                 result = math.floor( 100*result / total_votes )
-                if result >= 75 then
+                if result >= 66 then
                     game.print("Vote to reload the map has succeeded (" .. result .. "%)")
                     game.print("Map is being rerolled!", {r = 0.22, g = 0.88, b = 0.22})
                     Public.generate_new_map()


### PR DESCRIPTION
### Brief description of the changes:
Reduce the majority required for a map reroll from the current 75% to 66%

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [x] I've not tested the changes.

Vote : https://discord.com/channels/823696400797138974/823771211421974579/1264704865263943691