### PR TITLE
Synchronize voting time with displayed time in gui. 

### DIFF
--- a/commands/difficulty_voting_commands.lua
+++ b/commands/difficulty_voting_commands.lua
@@ -13,9 +13,9 @@ local function revote()
             return
 
         else
-            local tick = game.ticks_played
-            if not global.active_special_games["captain_mode"] then
-                tick = Functions.get_ticks_since_game_start() 
+            local tick = Functions.get_ticks_since_game_start()
+            if global.active_special_games["captain_mode"] then
+                 tick = game.ticks_played 
             end
             global.difficulty_votes_timeout = tick + 10800
             global.difficulty_player_votes = {}
@@ -50,10 +50,10 @@ local function close_difficulty_votes(cmd)
         game.print(message, difficulty_vote.difficulty_print_color())
         Server.to_discord_embed(message)
     end
-    local tick = game.ticks_played
-    if not global.active_special_games["captain_mode"] then
-        tick = Functions.get_ticks_since_game_start() 
-    end
+	local tick = Functions.get_ticks_since_game_start()
+	if global.active_special_games["captain_mode"] then
+		 tick = game.ticks_played 
+	end
     global.difficulty_votes_timeout = tick
     local msg = player.name .. " closed difficulty voting"
     game.print(msg)

--- a/commands/difficulty_voting_commands.lua
+++ b/commands/difficulty_voting_commands.lua
@@ -2,6 +2,7 @@ local Server = require 'utils.server'
 local Color = require 'utils.color_presets'
 local tables = require 'maps.biter_battles_v2.tables'
 local difficulty_vote = require 'maps.biter_battles_v2.difficulty_vote'
+local Functions = require "maps.biter_battles_v2.functions"
 
 local function revote()
     local player = game.player
@@ -13,6 +14,9 @@ local function revote()
 
         else
             local tick = game.ticks_played
+            if not global.active_special_games["captain_mode"] then
+                tick = Functions.get_ticks_since_game_start() 
+            end
             global.difficulty_votes_timeout = tick + 10800
             global.difficulty_player_votes = {}
             local msg = player.name .. " opened difficulty voting. Voting enabled for 3 mins"
@@ -46,7 +50,11 @@ local function close_difficulty_votes(cmd)
         game.print(message, difficulty_vote.difficulty_print_color())
         Server.to_discord_embed(message)
     end
-    global.difficulty_votes_timeout = game.ticks_played
+    local tick = game.ticks_played
+    if not global.active_special_games["captain_mode"] then
+        tick = Functions.get_ticks_since_game_start() 
+    end
+    global.difficulty_votes_timeout = tick
     local msg = player.name .. " closed difficulty voting"
     game.print(msg)
     Server.to_discord_embed(msg)

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -5,6 +5,7 @@ local Server = require 'utils.server'
 local Tables = require "maps.biter_battles_v2.tables"
 local gui_style = require 'utils.utils'.gui_style
 local closable_frame = require "utils.ui.closable_frame"
+local Functions = require "maps.biter_battles_v2.functions"
 local Public = {}
 
 local difficulties = Tables.difficulties
@@ -90,7 +91,10 @@ local function poll_difficulty(player)
 	end
 	
 	local tick = game.ticks_played
-	if tick > global.difficulty_votes_timeout then
+	if not global.active_special_games["captain_mode"] then
+		 tick = Functions.get_ticks_since_game_start() 
+	end
+	if tick >= global.difficulty_votes_timeout then
 		if player.online_time ~= 0 then
 			local t = math.abs(math.floor((global.difficulty_votes_timeout - tick) / 3600))
 			local str = "Votes have closed " .. t
@@ -212,7 +216,11 @@ local function on_gui_click(event)
 	end
 	if event.element.type ~= "button" then return end
 	if event.element.parent.name ~= "difficulty_poll" then return end
-	if game.ticks_played > global.difficulty_votes_timeout then event.element.parent.destroy() return end
+	local tick = game.ticks_played
+	if not global.active_special_games["captain_mode"] then
+		 tick = Functions.get_ticks_since_game_start() 
+	end
+	if tick >= global.difficulty_votes_timeout then event.element.parent.destroy() return end
 	local i = tonumber(event.element.name)
 	
 	if global.bb_settings.only_admins_vote or global.tournament_mode then

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -90,9 +90,9 @@ local function poll_difficulty(player)
 		end
 	end
 	
-	local tick = game.ticks_played
-	if not global.active_special_games["captain_mode"] then
-		 tick = Functions.get_ticks_since_game_start() 
+	local tick = Functions.get_ticks_since_game_start()
+	if global.active_special_games["captain_mode"] then
+		 tick = game.ticks_played 
 	end
 	if tick >= global.difficulty_votes_timeout then
 		if player.online_time ~= 0 then
@@ -216,9 +216,9 @@ local function on_gui_click(event)
 	end
 	if event.element.type ~= "button" then return end
 	if event.element.parent.name ~= "difficulty_poll" then return end
-	local tick = game.ticks_played
-	if not global.active_special_games["captain_mode"] then
-		 tick = Functions.get_ticks_since_game_start() 
+	local tick = Functions.get_ticks_since_game_start()
+	if global.active_special_games["captain_mode"] then
+		 tick = game.ticks_played 
 	end
 	if tick >= global.difficulty_votes_timeout then event.element.parent.destroy() return end
 	local i = tonumber(event.element.name)

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -212,7 +212,11 @@ end
 --- @param player LuaPlayer
 --- @param food string
 function Public.feed_biters_from_inventory(player, food)
-	if game.ticks_played < global.difficulty_votes_timeout then
+	local tick = game.ticks_played
+	if not global.active_special_games["captain_mode"] then
+		tick = Functions.get_ticks_since_game_start() 
+	end
+	if tick <= global.difficulty_votes_timeout then
 		player.print("Please wait for voting to finish before feeding")
 		return
 	end
@@ -250,7 +254,11 @@ end
 --- @param player LuaPlayer
 --- @param button defines.mouse_button_type
 function Public.feed_biters_mixed_from_inventory(player, button)
-	if game.ticks_played < global.difficulty_votes_timeout then
+	local tick = game.ticks_played
+	if not global.active_special_games["captain_mode"] then
+		tick = Functions.get_ticks_since_game_start() 
+	end
+	if tick <= global.difficulty_votes_timeout then
 		player.print("Please wait for voting to finish before feeding")
 		return
 	end

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -212,9 +212,9 @@ end
 --- @param player LuaPlayer
 --- @param food string
 function Public.feed_biters_from_inventory(player, food)
-	local tick = game.ticks_played
-	if not global.active_special_games["captain_mode"] then
-		tick = Functions.get_ticks_since_game_start() 
+	local tick = Functions.get_ticks_since_game_start()
+	if global.active_special_games["captain_mode"] then
+		 tick = game.ticks_played 
 	end
 	if tick <= global.difficulty_votes_timeout then
 		player.print("Please wait for voting to finish before feeding")
@@ -254,9 +254,9 @@ end
 --- @param player LuaPlayer
 --- @param button defines.mouse_button_type
 function Public.feed_biters_mixed_from_inventory(player, button)
-	local tick = game.ticks_played
-	if not global.active_special_games["captain_mode"] then
-		tick = Functions.get_ticks_since_game_start() 
+	local tick = Functions.get_ticks_since_game_start()
+	if global.active_special_games["captain_mode"] then
+		 tick = game.ticks_played 
 	end
 	if tick <= global.difficulty_votes_timeout then
 		player.print("Please wait for voting to finish before feeding")


### PR DESCRIPTION
### Brief description of the changes:
now voting time will use gui time instead of game.ticks_played
previously voting was closing even if no-one joined team.  
now players have 10 min to vote from the actual match start which is started by multiple actions like crafting mining.

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
