### PR TITLE
Community pick captain improvements

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -2721,7 +2721,7 @@ function Public.update_captain_player_gui(player, frame)
                 })
                 tab.add({
                     type = 'label',
-                    caption = Functions.format_ticks_as_time(Public.get_total_playtime_of_player(player_name)),
+                    caption = Functions.format_ticks_as_time(global.total_time_online_players[player_name] or 0),
                     style = 'valid_mod_label',
                 })
                 tab.add({

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1526,7 +1526,6 @@ local function on_gui_click(event)
                         special.communityPicksConfirmed[player_name] = nil
                     end
                 end
-                special.communityPicksConfirmed = {}
                 Public.update_all_captain_player_guis()
             else
                 player.print(

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -2392,9 +2392,8 @@ function Public.update_captain_player_gui(player, frame)
         then
             join_table.captain_player_want_to_play.visible = true
             join_table.captain_player_want_to_play.enabled = not waiting_to_be_picked
-            join_table.captain_player_do_not_want_to_play.visible = true
+            join_table.captain_player_do_not_want_to_play.visible = not special.communityPickingMode
             join_table.captain_player_do_not_want_to_play.enabled = waiting_to_be_picked
-                and not special.communityPickingMode
             if special.prepaPhase and not special.initialPickingPhaseStarted then
                 if special.captainGroupAllowed then
                     insert(

--- a/comfy_panel/special_games/captain_utils.lua
+++ b/comfy_panel/special_games/captain_utils.lua
@@ -2,6 +2,9 @@ local player_utils = require('utils.player')
 
 local CaptainUtils = {}
 
+---@param tab table
+---@param str any
+---@return boolean
 function CaptainUtils.table_contains(tab, str)
     for _, entry in ipairs(tab) do
         if entry == str then
@@ -11,7 +14,12 @@ function CaptainUtils.table_contains(tab, str)
     return false
 end
 
+---@param playerName string|integer
+---@return LuaPlayer?
 function CaptainUtils.cpt_get_player(playerName)
+    if not playerName then
+        return nil
+    end
     local special = global.special_games_variables.captain_mode
     if special and special.test_players and special.test_players[playerName] then
         local res = table.deepcopy(special.test_players[playerName])

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -10,8 +10,6 @@ map_intro_top_button=[font=default-bold]Scenario Info[/font] - Read the introduc
 polls_top_button=[font=default-bold]Polls[/font] - Toggle current/past polls window
 reroll_caption=Reroll map?  __1__s
 reroll_stats=[color=red]__1__[/color] Vs. [color=green]__2__[/color] - ( [color=blue]__3__[/color]% )
-automatic_captain_caption=Captain? __1__s
-automatic_captain_stats=[color=red]__1__[/color] Vs. [color=green]__2__[/color] - ( [color=blue]__3__[/color]% )
 research_info=[font=default-bold]Research info[/font] - Toggle the research summary window
 rocket_silo_health_stats=[font=default-bold]Rocket Silo health[/font] - __1__/5000  (__2__%)
 rocket_silo_health=[font=default-bold]Rocket Silo health[/font] - Show your team rocket silo health status
@@ -28,7 +26,6 @@ burner_balance=You have received __1__ x [item=burner-mining-drill], check your 
 dummy_print=[color=gray][to player __1__]:[/color] 
 
 [captain]
-change_captain_announcement=[color=blue]__1__[/color] has decided that [font=default-large-bold][color=green]__2__[/color][/font] will be the new captain instead of [color=orange]__3__[/color]
 change_captain_wrong_member=You cant elect a player as a captain if he is not in the team of the captain ! What are you even doing !
 change_player_team_err=[color=blue]__1__[/color] is already on [color=green]__2__[/color] and thus was not switched to [color=orange]__3__[/color]
 cmd_only_admin=Only referee or admin have license to use that command

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -146,7 +146,7 @@ end
 
 ---@param player LuaPlayer
 ---@param frame LuaGuiElement|LuaGuiElement.add_param
----@param style_name string
+---@param style_name string?
 ---@return LuaGuiElement
 function Gui.add_top_element(player, frame, style_name)
     local element = mod_gui.get_button_flow(player)[frame.name]


### PR DESCRIPTION
Captains games now support having a team be "captainless" (the actual captain variable is nil). In this case, all players are trusted to send science. When latejoiners need to be picked, they will be picked by a random player on the team chosen among the top 30% of players sorted by pick-order who are currently online.  In all captains games (whether they are community picked or not), this can be arranged with commands like `/replaceCaptainNorth !nobody!`.

Now, after a 'community-pick' game assigns people to teams, for each team, the players in the top 30% of the "pick order" are prompted to ask if they want to be a captain. They can answer one of Yes/Maybe/No (if they don't answer, it is the same as answering "no").  After 30 seconds, if people answered "Yes", then one of them is chosen at random to be captain. Else if people answered "Maybe", then one of them is chosen to be captain, else the team is captainless.

Also, 'community-pick' games now allow people to say "I don't want to play" before the game starts. All players that have already put that player in a pick order just stay as they were (and if the player changes their mind to play *again*, no more work is required by that user). Thus, even if someone keeps changing their mind about playing, it will not impact the game's start very much.

I also slightly reduced the maximum height of the "Join info" screen, as people seemed to complain about its size.

Also, 'community-pick' games can now be started with as few as 2 people who have confirmed their ranks. This is primarily to make testing easier for me.

I also fixed all (!) flagged LSP errors in captain.lua. This required a bunch of annotations like `--[[@as string]]` and some amount of code restructuring so that the type checker could validate that things were safe.  I just found that the type checker was actually finding a bunch of real issues (like passing the wrong number of arguments to functions), so it felt worthwhile to me to clean it up.

I also made a UI for "replaceCaptain", and allow all captains to use it anytime

Before this change, /replaceCaptain* commands could only be run by the referee. This gives captains the option of handing off leadership on their own without referee involvement.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
