### PR TITLE
Fixes related to subtle changes in Factorio 2.0 API

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -148,7 +148,7 @@ local function damage_player(player, kill, print_to_all)
             return
         end
         player.character.health = player.character.health - math.random(50, 100)
-        player.character.surface.create_entity({ name = 'water-splash', position = player.position })
+        player.character.surface.create_entity({ name = 'water-splash', position = player.character.position })
         local messages = {
             'Ouch.. That hurt! Better be careful now.',
             'Just a fleshwound.',
@@ -353,7 +353,7 @@ local function on_player_used_capsule(event)
     local position = { x = math.floor(x), y = math.floor(y) }
     if
         ammo_names[item.name]
-        and player.surface.count_entities_filtered({
+        and player.physical_surface.count_entities_filtered({
                 force = player.force.name .. '_biters',
                 area = { { x - 10, y - 10 }, { x + 10, y + 10 } },
                 limit = 1,
@@ -618,7 +618,7 @@ local function on_player_cancelled_crafting(event)
         local data = {
             player_name = player.name,
             event = crafting_queue_item_count .. ' ' .. event.recipe.name,
-            position = { x = math.floor(player.position.x), y = math.floor(player.position.y) },
+            position = { x = math.floor(player.physical_position.x), y = math.floor(player.physical_position.y) },
             time = game.ticks_played,
             server_time = game.tick,
         }
@@ -871,7 +871,7 @@ function Public.insert_into_capsule_history(player, position, msg)
     str = str .. ' Y:'
     str = str .. math.floor(position.y)
     str = str .. ' '
-    str = str .. 'surface:' .. player.surface.index
+    str = str .. 'surface:' .. player.physical_surface_index
     increment(this.capsule_history, str)
 end
 

--- a/comfy_panel/player_list.lua
+++ b/comfy_panel/player_list.lua
@@ -597,7 +597,7 @@ local function on_gui_click(event)
             if not target or not target.valid then
                 return
             end
-            Where.create_mini_camera_gui(player, target.name, target.position, target.surface.index)
+            Where.create_mini_camera_gui(player, target.name, target.physical_position, target.physical_surface_index)
         end
     --Poke other players
     elseif string.sub(event.element.name, 1, 11) == 'poke_player' then

--- a/commands/suspend.lua
+++ b/commands/suspend.lua
@@ -134,10 +134,10 @@ local function punish_player(playerSuspended)
     if playerSuspended.controller_type ~= defines.controllers.character then
         playerSuspended.set_controller({
             type = defines.controllers.character,
-            character = playerSuspended.surface.create_entity({
+            character = playerSuspended.physical_surface.create_entity({
                 name = 'character',
                 force = playerSuspended.force,
-                position = playerSuspended.position,
+                position = playerSuspended.physical_position,
             }),
         })
     end
@@ -181,7 +181,7 @@ local suspend_token = Token.register(function()
                 storage.suspended_players[suspend_info.suspendee_player_name] = game.ticks_played
                 local playerSuspended = game.get_player(suspend_info.suspendee_player_name)
                 storage.suspend_target_info = nil
-                if playerSuspended and playerSuspended.valid and playerSuspended.surface.name ~= 'gulag' then
+                if playerSuspended and playerSuspended.valid and playerSuspended.physical_surface.name ~= 'gulag' then
                     punish_player(playerSuspended)
                 end
                 return
@@ -255,11 +255,11 @@ local function suspend_player(cmd)
                 killer.print('You cant suspend a spectator', { color = Color.warning })
                 return
             end
-            if victim.surface.name == 'gulag' then
+            if victim.physical_surface.name == 'gulag' then
                 killer.print('You cant suspend a player in jail', { color = Color.warning })
                 return
             end
-            if killer.surface.name == 'gulag' then
+            if killer.physical_surface.name == 'gulag' then
                 killer.print('You cant suspend a player while you are in jail', { color = Color.warning })
                 return
             end

--- a/commands/where.lua
+++ b/commands/where.lua
@@ -53,7 +53,12 @@ commands.add_command('where', 'Locates a player', function(cmd)
 
         if target_player and validate_player(target_player) then
             Sounds.notify_player(player, 'utility/smart_pipette')
-            create_mini_camera_gui(player, target_player.name, target_player.position, target_player.surface.index)
+            create_mini_camera_gui(
+                player,
+                target_player.name,
+                target_player.physical_position,
+                target_player.physical_surface_index
+            )
         else
             player.print('Please type a name of a player who is connected.', { color = Color.warning })
         end

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -123,8 +123,8 @@ local function drop_burners(player, forced_join)
     end
     local burners_to_drop = player.get_item_count('burner-mining-drill')
     if burners_to_drop ~= 0 then
-        local items = player.surface.spill_item_stack({
-            position = player.position,
+        local items = player.physical_surface.spill_item_stack({
+            position = player.physical_position,
             stack = { name = 'burner-mining-drill', count = burners_to_drop },
             enable_looted = false,
             force = nil,
@@ -826,8 +826,8 @@ function Public.burners_balance(player)
         storage.got_burners[player.name] = true
         inserted = player.insert({ name = 'burner-mining-drill', count = burners_to_insert })
         if inserted < burners_to_insert then
-            local items = player.surface.spill_item_stack({
-                position = player.position,
+            player.physical_surface.spill_item_stack({
+                position = player.physical_position,
                 stack = { name = 'burner-mining-drill', count = burners_to_insert - inserted },
                 enable_looted = false,
                 force = nil,
@@ -874,7 +874,7 @@ function join_team(player, force_name, forced_join, auto_join)
     if not force_name then
         return
     end
-    local surface = player.surface
+    local surface = player.physical_surface
     local enemy_team = 'south'
     if force_name == 'south' then
         enemy_team = 'north'
@@ -1035,15 +1035,15 @@ function spectate(player, forced_join, stored_position)
         player.cancel_crafting(player.crafting_queue[1])
     end
 
-    player.driving = false
+    player.character.driving = false
     player.clear_cursor()
     drop_burners(player, forced_join)
 
     if stored_position then
         local p_data = get_player_data(player)
-        p_data.position = player.position
+        p_data.position = player.physical_position
     end
-    player.character.teleport(player.surface.find_non_colliding_position('character', { 0, 0 }, 4, 1))
+    player.character.teleport(player.physical_surface.find_non_colliding_position('character', { 0, 0 }, 4, 1))
     Sounds.notify_player(player, 'utility/build_blueprint_large')
     player.force = game.forces.spectator
     player.character.destructible = false
@@ -1075,8 +1075,8 @@ function Public.spy_fish()
             local surface = game.surfaces[storage.bb_surface_name]
             for _, player in pairs(game.forces[f[2]].connected_players) do
                 game.forces[f[1]].chart(surface, {
-                    { player.position.x - r, player.position.y - r },
-                    { player.position.x + r, player.position.y + r },
+                    { player.physical_position.x - r, player.physical_position.y - r },
+                    { player.physical_position.x + r, player.physical_position.y + r },
                 })
             end
         else
@@ -1179,7 +1179,7 @@ local function on_gui_click(event)
     end
 
     if name == 'bb_spectate' then
-        if player.position.y ^ 2 + player.position.x ^ 2 < 12000 then
+        if player.physical_position.y ^ 2 + player.physical_position.x ^ 2 < 12000 then
             spectate(player)
         else
             player.print('You are too far away from spawn to spectate.', { color = { r = 0.98, g = 0.66, b = 0.22 } })

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -1035,6 +1035,7 @@ function spectate(player, forced_join, stored_position)
         player.cancel_crafting(player.crafting_queue[1])
     end
 
+    player.driving = false
     player.character.driving = false
     player.clear_cursor()
     drop_burners(player, forced_join)

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -160,7 +160,7 @@ function do_ping(from_player_name, to_player, message)
     end
     Sounds.notify_player(to_player, 'utility/undo')
     -- to_player.play_sound({path = "utility/new_objective", volume_modifier = 0.6})
-    -- to_player.surface.create_entity({name = 'big-explosion', position = to_player.position})
+    -- to_player.physical_surface.create_entity({name = 'big-explosion', position = to_player.physical_position})
     local ping_header = to_player.gui.screen['ping_header']
     local uis = to_player.display_scale
     if not ping_header then
@@ -413,14 +413,14 @@ end
 local function autotagging_outposters()
     for _, p in pairs(game.connected_players) do
         if p.force.name == 'north' or p.force.name == 'south' then
-            if math.abs(p.position.x) < autoTagDistance then
+            if math.abs(p.physical_position.x) < autoTagDistance then
                 if hasOutpostTag(p.tag) then
                     p.tag = p.tag:gsub('%' .. autoTagWestOutpost, '')
                     p.tag = p.tag:gsub('%' .. autoTagEastOutpost, '')
                 end
             else
                 if not hasOutpostTag(p.tag) then
-                    p.tag = p.tag .. getTagOutpostName(p.position.x)
+                    p.tag = p.tag .. getTagOutpostName(p.physical_position.x)
                 end
             end
         end
@@ -541,7 +541,7 @@ end
 local function on_player_built_tile(event)
     local player = game.get_player(event.player_index)
     if event.item ~= nil and event.item.name == 'landfill' then
-        Terrain.restrict_landfill(player.surface, player, event.tiles)
+        Terrain.restrict_landfill(player.physical_surface, player, event.tiles)
     end
 end
 

--- a/modules/corpse_markers.lua
+++ b/modules/corpse_markers.lua
@@ -65,7 +65,7 @@ end
 
 local function on_player_died(event)
     local player = game.get_player(event.player_index)
-    draw_map_tag(player.surface, player.force, player.position)
+    draw_map_tag(player.physical_surface, player.force, player.physical_position)
 end
 
 local function on_character_corpse_expired(event)

--- a/modules/floaty_chat.lua
+++ b/modules/floaty_chat.lua
@@ -32,7 +32,7 @@ local function on_console_chat(event)
 
     storage.player_floaty_chat[player.index] = rendering.draw_text({
         text = event.message,
-        surface = player.surface,
+        surface = player.character.surface,
         target = { entity = player.character, offset = { -0.05, y_offset } },
         color = {
             r = player.color.r * 0.6 + 0.25,

--- a/utils/alert.lua
+++ b/utils/alert.lua
@@ -227,7 +227,7 @@ function Public.alert_all_players_location(player, message, color, duration)
             style = 'slot_button',
         })
 
-        Gui.set_data(sprite, player.position)
+        Gui.set_data(sprite, player.physical_position)
 
         local label = container.add({
             type = 'label',

--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -185,8 +185,8 @@ local teleport_player_to_gulag = function(player, action)
 
     if action == 'jail' then
         local gulag = game.surfaces['gulag']
-        p_data.fallback_surface_index = player.surface.index
-        p_data.position = player.position
+        p_data.fallback_surface_index = player.physical_surface_index
+        p_data.position = player.physical_position
         p_data.p_group_id = player.permission_group.group_id
         p_data.locked = true
         player.character.teleport(gulag.find_non_colliding_position('character', { 0, 0 }, 128, 1), gulag.name)

--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -372,6 +372,7 @@ local jail = function(player, griefer, msg)
     then
         game.get_player(griefer).character.driving = false
     end
+    game.get_player(griefer).driving = false
 
     jailed[griefer] = { jailed = true, actor = player, reason = msg }
     set_data(jailed_data_set, griefer, { jailed = true, actor = player, reason = msg })

--- a/utils/game.lua
+++ b/utils/game.lua
@@ -57,9 +57,9 @@ function Game.print_player_floating_text_position(player_index, text, color, x_o
         return
     end
 
-    local position = player.position
+    local position = player.physical_position
     return Game.print_floating_text(
-        player.surface,
+        player.physical_surface,
         { x = position.x + x_offset, y = position.y + y_offset },
         text,
         color


### PR DESCRIPTION
Next fields from `LuaPlayer` have changed their semantic and were renamed/moved:

* position -> physical_position
* surface -> physical_surface
* driving -> character.driving
* vehicle -> physical_vehicle
* controller_type -> physical_controller_type

Old names are still available, but they additionally reference remote view if it's active. This creates bizarre bugs and corner cases in the old code.

Here's non-exhaustive list of fixed issues:
* Admin teleporting of driving player while he's in remote view fails
* Admin teleporting of dead player error (in log)
* Admin "bring player/bring to spawn/go to player": incorrect destination position/surface while in remote view
* Admin "spank/damage": incorrect particle position while target in remote view
* Show player in player list: remote view position was used instead of physical
* "/where" command view: remote view position was used instead of physical
* Suspend player remote viewing gulag failure/double suspend
* Suspend player in remote view leaves corpses in invalid location
* Player going into spectate mode drops burner miners on remote viewed position
* Player receiving burners vie burner balance spills overflow to remote view position
* Player joining team while remote viewing other surface spawns on incorrect surface
* Player rejoining team in incorrect location after afk forced to spectate in remote view
* Spying on the other team was done incorrectly by using remote view position of the enemy players
* Players could bypass requirement to be near spawn point and just go spectate via remote view
* Players could refuse to be teleported to spec island by being in remote view and driving
* Outposting players were autotagged based by their remote view position
* Freeing from gulag restores player at their remote view position
* Player leaves dummy characters alongside with his corpses while being suspended in remote view or in editor mode and multiple other incorrectly handled corner cases alongside
* Stop jailed player from driving in remote view

All changes were tested in multiplayer. Following changes were untested due to being located in unused code:
* "/notify_all_players" command displayed remote view position of the notificator
* Floating text from module 'utils.game'