### PR TITLE
teamstats: log json version of stats in various places

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -445,6 +445,7 @@ function Public.silo_death(event)
                           '\\n\\n' .. north_players .. '\\n\\n' .. south_players
 
     Server.to_discord_embed(discord_message)
+    log({'', '[TEAMSTATS-FINAL]', game.table_to_json(global.team_stats)})
 
     global.results_sent_south = false
     global.results_sent_north = false
@@ -476,6 +477,7 @@ function Public.silo_death(event)
           log_to_db('[Playtime][' .. player.name .. ']' .. special.stats.playerPlaytimes[player.name] .. '\n', true)
         end
       end
+      log_to_db('[TeamStats]'..game.table_to_json(global.team_stats)..'\n',true)
       log_to_db('>End of log', true)
     end
   end

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -253,6 +253,7 @@ function Public.tables()
 	global.science_logs_total_south = nil
 	---@type TeamStats
 	global.team_stats = {forces = {north = {items = {}, food = {}, damage_types = {}}, south = {items = {}, food = {}, damage_types = {}}}}
+	global.last_teamstats_print_at = 0
 	-- Name of main BB surface within game.surfaces
 	-- We hot-swap here between 2 surfaces.
 	if global.bb_surface_name == 'bb0' then

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -171,6 +171,12 @@ local function update_teamstats()
             end
         end
     end
+
+    local last_print = global.last_teamstats_print_at or 0
+    if tick - last_print > 5 * 60 * 60 then
+        log({'', '[TEAMSTATS-PERIODIC]', game.table_to_json(team_stats)})
+        global.last_teamstats_print_at = tick
+    end
 end
 
 ---@param max number


### PR DESCRIPTION
This should allow them to be part of captains game histories, and if someone builds a more generic database copying logic, they could also be taken from the logs in general for all games.

From my random sampling of the artifically/randomly generated numbers, it ends up as approximately 5kb worth of JSON data.

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
