### PR TITLE
Replace "reanim_chance" with "biter_health_factor"

### DIFF
--- a/comfy_panel/poll.lua
+++ b/comfy_panel/poll.lua
@@ -333,6 +333,10 @@ local function draw_main_frame(player)
     local poll_flow = Gui.add_left_element(player, { type = 'flow', name = poll_flow_name, direction = 'vertical' })
     gui_style(poll_flow, flow_style)
 
+    local old_frame = poll_flow[main_frame_name]
+    if old_frame then
+        old_frame.destroy()
+    end
     local frame = poll_flow.add({ type = 'frame', name = main_frame_name, direction = 'vertical' })
     gui_style(frame, frame_style())
 

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -123,7 +123,7 @@ local function spawn_biters(
     -- *1.5 because we add 50% health bonus as it's just one unit.
     -- *20 because one boss is equal of 20 biters in theory
     -- formula because 90% revive chance is 1/(1-0.9) = 10, which means biters needs to be killed 10 times, so *10 . easy fast-check : 50% revive is 2 biters worth, formula matches. 0% revive -> 1 biter worth
-    local health_buff_equivalent_revive = 1.0 / (1.0 - global.reanim_chance[game.forces[biter_force_name].index] / 100)
+    local health_buff_equivalent_revive = global.biter_health_factor[game.forces[biter_force_name].index]
     if not isItnormalBiters then
         health_buff_equivalent_revive = health_buff_equivalent_revive * 20
     end
@@ -191,7 +191,7 @@ local function on_entity_spawned(event)
         return
     end
     if entity.force.name == 'north_biters' or entity.force.name == 'south_biters' then
-        local health_factor = 1 / (1 - global.reanim_chance[entity.force.index] / 100)
+        local health_factor = global.biter_health_factor[entity.force.index]
         if health_factor > 1 then
             BossUnit.add_high_health_unit(entity, health_factor, false)
         end
@@ -446,8 +446,7 @@ function Public.subtract_threat(entity)
         is_boss = true
     end
     if is_boss == true then
-        local health_buff_equivalent_revive = 1.0
-            / (1.0 - global.reanim_chance[game.forces[biter_not_boss_force].index] / 100)
+        local health_buff_equivalent_revive = global.biter_health_factor[game.forces[biter_not_boss_force].index]
         factor = bb_config.health_multiplier_boss * health_buff_equivalent_revive
     end
     global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force]

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -32,18 +32,6 @@ local function set_biter_endgame_modifiers(force)
         return
     end
 
-    -- Calculates reanimation chance. This value is normalized onto
-    -- maximum re-animation threshold. For example if real evolution is 150
-    -- and max is 350, then 150 / 350 = 42% chance.
-    local threshold = global.bb_evolution[force.name]
-    threshold = math_floor((threshold - 1.0) * 100.0)
-    threshold = threshold / global.max_reanim_thresh * 100
-    threshold = math_floor(threshold)
-    if threshold > 90.0 then
-        threshold = 90.0
-    end
-    global.reanim_chance[force.index] = threshold
-
     local damage_mod = math_round((global.bb_evolution[force.name] - 1) * 1.0, 3)
     force.set_ammo_damage_modifier('melee', damage_mod)
     force.set_ammo_damage_modifier('biological', damage_mod)
@@ -259,7 +247,7 @@ function Public.do_raw_feed(flask_amount, food, biter_force_name)
     evo = evo + effects.evo_increase
     threat = threat + effects.threat_increase * (global.threat_multiplier or 1)
     evo = math_round(evo, decimals)
-    global.reanim_chance[force_index] = effects.reanim_chance
+    global.biter_health_factor[force_index] = effects.biter_health_factor
 
     --SET THREAT INCOME
     global.bb_threat_income[biter_force_name] = evo * 25

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -20,8 +20,8 @@ end
 ---@param food_value number
 ---@param num_flasks integer
 ---@param current_player_count integer
----@param max_reanim_thresh number
----@return { evo_increase: number, threat_increase: number, reanim_chance: number }
+---@param max_reanim_thresh number Long ago, we used reanim_chance rather than health_factor, and this is the evo value at which it would sortof be 100% reanim_chance
+---@return { evo_increase: number, threat_increase: number, biter_health_factor: number }
 function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_player_count, max_reanim_thresh)
     local threat = 0
     local evo = initial_evo
@@ -68,7 +68,7 @@ function Public.calc_feed_effects(initial_evo, food_value, num_flasks, current_p
     return {
         evo_increase = evo - initial_evo,
         threat_increase = threat,
-        reanim_chance = reanim_chance,
+        biter_health_factor = 1 / (1 - reanim_chance / 100),
     }
 end
 

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -182,15 +182,14 @@ local function get_evo_tooltip(force, verbose)
         prefix = style.bold('Evolution') .. ' - ' .. gui_values[force].t1 .. '\n'
     end
     local biter_force = game.forces[gui_values[force].biter_force]
-    local damage, revive =
-        (biter_force.get_ammo_damage_modifier('melee') + 1) * 100, global.reanim_chance[biter_force.index]
+    local damage = (biter_force.get_ammo_damage_modifier('melee') + 1) * 100
     return prefix
         .. style.listbox('Evolution: ')
         .. style.yellow(style.stat(string_format('%.2f', (global.bb_evolution[biter_force.name] * 100))))
         .. style.listbox('%\nDamage: ')
         .. style.yellow(style.stat(damage))
-        .. style.listbox('%\nRevive: ')
-        .. style.yellow(style.stat(revive))
+        .. style.listbox('%\nHealth: ')
+        .. style.yellow(style.stat(string_format('%.0f', (global.biter_health_factor[biter_force.index] * 100))))
         .. style.listbox('%')
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -377,11 +377,12 @@ function Public.tables()
     -- 100, so this value starts having an effect only at that point.
     -- To reach 100% reanimation chance at 200% evolution, set it to 100.
     -- To reach 100% reanimation chance at 350% evolution, set it to 250.
+    -- This is used to calculate biter_health_factor.
     global.max_reanim_thresh = 250
 
-    -- Container for storing chance of reanimation. The stored value
-    -- is a range between [0, 100], accessed by key with force's index.
-    global.reanim_chance = {}
+    -- Container for storing health factor, accessed by key with force's index.
+    ---@type table<integer, number>
+    global.biter_health_factor = {}
 
     global.next_attack = 'north'
     if global.random_generator(1, 2) == 1 then
@@ -520,7 +521,7 @@ function Public.forces()
         global.ai_target_destroyed_map = {}
         global.spy_fish_timeout[force.name] = 0
         global.bb_evolution[force.name] = 0
-        global.reanim_chance[force.index] = 0
+        global.biter_health_factor[force.index] = 1.0
         global.bb_threat_income[force.name] = 0
         global.bb_threat[force.name] = 0
     end

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -341,7 +341,7 @@ local function on_entity_died(event)
         return
     end
 
-    health_factor = health_factor / (1 - global.reanim_chance[game.forces[force_name .. '_biters'].index] / 100)
+    health_factor = health_factor * global.biter_health_factor[game.forces[force_name .. '_biters'].index]
 
     local force_stats = global.team_stats.forces[force_name]
     local damage_stats = force_stats.damage_types[event.damage_type.name]
@@ -350,7 +350,7 @@ local function on_entity_died(event)
         force_stats.damage_types[event.damage_type.name] = damage_stats
     end
     damage_stats.kills = damage_stats.kills + 1
-    -- This is somewhat inaccurate, because revive% might be different
+    -- This is somewhat inaccurate, because biter_health_factor might be different
     -- now than when the biter was spawned, but it is close enough for me.
     damage_stats.damage = damage_stats.damage + entity.prototype.max_health * health_factor
 end


### PR DESCRIPTION
This just makes more sense to me. Examples of old-vs-new text:
```
      "Revive: 0%"  -> "Health: 100%"
      "Revive: 10%" -> "Health: 111%"
      "Revive: 80%" -> "Health: 500%"
      "Revive: 90%" -> "Health: 1000%"
```
This change should not actually impact gameplay at all, just what is displayed.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
