### PR TITLE
Fix captain text render

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -151,6 +151,16 @@ local function switch_team_of_player(playerName, playerForceName)
     add_to_trust(playerName)
 end
 
+local function clear_captain_rendering()
+    if not global.special_games_variables.rendering then return end
+    for _, textId in pairs(global.special_games_variables.rendering) do
+        if rendering.is_valid(textId) then
+            rendering.destroy(textId)
+        end
+        textId = nil
+    end
+end
+
 local function clear_gui_captain_mode()
     for _, player in pairs(game.players) do
         local gui = player.gui
@@ -193,7 +203,7 @@ local function force_end_captain_event()
     global.active_special_games.captain_mode = false
     global.bb_threat.north_biters = 0
     global.bb_threat.south_biters = 0
-    rendering.clear()
+    clear_captain_rendering()
     clear_gui_captain_mode()
     for _, pl in pairs(game.connected_players) do
         if pl.force.name ~= 'spectator' then
@@ -752,7 +762,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
     if global.special_games_variables.rendering == nil then
         global.special_games_variables.rendering = {}
     end
-    rendering.clear()
+    clear_captain_rendering()
     render_text(
         'captainLineTen',
         "Special Captain's tournament mode enabled",
@@ -968,7 +978,7 @@ local function start_captain_event()
     global.bb_threat.north_biters = 0
     global.bb_threat.south_biters = 0
 
-    rendering.clear()
+    clear_captain_rendering()
     render_text(
         'captainLineSeventeen',
         "Special Captain's tournament mode enabled",

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -152,7 +152,9 @@ local function switch_team_of_player(playerName, playerForceName)
 end
 
 local function clear_captain_rendering()
-    if not global.special_games_variables.rendering then return end
+    if not global.special_games_variables or not global.special_games_variables.rendering then
+        return
+    end
     for textId, render in pairs(global.special_games_variables.rendering) do
         if rendering.is_valid(render) then
             rendering.destroy(render)

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -157,7 +157,7 @@ local function clear_captain_rendering()
         if rendering.is_valid(render) then
             rendering.destroy(render)
         end
-        global.special_games_variables[textId] = nil
+        global.special_games_variables.rendering[textId] = nil
     end
 end
 

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -153,11 +153,11 @@ end
 
 local function clear_captain_rendering()
     if not global.special_games_variables.rendering then return end
-    for _, textId in pairs(global.special_games_variables.rendering) do
-        if rendering.is_valid(textId) then
-            rendering.destroy(textId)
+    for textId, render in pairs(global.special_games_variables.rendering) do
+        if rendering.is_valid(render) then
+            rendering.destroy(render)
         end
-        textId = nil
+        global.special_games_variables[textId] = nil
     end
 end
 

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -311,6 +311,7 @@ function Public.tables()
     global.random_generator.re_seed(global.next_map_seed)
     global.reroll_map_voting = {}
     global.automatic_captain_voting = {}
+    global.captain_rendering = {}
     global.bb_evolution = {}
     global.benchmark_mode = false
     global.bb_game_won_by_team = nil

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -311,7 +311,6 @@ function Public.tables()
     global.random_generator.re_seed(global.next_map_seed)
     global.reroll_map_voting = {}
     global.automatic_captain_voting = {}
-    global.captain_rendering = {}
     global.bb_evolution = {}
     global.benchmark_mode = false
     global.bb_game_won_by_team = nil


### PR DESCRIPTION
### Brief description of the changes:
---Fill in---
This turned out to be quite easy.

The captain rendering is all being stored in global.special_games_variables.rendering, with keys of a name string (textId) and values of uint64 rendering IDs returned by rendering.draw_text() and analogous methods. As such, no new book keeping is required, just looping over these objects and destroying them specifically.

The one caveat is that the current implementation would destroy all special game rendering that is correctly registered within global.special_games_variables.rendering. I'm unsure if anyone actually uses it (I do not use it and barely knew the structures existed).

To make it compatible with this case, one can add `if string.sub(textId, 1, 7) == 'captain' then` into the new clear_captain_rendering() method to only remove rendering with matching textIds. This does commit the captain machinery to uniformly use this format for naming all text, which is why I opted not to do it that way (and would be ever so slightly slower).

I can test later but wanted to take care of this. Recommend merging all the little commits, they are mostly silly typos and backtracking with web-based github.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
