### PR TITLE
teamstats: fix space-sci-equiv-produced number

### DIFF
--- a/maps/biter_battles_v2/team_stats_compare.lua
+++ b/maps/biter_battles_v2/team_stats_compare.lua
@@ -241,7 +241,8 @@ function TeamStatsCompare.show_stats(player)
         end
         local produced_info = ''
         if not exclude_forces[force_name] then
-            produced_info = string_format(' produced: %s', format_with_thousands_sep(total_produced_mutagen))
+            produced_info =
+                string_format(' produced: %s', format_one_sig_fig(total_produced_mutagen / space_sci_mutagen))
         end
         add_small_label(science_flow, {
             caption = string_format(


### PR DESCRIPTION
This number was wrong, depending on mutagen effectiveness.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
