### PR TITLE
Disable /inventory

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -21,7 +21,7 @@ require('commands')
 require('antigrief')
 require('modules.corpse_markers')
 require('modules.floaty_chat')
-require('modules.show_inventory')
+-- require('modules.show_inventory')
 
 require('comfy_panel.main')
 require('comfy_panel.player_list')


### PR DESCRIPTION
### Brief description of the changes:
Any player can crash the server when doing /inventory on himself when in remote view.
Issue is already raised here https://forums.factorio.com/viewtopic.php?f=7&t=121320&p=638851#p638851 and it cannot be fixed on our side, so for now disable it.
