### PR TITLE
Adjust nests value by evolution

### DIFF
--- a/comfy_panel/config.lua
+++ b/comfy_panel/config.lua
@@ -2,6 +2,7 @@
 
 local Antigrief = require('antigrief')
 local Color = require('utils.color_presets')
+local Functions = require('maps.biter_battles_v2.functions')
 local SessionData = require('utils.datastore.session_data')
 local Utils = require('utils.core')
 local Gui = require('utils.gui')
@@ -46,7 +47,8 @@ local function spaghett_deny_building(event)
         inventory.insert({ name = entity.name, count = 1 })
     end
 
-    event.entity.create_local_flying_text({
+    Functions.create_local_flying_text({
+        surface = entity.surface,
         position = entity.position,
         text = 'Spaghett Mode Active!',
         color = { r = 0.98, g = 0.66, b = 0.22 },

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -448,8 +448,7 @@ function Public.subtract_threat(entity)
     if is_boss == true then
         local health_buff_equivalent_revive = storage.biter_health_factor[game.forces[biter_not_boss_force].index]
         factor = bb_config.health_multiplier_boss * health_buff_equivalent_revive
-    end
-    if entity.type == 'unit-spawner' then
+    elseif entity.type == 'unit-spawner' then
         local evo = game.forces[biter_not_boss_force].get_evolution_factor(entity.surface.name)
         factor = 1 + 9 * evo ^ 2.25
     end

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -449,6 +449,10 @@ function Public.subtract_threat(entity)
         local health_buff_equivalent_revive = storage.biter_health_factor[game.forces[biter_not_boss_force].index]
         factor = bb_config.health_multiplier_boss * health_buff_equivalent_revive
     end
+    if entity.type == 'unit-spawner' then
+        local evo = game.forces[biter_not_boss_force].get_evolution_factor(entity.surface.name)
+        factor = 1 + 9 * evo ^ 2.25
+    end
     if storage.active_special_games['threat_farm_threshold'] then
         local threat_value = threat_values[entity.name] * factor
         local special_variables = storage.special_games_variables['threat_farm_threshold']

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -657,9 +657,9 @@ function Functions.clear_corpses(player, param)
     player.print('Cleared biter-corpses.', { color = Color.success })
 end
 
+--- Will create the text only for those on the same surface
 --- See the docs for LuaPlayer::create_local_flying_text, + surface param
----@param params table
----@field surface LuaSurfaceIdentification will create the text only for those on the same surface
+---@param params {surface: string|integer|LuaSurface}
 function Functions.create_local_flying_text(params)
     local surface = game.get_surface(params.surface.name or params.surface.index or params.surface)
     if not surface then

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -657,4 +657,19 @@ function Functions.clear_corpses(player, param)
     player.print('Cleared biter-corpses.', { color = Color.success })
 end
 
+--- See the docs for LuaPlayer::create_local_flying_text, + surface param
+---@param params table
+---@field surface LuaSurfaceIdentification will create the text only for those on the same surface
+function Functions.create_local_flying_text(params)
+    local surface = game.get_surface(params.surface.name or params.surface.index or params.surface)
+    if not surface then
+        return
+    end
+    for _, player in pairs(game.connected_players) do
+        if player.surface_index == surface.index then
+            player.create_local_flying_text(params)
+        end
+    end
+end
+
 return Functions


### PR DESCRIPTION
Biter nests health increases with evo (see [FFF-427](https://factorio.com/blog/post/fff-427)). This adjusts the score obtained by killing spawners according to the new approximated function of:

`y = 350 + 3150 * (x^2.25)`

resulting in

`factor = 1 + 9 * (evolution^2.25)`

which describes the factor of `nest_health / base_prototype_health` in function of evo(x). Note that this only applies up to 100% evo, after that, the threat reduction for killing (and health value of) the biter nests does not change.

![graph](https://cdn.factorio.com/assets/blog-sync/fff-427-spawner-health-graph.png)