### PR TITLE
Migration to Factorio 2.0 fixes

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -398,7 +398,6 @@ local function on_entity_died(event)
         }
         if chests[event.entity.type] then
             local inv = event.entity.get_inventory(1)
-            local contents = inv.get_contents()
             data.event = table.concat({ data.event, ' with ', inv.get_item_count(), ' items' })
         end
         this.histories_idx.friendly_fire = this.histories_idx.friendly_fire % size + 1

--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -67,8 +67,8 @@ local function inventory_costs_command(cmd)
     safe_wrap_with_player_print(player, inventory_costs, cmd)
 end
 
--- commands.add_command(
---     'inventory-costs',
---     "Print out the top players by inventory values. Pass 'all' to see it for both forces.",
---     inventory_costs_command
--- )
+commands.add_command(
+    'inventory-costs',
+    "Print out the top players by inventory values. Pass 'all' to see it for both forces.",
+    inventory_costs_command
+)

--- a/commands/inventory_costs.lua
+++ b/commands/inventory_costs.lua
@@ -11,14 +11,14 @@ local function inventory_cost(player)
     if storage.special_games_variables['infinity_chest'] then
         freebies = storage.special_games_variables['infinity_chest'].freebies
     end
-    for name, count in pairs(inventory.get_contents()) do
+    for _, item in pairs(inventory.get_contents()) do
         local item_cost
-        if freebies and freebies[name] then
+        if freebies and freebies[item.name] then
             item_cost = 0
         else
-            item_cost = ItemCosts.get_cost(name)
+            item_cost = ItemCosts.get_cost(item.name)
         end
-        cost = cost + item_cost * count
+        cost = cost + item_cost * item.count
     end
     return cost
 end

--- a/maps/biter_battles_v2/feed_values_tab.lua
+++ b/maps/biter_battles_v2/feed_values_tab.lua
@@ -158,20 +158,19 @@ local function add_feed_values(player, element, food_product_info)
     end
 end
 
--- TODO: Fix stack overflow in FeedValues
 local function build_config_gui(player, frame)
-    -- local frame_feed_values = Tabs.comfy_panel_get_active_frame(player)
-    -- if not frame_feed_values then
-    --     return
-    -- end
-    -- frame_feed_values.clear()
+    local frame_feed_values = Tabs.comfy_panel_get_active_frame(player)
+    if not frame_feed_values then
+        return
+    end
+    frame_feed_values.clear()
 
-    -- local food_product_info = {}
-    -- for food, _ in pairs(Tables.food_names) do
-    --     food_product_info[food] = ItemCosts.get_info(food)
-    -- end
+    local food_product_info = {}
+    for food, _ in pairs(Tables.food_names) do
+        food_product_info[food] = ItemCosts.get_info(food)
+    end
 
-    -- add_feed_values(player, frame_feed_values, food_product_info)
+    add_feed_values(player, frame_feed_values, food_product_info)
 end
 
 comfy_panel_tabs['FeedValues'] = { gui = build_config_gui, admin = false }

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -635,8 +635,8 @@ function Functions.get_entity_contents(entity)
     for i_id = 1, entity.get_max_inventory_index() do
         local inventory = entity.get_inventory(i_id)
         if inventory and inventory.valid and not inventory.is_empty() then
-            for item, props in pairs(inventory.get_contents()) do
-                totals[item] = (totals[item] or 0) + props.count
+            for _, item in pairs(inventory.get_contents()) do
+                totals[item.name] = (totals[item.name] or 0) + item.count
             end
         end
     end

--- a/maps/biter_battles_v2/item_costs.lua
+++ b/maps/biter_battles_v2/item_costs.lua
@@ -40,7 +40,6 @@ local raw_costs = ItemCosts.raw_costs
 local recipe_productivity = {
     ['rocket-part'] = 1.4,
     ['processing-unit'] = 1.08,
-    ['rocket-part'] = 1.08,
     ['production-science-pack'] = 1.08,
     ['utility-science-pack'] = 1.08,
 }
@@ -251,7 +250,7 @@ local function find_all_costs()
         ingredients = {
             { name = 'low-density-structure', amount = 10 },
             { name = 'rocket-fuel', amount = 10 },
-            { name = 'rocket-part', amount = 10 },
+            { name = 'processing-unit', amount = 10 },
         },
         products = { { name = 'rocket-part', amount = 1 } },
         energy = 3, -- Time to craft one rocket part

--- a/maps/biter_battles_v2/team_stats_collect.lua
+++ b/maps/biter_battles_v2/team_stats_collect.lua
@@ -36,7 +36,6 @@ TeamStatsCollect.items_to_show_summaries_of = {
     { item = 'advanced-circuit', hide_by_default = true },
     { item = 'processing-unit', space_after = true, hide_by_default = true },
 
-    { item = 'rocket-part', hide_by_default = true },
     { item = 'rocket-fuel', hide_by_default = true },
     { item = 'low-density-structure', space_after = true, hide_by_default = true },
 

--- a/modules/show_inventory.lua
+++ b/modules/show_inventory.lua
@@ -184,7 +184,8 @@ local function redraw_inventory(gui, source, target, caption, panel_type)
                         tooltip = types[opts.name].localised_name,
                         style = 'slot_button',
                     })
-                    armor_gui.enabled = false
+                    armor_gui.enabled = true
+                    armor_gui.ignored_by_interaction = true
                 end
             end
         end


### PR DESCRIPTION
More fixes of some places affected by removal of RCU. Fixes some usages of changed API of `LuaInventory::get_contents`.

This allows to enable `/inventory-costs` command and 'FeedValues' tab from 'Menu & Settings'.

I also missed grayed out armor grid icons of `/inventory` ui, so this pull requests contains this fix as a continuation to https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/pull/645

As a side note: to keep in mind, I've noticed that Factorio 2.0.22 has a breaking change (`LuaEquipmentGrid::get_contents` [old](https://lua-api.factorio.com/2.0.21/classes/LuaEquipmentGrid.html#get_contents) -> [new](https://lua-api.factorio.com/2.0.22/classes/LuaEquipmentGrid.html#get_contents)), which will affect, for example, this code https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/blob/3455f48ceb2b1668643615ae0470cefad68fea58/modules/show_inventory.lua#L177 