### PR TITLE
Fix send science when disabled

### DIFF
--- a/maps/biter_battles_v2/shortcuts.lua
+++ b/maps/biter_battles_v2/shortcuts.lua
@@ -81,7 +81,9 @@ local main_frame_actions = {
         if handle_spectator(player) then
             return
         end
-        if Captain_event.captain_is_player_prohibited_to_throw(player) then
+        if global.active_special_games.disable_sciences then
+            player.print('Disabled by special game', Color.red)
+        elseif Captain_event.captain_is_player_prohibited_to_throw(player) then
             player.print('You are not allowed to send science, ask your captain', Color.red)
         else
             Feeding.feed_biters_mixed_from_inventory(player, event.button)


### PR DESCRIPTION
Fixed that it was possible to send science through a new UI shortcut button when sending science was disabled by a special game


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
