### PR TITLE
Community pick fixes/logging

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1194,11 +1194,13 @@ local function start_picking_phase()
             end
             final_community_picks[player] = filtered_picks
         end
-        local picks = CaptainCommunityPick.assign_teams(final_community_picks)
-        if not picks then
+        local pick_order = CaptainCommunityPick.pick_order(final_community_picks)
+        if not pick_order then
             force_end_captain_event()
             return
         end
+        local picks = CaptainCommunityPick.assign_teams(pick_order)
+        special.stats.communityPickInfo = { votes = final_community_picks, pick_order = pick_order }
         for i, team in ipairs(picks) do
             local force_name = i == 1 and 'north' or 'south'
             for _, player in ipairs(team) do

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1519,11 +1519,13 @@ local function on_gui_click(event)
         if not special.pickingPhase then
             if check_if_enough_playtime_to_play(player) then
                 insert_player_by_playtime(player.name)
-                -- make players that don't have this player in their pick order already re-confirm their pick order
-                for player_name, _ in pairs(special.communityPicksConfirmed) do
-                    local pick_order = special.communityPickOrder[player_name]
-                    if not table_contains(pick_order, player.name) then
-                        special.communityPicksConfirmed[player_name] = nil
+                if not special.initialPickingPhaseStarted then
+                    -- make players that don't have this player in their pick order already re-confirm their pick order
+                    for player_name, _ in pairs(special.communityPicksConfirmed) do
+                        local pick_order = special.communityPickOrder[player_name]
+                        if not table_contains(pick_order, player.name) then
+                            special.communityPicksConfirmed[player_name] = nil
+                        end
                     end
                 end
                 Public.update_all_captain_player_guis()

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -2937,7 +2937,7 @@ function Public.update_captain_referee_gui(player, frame)
             local b = scroll.add({
                 type = 'button',
                 name = 'captain_force_captains_ready',
-                caption = 'Force all captains to be ready',
+                caption = 'Force both teams to be ready',
                 style = 'red_button',
             })
         end

--- a/comfy_panel/special_games/captain_community_pick.lua
+++ b/comfy_panel/special_games/captain_community_pick.lua
@@ -2,6 +2,9 @@ local Color = require('utils.color_presets')
 
 local CaptainCommunityPick = {}
 
+local table_insert = table.insert
+local math_random = math.random
+
 ---@param player string
 ---@param community_picks table<string, string[]>
 ---@return nil
@@ -114,7 +117,7 @@ function CaptainCommunityPick.pick_order(community_picks)
             return nil
         end
 
-        table.insert(result, top_pick)
+        table_insert(result, top_pick)
         remove_player_from_picks(top_pick, community_picks)
         num_players = num_players - 1
     end
@@ -125,10 +128,10 @@ end
 ---@return string[][]
 function CaptainCommunityPick.assign_teams(pick_order)
     local result = { {}, {} }
-    local next_team_to_pick = math.random(#result)
+    local next_team_to_pick = math_random(#result)
     for _, pick in ipairs(pick_order) do
         -- game.print(string.format('picked %s for %s', pick, next_team_to_pick == 1 and 'North' or 'South'))
-        table.insert(result[next_team_to_pick], pick)
+        table_insert(result[next_team_to_pick], pick)
         local other_possible_next_team_to_pick = 3 - next_team_to_pick
         -- do 1, 2, 2, 2, ... picking
         if #result[next_team_to_pick] > #result[other_possible_next_team_to_pick] then

--- a/comfy_panel/special_games/captain_community_pick.lua
+++ b/comfy_panel/special_games/captain_community_pick.lua
@@ -63,8 +63,8 @@ local function find_top_pick(community_picks, num_votes_required_for_win)
 end
 
 ---@param community_picks table<string, string[]>
----@return string[][]?
-function CaptainCommunityPick.assign_teams(community_picks)
+---@return string[]?
+function CaptainCommunityPick.pick_order(community_picks)
     -- do not modify the argument
     community_picks = table.deepcopy(community_picks)
 
@@ -106,18 +106,29 @@ function CaptainCommunityPick.assign_teams(community_picks)
         end
     end
 
-    local result = { {}, {} }
-    local next_team_to_pick = math.random(#result)
+    local result = {}
     local num_votes_required_for_win = math.ceil(table_size(community_picks) / 2)
     while num_players > 0 do
         local top_pick = find_top_pick(community_picks, num_votes_required_for_win)
         if not top_pick then
             return nil
         end
-        -- game.print(string.format('picked %s for %s', top_pick, next_team_to_pick == 1 and 'North' or 'South'))
-        table.insert(result[next_team_to_pick], top_pick)
+
+        table.insert(result, top_pick)
         remove_player_from_picks(top_pick, community_picks)
         num_players = num_players - 1
+    end
+    return result
+end
+
+---@param pick_order string[]
+---@return string[][]
+function CaptainCommunityPick.assign_teams(pick_order)
+    local result = { {}, {} }
+    local next_team_to_pick = math.random(#result)
+    for _, pick in ipairs(pick_order) do
+        -- game.print(string.format('picked %s for %s', pick, next_team_to_pick == 1 and 'North' or 'South'))
+        table.insert(result[next_team_to_pick], pick)
         local other_possible_next_team_to_pick = 3 - next_team_to_pick
         -- do 1, 2, 2, 2, ... picking
         if #result[next_team_to_pick] > #result[other_possible_next_team_to_pick] then

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -519,8 +519,12 @@ function Public.silo_death(event)
             Server.send_special_game_state('[CAPTAIN-SPECIAL]')
             log_to_db('>Game has ended\n', false)
             log_to_db('[RefereeName]' .. special.stats.InitialReferee .. '\n', true)
-            log_to_db('[CaptainNorth]' .. special.stats.NorthInitialCaptain .. '\n', true)
-            log_to_db('[CaptainSouth]' .. special.stats.SouthInitialCaptain .. '\n', true)
+            if special.stats.NorthInitialCaptain then
+                log_to_db('[CaptainNorth]' .. special.stats.NorthInitialCaptain .. '\n', true)
+            end
+            if special.stats.SouthInitialCaptain then
+                log_to_db('[CaptainSouth]' .. special.stats.SouthInitialCaptain .. '\n', true)
+            end
             local listPicks = table.concat(special.stats.northPicks, ';')
             log_to_db('[NorthTeam]' .. listPicks .. '\n', true)
             listPicks = table.concat(special.stats.southPicks, ';')

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -512,7 +512,7 @@ function Public.silo_death(event)
 
         freeze_all_biters(entity.surface)
         local special = global.special_games_variables.captain_mode
-        if global.active_special_games.captain_mode and not special.prepaPhase then
+        if special and not special.prepaPhase then
             global.tournament_mode = false
             game.print('Tournament mode is now disabled')
             game.print('Updating logs for the game')
@@ -540,6 +540,9 @@ function Public.silo_death(event)
                         true
                     )
                 end
+            end
+            if special.stats.communityPickInfo then
+                log_to_db('[CommunityPickInfo]' .. game.table_to_json(special.stats.communityPickInfo) .. '\n', true)
             end
             log_to_db('[TeamStats]' .. game.table_to_json(global.team_stats) .. '\n', true)
             log_to_db('>End of log', true)


### PR DESCRIPTION
captain_mode: fix bug with game-stats-logging when a team is captainless to start out with

Add logging of community picks on the server

captain community pick: do not clear out special.communityPicksConfirmed after game start
Useful for debugging how/why things were picked as they were.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
