### PR TITLE
Fix uses of inventories

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -591,7 +591,7 @@ local function on_player_cancelled_crafting(event)
     local player = game.get_player(event.player_index)
 
     local crafting_queue_item_count = event.items.get_item_count()
-    local free_slots = player.get_main_inventory().count_empty_stacks()
+    local free_slots = player.character.get_main_inventory().count_empty_stacks()
     local crafted_items = #event.items
 
     if crafted_items > free_slots then

--- a/comfy_panel/special_games/disabled_entities.lua
+++ b/comfy_panel/special_games/disabled_entities.lua
@@ -55,9 +55,9 @@ local function on_built_entity(event)
     if storage.special_games_variables['disabled_entities'][force.name][entity.name] then
         player.create_local_flying_text({ text = 'Disabled by special game', position = entity.position })
         if entity.name == 'straight-rail' or entity.name == 'curved-rail' then
-            player.get_inventory(defines.inventory.character_main).insert({ name = 'rail', count = 1 })
+            player.character.get_inventory(defines.inventory.character_main).insert({ name = 'rail', count = 1 })
         else
-            player.get_inventory(defines.inventory.character_main).insert({ name = entity.name, count = 1 })
+            player.character.get_inventory(defines.inventory.character_main).insert({ name = entity.name, count = 1 })
         end
         entity.destroy()
     elseif

--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -2,7 +2,7 @@ local ItemCosts = require('maps.biter_battles_v2.item_costs')
 local safe_wrap_with_player_print = require('utils.utils').safe_wrap_with_player_print
 
 local function inventory_cost(player)
-    local inventory = player.get_inventory(defines.inventory.character_main)
+    local inventory = player.character.get_inventory(defines.inventory.character_main)
     if not inventory then
         return 0
     end

--- a/commands/suspend.lua
+++ b/commands/suspend.lua
@@ -105,12 +105,12 @@ local function leave_corpse(player)
     })
 
     local inventories = {
-        player.get_inventory(defines.inventory.character_main),
-        player.get_inventory(defines.inventory.character_guns),
-        player.get_inventory(defines.inventory.character_ammo),
-        player.get_inventory(defines.inventory.character_armor),
-        player.get_inventory(defines.inventory.character_vehicle),
-        player.get_inventory(defines.inventory.character_trash),
+        player.character.get_inventory(defines.inventory.character_main),
+        player.character.get_inventory(defines.inventory.character_guns),
+        player.character.get_inventory(defines.inventory.character_ammo),
+        player.character.get_inventory(defines.inventory.character_armor),
+        player.character.get_inventory(defines.inventory.character_vehicle),
+        player.character.get_inventory(defines.inventory.character_trash),
     }
 
     local corpse = false

--- a/commands/suspend.lua
+++ b/commands/suspend.lua
@@ -98,12 +98,6 @@ local function leave_corpse(player)
         return
     end
 
-    -- Make sure player is not in remote view.
-    player.set_controller({
-        type = defines.controllers.character,
-        character = player.character,
-    })
-
     local inventories = {
         player.character.get_inventory(defines.inventory.character_main),
         player.character.get_inventory(defines.inventory.character_guns),

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -299,7 +299,7 @@ function Public.feed_biters_from_inventory(player, food)
 
     local biter_force_name = enemy_force_name .. '_biters'
 
-    local i = player.get_main_inventory()
+    local i = player.character.get_main_inventory()
     if not i then
         player.print('You cannot feed biters while in remote view')
         return
@@ -369,7 +369,7 @@ function Public.feed_biters_mixed_from_inventory(player, button)
             'automation-science-pack',
         }
     end
-    local i = player.get_main_inventory()
+    local i = player.character.get_main_inventory()
     if not i then
         player.print('You cannot feed biters while in remote view')
         return

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -301,7 +301,6 @@ function Public.feed_biters_from_inventory(player, food)
 
     local i = player.character.get_main_inventory()
     if not i then
-        player.print('You cannot feed biters while in remote view')
         return
     end
     local flask_amount = i.get_item_count(food)
@@ -371,7 +370,6 @@ function Public.feed_biters_mixed_from_inventory(player, button)
     end
     local i = player.character.get_main_inventory()
     if not i then
-        player.print('You cannot feed biters while in remote view')
         return
     end
     local colored_player_name = table.concat({

--- a/maps/biter_battles_v2/feeding_calculations.lua
+++ b/maps/biter_battles_v2/feeding_calculations.lua
@@ -198,7 +198,7 @@ function Public.calc_send_command(
         error_msg = 'Must specify "count" after "color"'
     end
     if error_msg == nil and #foods == 0 and player ~= nil then
-        local i = player.get_main_inventory()
+        local i = player.character.get_main_inventory()
         if i then
             for food_type, _ in pairs(Tables.food_values) do
                 local flask_amount = i.get_item_count(food_type)

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -523,7 +523,6 @@ function Functions.spy_fish(player, event)
     local duration_per_unit = 2700
     local i2 = player.character.get_inventory(defines.inventory.character_main)
     if not i2 then
-        player.print('You cannot send spy while in remote view')
         return
     end
     local owned_fish = i2.get_item_count('raw-fish')

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -521,7 +521,7 @@ function Functions.spy_fish(player, event)
         return
     end
     local duration_per_unit = 2700
-    local i2 = player.get_inventory(defines.inventory.character_main)
+    local i2 = player.character.get_inventory(defines.inventory.character_main)
     if not i2 then
         player.print('You cannot send spy while in remote view')
         return

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -986,11 +986,6 @@ function join_team(player, force_name, forced_join, auto_join)
         game.print(message, { color = { r = 0.98, g = 0.66, b = 0.22 } })
     end
 
-    player.set_controller({
-        type = defines.controllers.character,
-        character = player.character,
-    })
-
     local i = player.character.get_inventory(defines.inventory.character_main)
     i.clear()
     player.insert({ name = 'pistol', count = 1 })

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -991,7 +991,7 @@ function join_team(player, force_name, forced_join, auto_join)
         character = player.character,
     })
 
-    local i = player.get_inventory(defines.inventory.character_main)
+    local i = player.character.get_inventory(defines.inventory.character_main)
     i.clear()
     player.insert({ name = 'pistol', count = 1 })
     player.insert({ name = 'raw-fish', count = 3 })

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -66,12 +66,6 @@ local function leave_corpse(player)
         return
     end
 
-    -- Make sure player is not in remote view.
-    player.set_controller({
-        type = defines.controllers.character,
-        character = player.character,
-    })
-
     local inventories = {
         player.character.get_inventory(defines.inventory.character_main),
         player.character.get_inventory(defines.inventory.character_guns),

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -73,12 +73,12 @@ local function leave_corpse(player)
     })
 
     local inventories = {
-        player.get_inventory(defines.inventory.character_main),
-        player.get_inventory(defines.inventory.character_guns),
-        player.get_inventory(defines.inventory.character_ammo),
-        player.get_inventory(defines.inventory.character_armor),
-        player.get_inventory(defines.inventory.character_vehicle),
-        player.get_inventory(defines.inventory.character_trash),
+        player.character.get_inventory(defines.inventory.character_main),
+        player.character.get_inventory(defines.inventory.character_guns),
+        player.character.get_inventory(defines.inventory.character_ammo),
+        player.character.get_inventory(defines.inventory.character_armor),
+        player.character.get_inventory(defines.inventory.character_vehicle),
+        player.character.get_inventory(defines.inventory.character_trash),
     }
 
     local corpse = false

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -172,8 +172,8 @@ local function redraw_inventory(gui, source, target, caption, panel_type)
         button.enabled = false
 
         if caption == 'Armor' then
-            if target.get_inventory(5)[1].grid then
-                local p_armor = target.get_inventory(5)[1].grid.get_contents()
+            if target.character.get_inventory(5)[1].grid then
+                local p_armor = target.character.get_inventory(5)[1].grid.get_contents()
                 for k, v in pairs(p_armor) do
                     local armor_gui = flow.add({
                         type = 'sprite-button',
@@ -263,11 +263,11 @@ local function open_inventory(source, target)
     data.player_opened = target
     data.last_tab = 'Main'
 
-    local main = target.get_main_inventory().get_contents()
-    local armor = target.get_inventory(defines.inventory.character_armor).get_contents()
-    local guns = target.get_inventory(defines.inventory.character_guns).get_contents()
-    local ammo = target.get_inventory(defines.inventory.character_ammo).get_contents()
-    local trash = target.get_inventory(defines.inventory.character_trash).get_contents()
+    local main = target.character.get_main_inventory().get_contents()
+    local armor = target.character.get_inventory(defines.inventory.character_armor).get_contents()
+    local guns = target.character.get_inventory(defines.inventory.character_guns).get_contents()
+    local ammo = target.character.get_inventory(defines.inventory.character_ammo).get_contents()
+    local trash = target.character.get_inventory(defines.inventory.character_trash).get_contents()
 
     local types = {
         ['Main'] = main,
@@ -318,19 +318,19 @@ local function on_gui_click(event)
     if valid then
         local target_inventories = {
             ['Main'] = function()
-                return target.get_main_inventory().get_contents()
+                return target.character.get_main_inventory().get_contents()
             end,
             ['Armor'] = function()
-                return target.get_inventory(defines.inventory.character_armor).get_contents()
+                return target.character.get_inventory(defines.inventory.character_armor).get_contents()
             end,
             ['Guns'] = function()
-                return target.get_inventory(defines.inventory.character_guns).get_contents()
+                return target.character.get_inventory(defines.inventory.character_guns).get_contents()
             end,
             ['Ammo'] = function()
-                return target.get_inventory(defines.inventory.character_ammo).get_contents()
+                return target.character.get_inventory(defines.inventory.character_ammo).get_contents()
             end,
             ['Trash'] = function()
-                return target.get_inventory(defines.inventory.character_trash).get_contents()
+                return target.character.get_inventory(defines.inventory.character_trash).get_contents()
             end,
         }
 
@@ -400,19 +400,19 @@ local function update_gui(event)
     -- of getting all inventories if only some are watched
     local target_inventories = {
         ['Main'] = function()
-            return target.get_main_inventory().get_contents()
+            return target.character.get_main_inventory().get_contents()
         end,
         ['Armor'] = function()
-            return target.get_inventory(defines.inventory.character_armor).get_contents()
+            return target.character.get_inventory(defines.inventory.character_armor).get_contents()
         end,
         ['Guns'] = function()
-            return target.get_inventory(defines.inventory.character_guns).get_contents()
+            return target.character.get_inventory(defines.inventory.character_guns).get_contents()
         end,
         ['Ammo'] = function()
-            return target.get_inventory(defines.inventory.character_ammo).get_contents()
+            return target.character.get_inventory(defines.inventory.character_ammo).get_contents()
         end,
         ['Trash'] = function()
-            return target.get_inventory(defines.inventory.character_trash).get_contents()
+            return target.character.get_inventory(defines.inventory.character_trash).get_contents()
         end,
     }
 

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -314,6 +314,9 @@ local function on_gui_click(event)
     data.last_tab = name
 
     local valid, target = player_opened(player)
+    if not validate_player(target) then
+        return
+    end
 
     if valid then
         local target_inventories = {

--- a/utils/freeplay.lua
+++ b/utils/freeplay.lua
@@ -91,7 +91,7 @@ local on_player_created = function(event)
             )
             util.remove_safe(player, this.crashed_ship_items)
             util.remove_safe(player, this.crashed_debris_items)
-            player.get_main_inventory().sort_and_merge()
+            player.character.get_main_inventory().sort_and_merge()
             if player.character then
                 player.character.destructible = false
             end


### PR DESCRIPTION
### Brief description of the changes:
So far I was convinced that get_inventory is broken, but turns out you can easily use player.character.get_inventory to access it regardless of player's controller state. This information wasn't in 2.0 change log. This PR fixes all uses of get_inventory. I also managed to patch old bug that causes errors if /inventory is open for a player that has left already.
