### PR TITLE
Fix New Year Island snow transition

### DIFF
--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -970,7 +970,7 @@ function Public.add_new_year_island_decorations(surface)
             surface = surface,
             sprite = params.sprite,
             target = params.target,
-            render_layer = "3",
+            render_layer = '3',
             x_scale = params.x_scale,
             y_scale = params.y_scale,
             orientation = params.orientation or 0,
@@ -1002,7 +1002,6 @@ function Public.add_new_year_island_decorations(surface)
     -- top-left
     draw_sprite_snow({ sprite = sprite, target = { -3.48, -3.48 }, x_scale = scale, y_scale = scale })
     draw_sprite_snow({ sprite = sprite, target = { -3, -3 }, x_scale = scale, y_scale = scale })
-
 
     for _ = 1, storage.random_generator(0, 4) do
         local stump = surface.create_entity({

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -966,42 +966,42 @@ end
 function Public.add_new_year_island_decorations(surface)
     -- To fix lab-white tiles transition, draw border snow with sprites
     local function draw_sprite_snow(params)
-        rendering.draw_sprite{
+        rendering.draw_sprite({
             surface = surface,
             sprite = params.sprite,
             target = params.target,
             render_layer = "3",
             x_scale = params.x_scale,
             y_scale = params.y_scale,
-            orientation = params.orientation or 0
-        }
+            orientation = params.orientation or 0,
+        })
     end
 
     -- top and bottom
-    draw_sprite_snow{sprite = "virtual-signal/shape-horizontal", target = {0, 5.22}, x_scale = 4.6, y_scale = 5}
-    draw_sprite_snow{sprite = "virtual-signal/shape-horizontal", target = {0, -5.22}, x_scale = 4.6, y_scale = 5}
+    draw_sprite_snow({ sprite = 'virtual-signal/shape-horizontal', target = { 0, 5.22 }, x_scale = 4.6, y_scale = 5 })
+    draw_sprite_snow({ sprite = 'virtual-signal/shape-horizontal', target = { 0, -5.22 }, x_scale = 4.6, y_scale = 5 })
 
     -- sides
-    draw_sprite_snow{sprite = "virtual-signal/shape-vertical", target = {-5.25, 0}, x_scale = 5, y_scale = 4.5}
-    draw_sprite_snow{sprite = "virtual-signal/shape-vertical", target = {5.25, 0}, x_scale = 5, y_scale = 4.5}
+    draw_sprite_snow({ sprite = 'virtual-signal/shape-vertical', target = { -5.25, 0 }, x_scale = 5, y_scale = 4.5 })
+    draw_sprite_snow({ sprite = 'virtual-signal/shape-vertical', target = { 5.25, 0 }, x_scale = 5, y_scale = 4.5 })
 
-    local sprite = "virtual-signal/shape-diagonal"
+    local sprite = 'virtual-signal/shape-diagonal'
     local scale = 5.75
     -- bottom-right
-    draw_sprite_snow{sprite = sprite, target = {3.48, 3.48}, x_scale = scale, y_scale = scale}
-    draw_sprite_snow{sprite = sprite, target = {3, 3}, x_scale = scale, y_scale = scale}
+    draw_sprite_snow({ sprite = sprite, target = { 3.48, 3.48 }, x_scale = scale, y_scale = scale })
+    draw_sprite_snow({ sprite = sprite, target = { 3, 3 }, x_scale = scale, y_scale = scale })
 
     -- bottom-left
-    draw_sprite_snow{sprite = sprite, target = {-3.48, 3.48}, x_scale = scale, y_scale = scale, orientation = 0.25}
-    draw_sprite_snow{sprite = sprite, target = {-3, 3}, x_scale = scale, y_scale = scale, orientation = 0.25}
+    draw_sprite_snow({ sprite = sprite, target = { -3.48, 3.48 }, x_scale = scale, y_scale = scale, orientation = 0.25 })
+    draw_sprite_snow({ sprite = sprite, target = { -3, 3 }, x_scale = scale, y_scale = scale, orientation = 0.25 })
 
     -- top-right
-    draw_sprite_snow{sprite = sprite, target = {3.48, -3.48}, x_scale = scale, y_scale = scale, orientation = 0.25}
-    draw_sprite_snow{sprite = sprite, target = {3, -3}, x_scale = scale, y_scale = scale, orientation = 0.25}
+    draw_sprite_snow({ sprite = sprite, target = { 3.48, -3.48 }, x_scale = scale, y_scale = scale, orientation = 0.25 })
+    draw_sprite_snow({ sprite = sprite, target = { 3, -3 }, x_scale = scale, y_scale = scale, orientation = 0.25 })
 
     -- top-left
-    draw_sprite_snow{sprite = sprite, target = {-3.48, -3.48}, x_scale = scale, y_scale = scale}
-    draw_sprite_snow{sprite = sprite, target = {-3, -3}, x_scale = scale, y_scale = scale}
+    draw_sprite_snow({ sprite = sprite, target = { -3.48, -3.48 }, x_scale = scale, y_scale = scale })
+    draw_sprite_snow({ sprite = sprite, target = { -3, -3 }, x_scale = scale, y_scale = scale })
 
 
     for _ = 1, storage.random_generator(0, 4) do

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -551,6 +551,9 @@ function Public.draw_spawn_island(surface)
                 if storage.bb_settings['new_year_island'] then
                     tile_name = 'blue-refined-concrete'
                     if distance_to_center < 6.3 then
+                        tile_name = 'sand-1'
+                    end
+                    if distance_to_center < 4.9 then
                         tile_name = 'lab-white'
                     end
                 end
@@ -961,6 +964,46 @@ local function add_gifts(surface)
 end
 
 function Public.add_new_year_island_decorations(surface)
+    -- To fix lab-white tiles transition, draw border snow with sprites
+    local function draw_sprite_snow(params)
+        rendering.draw_sprite{
+            surface = surface,
+            sprite = params.sprite,
+            target = params.target,
+            render_layer = "3",
+            x_scale = params.x_scale,
+            y_scale = params.y_scale,
+            orientation = params.orientation or 0
+        }
+    end
+
+    -- top and bottom
+    draw_sprite_snow{sprite = "virtual-signal/shape-horizontal", target = {0, 5.22}, x_scale = 4.6, y_scale = 5}
+    draw_sprite_snow{sprite = "virtual-signal/shape-horizontal", target = {0, -5.22}, x_scale = 4.6, y_scale = 5}
+
+    -- sides
+    draw_sprite_snow{sprite = "virtual-signal/shape-vertical", target = {-5.25, 0}, x_scale = 5, y_scale = 4.5}
+    draw_sprite_snow{sprite = "virtual-signal/shape-vertical", target = {5.25, 0}, x_scale = 5, y_scale = 4.5}
+
+    local sprite = "virtual-signal/shape-diagonal"
+    local scale = 5.75
+    -- bottom-right
+    draw_sprite_snow{sprite = sprite, target = {3.48, 3.48}, x_scale = scale, y_scale = scale}
+    draw_sprite_snow{sprite = sprite, target = {3, 3}, x_scale = scale, y_scale = scale}
+
+    -- bottom-left
+    draw_sprite_snow{sprite = sprite, target = {-3.48, 3.48}, x_scale = scale, y_scale = scale, orientation = 0.25}
+    draw_sprite_snow{sprite = sprite, target = {-3, 3}, x_scale = scale, y_scale = scale, orientation = 0.25}
+
+    -- top-right
+    draw_sprite_snow{sprite = sprite, target = {3.48, -3.48}, x_scale = scale, y_scale = scale, orientation = 0.25}
+    draw_sprite_snow{sprite = sprite, target = {3, -3}, x_scale = scale, y_scale = scale, orientation = 0.25}
+
+    -- top-left
+    draw_sprite_snow{sprite = sprite, target = {-3.48, -3.48}, x_scale = scale, y_scale = scale}
+    draw_sprite_snow{sprite = sprite, target = {-3, -3}, x_scale = scale, y_scale = scale}
+
+
     for _ = 1, storage.random_generator(0, 4) do
         local stump = surface.create_entity({
             name = 'tree-05-stump',


### PR DESCRIPTION
After update to 2.0 `lab-white`  tile render level changed and now it renders over other tiles. This PR fixes it with white sprites.
![image](https://github.com/user-attachments/assets/bdecca61-11c3-4fe2-9a0e-2c2525fb3b58)


### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
