### PR TITLE
added threat farm special

### DIFF
--- a/comfy_panel/special_games.lua
+++ b/comfy_panel/special_games.lua
@@ -17,6 +17,7 @@ local valid_special_games = {
     disable_sciences = require('comfy_panel.special_games.disable_sciences'),
     send_to_external_server = require('comfy_panel.special_games.send_to_external_server'),
     captain = require('comfy_panel.special_games.captain'),
+    threat_farm_threshold = require('comfy_panel.special_games.threat_farm_threshold'),
     --[[
     Add your special game here.
     Syntax:

--- a/comfy_panel/special_games/threat_farm_threshold.lua
+++ b/comfy_panel/special_games/threat_farm_threshold.lua
@@ -1,0 +1,27 @@
+local color_presets = require "utils.color_presets"
+
+local Public = {
+   name = {type = "label", caption = "threat threshold", tooltip= "threat cant fall below threshold, fraction of excess threat is send to enemy"},
+   config = {
+    [1] = {name = "label1", type = "label", caption = "minimum threat amount"},
+    [2] = {name = "threat_farm_threshold", type = "textfield", width = 40, text=0},
+    [3] = {name = "label2", type = "label", caption="fraction of excess threat, send to enemy"},
+    [4] = {name = "threat_farm_send_fraction", type= "textfield", width = 40, text=0.5},
+   },
+   button = {name = "apply", type= "button", caption = "Apply"},
+   generate = function (config, player)
+        if(not tonumber(config["threat_farm_threshold"].text)or not tonumber(config["threat_farm_send_fraction"].text)) then
+            game.print("invalid configuration, only numbers allowed",color_presets.warning)
+            return
+        end
+
+        global.active_special_games["threat_farm_threshold"] = true
+        global.special_games_variables["threat_farm_threshold"] = tonumber(config["threat_farm_threshold"].text)
+        global.special_games_variables["threat_farm_send_fraction"] = tonumber(config["threat_farm_send_fraction"].text)
+
+        
+        
+        game.print("excess threat below " .. global.special_games_variables["threat_farm_threshold"] .. " will be added to opponent with a factor of " .. global.special_games_variables["threat_farm_send_fraction"], color_presets.warning)
+    end,
+}
+return Public

--- a/comfy_panel/special_games/threat_farm_threshold.lua
+++ b/comfy_panel/special_games/threat_farm_threshold.lua
@@ -13,7 +13,7 @@ local Public = {
             type = 'textfield',
             numeric = true,
             allow_negative = true,
-            width = 40,
+            width = 80,
             text = 0,
         },
         [3] = { name = 'l2', type = 'label', caption = 'fraction of excess threat, send to enemy' },
@@ -26,27 +26,28 @@ local Public = {
             width = 40,
             text = 0.5,
         },
-        [5] = { name = 'l3', type = 'label', caption = 'hide message' },
-        [6] = { name = 'hide message', type = 'checkbox', state = false },
     },
     button = { name = 'apply', type = 'button', caption = 'Apply' },
     generate = function(config, player)
         local variables = {
-            threat_threshold = config['threat_threshold'].text,
-            excess_threat_send_fraction = config['excess_threat_send_fraction'].text,
+            threat_threshold = tonumber(config['threat_threshold'].text),
+            excess_threat_send_fraction = tonumber(config['excess_threat_send_fraction'].text),
         }
 
+        if not (variables.threat_threshold and variables.excess_threat_send_fraction) then
+            game.print('invalid configuration, only numbers allowed', color_presets.warning)
+            return
+        end
         global.active_special_games['threat_farm_threshold'] = true
         global.special_games_variables['threat_farm_threshold'] = variables
-        if not config['hide message'].state then
-            game.print(
-                'Threat threshold enabled! Excess threat below '
-                    .. variables.threat_threshold
-                    .. ' will be added to opponent with a factor of '
-                    .. variables.excess_threat_send_fraction,
-                color_presets.warning
-            )
-        end
+
+        game.print(
+            'Threat threshold enabled! Excess threat below '
+                .. variables.threat_threshold
+                .. ' will be added to opponent with a factor of '
+                .. variables.excess_threat_send_fraction,
+            color_presets.warning
+        )
     end,
 }
 return Public

--- a/comfy_panel/special_games/threat_farm_threshold.lua
+++ b/comfy_panel/special_games/threat_farm_threshold.lua
@@ -1,27 +1,52 @@
-local color_presets = require "utils.color_presets"
+local color_presets = require('utils.color_presets')
 
 local Public = {
-   name = {type = "label", caption = "threat threshold", tooltip= "threat cant fall below threshold, fraction of excess threat is send to enemy"},
-   config = {
-    [1] = {name = "label1", type = "label", caption = "minimum threat amount"},
-    [2] = {name = "threat_farm_threshold", type = "textfield", width = 40, text=0},
-    [3] = {name = "label2", type = "label", caption="fraction of excess threat, send to enemy"},
-    [4] = {name = "threat_farm_send_fraction", type= "textfield", width = 40, text=0.5},
-   },
-   button = {name = "apply", type= "button", caption = "Apply"},
-   generate = function (config, player)
-        if(not tonumber(config["threat_farm_threshold"].text)or not tonumber(config["threat_farm_send_fraction"].text)) then
-            game.print("invalid configuration, only numbers allowed",color_presets.warning)
-            return
+    name = {
+        type = 'label',
+        caption = 'threat threshold',
+        tooltip = 'threat cant fall below threshold, fraction of excess threat is send to enemy',
+    },
+    config = {
+        [1] = { name = 'l1', type = 'label', caption = 'minimum threat amount' },
+        [2] = {
+            name = 'threat_threshold',
+            type = 'textfield',
+            numeric = true,
+            allow_negative = true,
+            width = 40,
+            text = 0,
+        },
+        [3] = { name = 'l2', type = 'label', caption = 'fraction of excess threat, send to enemy' },
+        [4] = {
+            name = 'excess_threat_send_fraction',
+            type = 'textfield',
+            numeric = true,
+            allow_decimal = true,
+            allow_negative = true,
+            width = 40,
+            text = 0.5,
+        },
+        [5] = { name = 'l3', type = 'label', caption = 'hide message' },
+        [6] = { name = 'hide message', type = 'checkbox', state = false },
+    },
+    button = { name = 'apply', type = 'button', caption = 'Apply' },
+    generate = function(config, player)
+        local variables = {
+            threat_threshold = config['threat_threshold'].text,
+            excess_threat_send_fraction = config['excess_threat_send_fraction'].text,
+        }
+
+        global.active_special_games['threat_farm_threshold'] = true
+        global.special_games_variables['threat_farm_threshold'] = variables
+        if not config['hide message'].state then
+            game.print(
+                'Threat threshold enabled! Excess threat below '
+                    .. variables.threat_threshold
+                    .. ' will be added to opponent with a factor of '
+                    .. variables.excess_threat_send_fraction,
+                color_presets.warning
+            )
         end
-
-        global.active_special_games["threat_farm_threshold"] = true
-        global.special_games_variables["threat_farm_threshold"] = tonumber(config["threat_farm_threshold"].text)
-        global.special_games_variables["threat_farm_send_fraction"] = tonumber(config["threat_farm_send_fraction"].text)
-
-        
-        
-        game.print("excess threat below " .. global.special_games_variables["threat_farm_threshold"] .. " will be added to opponent with a factor of " .. global.special_games_variables["threat_farm_send_fraction"], color_presets.warning)
     end,
 }
 return Public

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -449,9 +449,20 @@ function Public.subtract_threat(entity)
         local health_buff_equivalent_revive = global.biter_health_factor[game.forces[biter_not_boss_force].index]
         factor = bb_config.health_multiplier_boss * health_buff_equivalent_revive
     end
-    global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force]
-        - threat_values[entity.name] * factor
-    return true
+	if((global.active_special_games["threat_farm_threshold"])) then
+		local threat_value = threat_values[entity.name] * factor;
+		local threat_below_threshold = global.special_games_variables["threat_farm_threshold"] - (global.bb_threat[biter_not_boss_force] - threat_value)
+		local enemy_force
+		if(threat_below_threshold > 0) then
+			global.bb_threat[biter_not_boss_force] = global.special_games_variables["threat_farm_threshold"]
+			if biter_not_boss_force ==  "south_biters" then enemy_force = "north_biters" else enemy_force = "south_biters" end
+			global.bb_threat[enemy_force] = global.bb_threat[enemy_force] + threat_below_threshold * global.special_games_variables["threat_farm_send_fraction"]
+		else global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_value
+		end
+        return true
+	end
+	global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_values[entity.name] * factor
+	return true
 end
 
 return Public

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -463,7 +463,7 @@ function Public.subtract_threat(entity)
                 enemy_force = 'south_biters'
             end
             global.bb_threat[enemy_force] = global.bb_threat[enemy_force]
-            + threat_below_threshold
+                + threat_below_threshold
                     * global.special_games_variables['threat_farm_threshold'].excess_threat_send_fraction
         else
             global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_value

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -451,20 +451,19 @@ function Public.subtract_threat(entity)
     end
     if global.active_special_games['threat_farm_threshold'] then
         local threat_value = threat_values[entity.name] * factor
-        local threat_below_threshold = global.special_games_variables['threat_farm_threshold'].threat_threshold
+        local special_variables = global.special_games_variables['threat_farm_threshold']
+        local threat_below_threshold = special_variables.threat_threshold
             - (global.bb_threat[biter_not_boss_force] - threat_value)
         local enemy_force
         if threat_below_threshold > 0 then
-            global.bb_threat[biter_not_boss_force] =
-                global.special_games_variables['threat_farm_threshold'].threat_threshold
+            global.bb_threat[biter_not_boss_force] = special_variables.threat_threshold
             if biter_not_boss_force == 'south_biters' then
                 enemy_force = 'north_biters'
             else
                 enemy_force = 'south_biters'
             end
             global.bb_threat[enemy_force] = global.bb_threat[enemy_force]
-                + threat_below_threshold
-                    * global.special_games_variables['threat_farm_threshold'].excess_threat_send_fraction
+                + threat_below_threshold * special_variables.excess_threat_send_fraction
         else
             global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_value
         end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -449,20 +449,30 @@ function Public.subtract_threat(entity)
         local health_buff_equivalent_revive = global.biter_health_factor[game.forces[biter_not_boss_force].index]
         factor = bb_config.health_multiplier_boss * health_buff_equivalent_revive
     end
-	if((global.active_special_games["threat_farm_threshold"])) then
-		local threat_value = threat_values[entity.name] * factor;
-		local threat_below_threshold = global.special_games_variables["threat_farm_threshold"] - (global.bb_threat[biter_not_boss_force] - threat_value)
-		local enemy_force
-		if(threat_below_threshold > 0) then
-			global.bb_threat[biter_not_boss_force] = global.special_games_variables["threat_farm_threshold"]
-			if biter_not_boss_force ==  "south_biters" then enemy_force = "north_biters" else enemy_force = "south_biters" end
-			global.bb_threat[enemy_force] = global.bb_threat[enemy_force] + threat_below_threshold * global.special_games_variables["threat_farm_send_fraction"]
-		else global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_value
-		end
+    if global.active_special_games['threat_farm_threshold'] then
+        local threat_value = threat_values[entity.name] * factor
+        local threat_below_threshold = global.special_games_variables['threat_farm_threshold'].threat_threshold
+            - (global.bb_threat[biter_not_boss_force] - threat_value)
+        local enemy_force
+        if threat_below_threshold > 0 then
+            global.bb_threat[biter_not_boss_force] =
+                global.special_games_variables['threat_farm_threshold'].threat_threshold
+            if biter_not_boss_force == 'south_biters' then
+                enemy_force = 'north_biters'
+            else
+                enemy_force = 'south_biters'
+            end
+            global.bb_threat[enemy_force] = global.bb_threat[enemy_force]
+            + threat_below_threshold
+                    * global.special_games_variables['threat_farm_threshold'].excess_threat_send_fraction
+        else
+            global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_value
+        end
         return true
-	end
-	global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force] - threat_values[entity.name] * factor
-	return true
+    end
+    global.bb_threat[biter_not_boss_force] = global.bb_threat[biter_not_boss_force]
+        - threat_values[entity.name] * factor
+    return true
 end
 
 return Public


### PR DESCRIPTION
### Brief description of the changes:
Adds a threat threshold. Kills that would decrease threat further, increase enemy threat instead. 
The threshold and the fraction of excess threat, that gets added to the enemy can be configured.
Can be used to limit threat farming, or make it op for a fun game.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
