### PR TITLE
Fix reply notification to wrong player

### DIFF
--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -293,7 +293,7 @@ local function on_console_command(event)
 		local to_player = game.get_player(to_player_name)
 		if to_player then
 			do_ping(player.name, to_player, player.name .. " (whisper): " .. rest_of_message)
-			global.reply_target[to_player_name] = player.name
+			global.reply_target[to_player.name] = player.name
 		end
 	elseif cmd == "r" or cmd == "reply" then
 		local to_player_name = global.reply_target[player.name]

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -293,6 +293,7 @@ local function on_console_command(event)
 		local to_player = game.get_player(to_player_name)
 		if to_player then
 			do_ping(player.name, to_player, player.name .. " (whisper): " .. rest_of_message)
+			-- to_player_name is case insensitive, so use to_player.name instead
 			global.reply_target[to_player.name] = player.name
 		end
 	elseif cmd == "r" or cmd == "reply" then


### PR DESCRIPTION
Possible fix to https://discord.com/channels/823696400797138974/1003021908796784800/1271577169344204821
For private messages, players can write the username in a different case, for example `/w PaveV` or `/w pavev`
Such messages will reach the user correctly. But this will create entries with different keys in the `global.reply_target table`
So then, in response with `/r` command, the wrong entry is chosen and the wrong player receives the notification.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
