### PR TITLE
Add back missing text for automatic captain poll that got removed 

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -10,6 +10,8 @@ map_intro_top_button=[font=default-bold]Scenario Info[/font] - Read the introduc
 polls_top_button=[font=default-bold]Polls[/font] - Toggle current/past polls window
 reroll_caption=Reroll map?  __1__s
 reroll_stats=[color=red]__1__[/color] Vs. [color=green]__2__[/color] - ( [color=blue]__3__[/color]% )
+automatic_captain_caption=Captain? __1__s
+automatic_captain_stats=[color=red]__1__[/color] Vs. [color=green]__2__[/color] - ( [color=blue]__3__[/color]% )
 research_info=[font=default-bold]Research info[/font] - Toggle the research summary window
 rocket_silo_health_stats=[font=default-bold]Rocket Silo health[/font] - __1__/5000  (__2__%)
 rocket_silo_health=[font=default-bold]Rocket Silo health[/font] - Show your team rocket silo health status


### PR DESCRIPTION
### Brief description of the changes:
Not much to say, this commit add back the text from automatic captain that got removed by a recent commit resulting in broken UI :  [PR604](https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/604)

Added it back

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
