### PR TITLE
Fix alert display

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -76,6 +76,9 @@ function Public.initial_setup()
     game.forces.spectator.set_surface_hidden('gulag', true)
     game.forces.north.set_surface_hidden('gulag', true)
     game.forces.south.set_surface_hidden('gulag', true)
+    game.forces.spectator.set_surface_hidden('nauvis', true)
+    game.forces.north.set_surface_hidden('nauvis', true)
+    game.forces.south.set_surface_hidden('nauvis', true)
     game.forces.spectator.research_all_technologies()
     local defs = {
         defines.input_action.import_blueprint_string,
@@ -209,10 +212,6 @@ function Public.playground_surface()
     surface.request_to_generate_chunks({ x = 0, y = -256 }, 7)
     surface.force_generate_chunk_requests()
     surface.brightness_visual_weights = { -1.17, -0.975, -0.52 }
-
-    game.forces.spectator.set_surface_hidden(storage.bb_surface_name, true)
-    game.forces.north.set_surface_hidden(storage.bb_surface_name, true)
-    game.forces.south.set_surface_hidden(storage.bb_surface_name, true)
 end
 
 function Public.draw_structures()


### PR DESCRIPTION
### Brief description of the changes:
Because bbX surface was hidden from surface list player could see an alert, but it wasn't possible to click on it to zoom at location where it was triggered. The alert panel appeared broken. I found that hiding nauvis surface instead of bb surface makes the surface list go away, but now alerts works as they should.
