### PR TITLE
Fixed laser damage buff wasn't applied due to technology rename

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -104,28 +104,28 @@ local balance_functions = {
     ['refined-flammables-7'] = function(force_name)
         flamer_buff(0.06, 0.06, force_name)
     end,
-    ['energy-weapons-damage'] = function(force_name)
+    ['laser-weapons-damage'] = function(force_name)
         laser_buff(get_upgrade_modifier('laser-turret') * 2, force_name)
     end,
-    ['energy-weapons-damage-1'] = function(force_name)
+    ['laser-weapons-damage-1'] = function(force_name)
         laser_buff(0.2, force_name)
     end,
-    ['energy-weapons-damage-2'] = function(force_name)
+    ['laser-weapons-damage-2'] = function(force_name)
         laser_buff(0.2, force_name)
     end,
-    ['energy-weapons-damage-3'] = function(force_name)
+    ['laser-weapons-damage-3'] = function(force_name)
         laser_buff(0.4, force_name)
     end,
-    ['energy-weapons-damage-4'] = function(force_name)
+    ['laser-weapons-damage-4'] = function(force_name)
         laser_buff(0.4, force_name)
     end,
-    ['energy-weapons-damage-5'] = function(force_name)
+    ['laser-weapons-damage-5'] = function(force_name)
         laser_buff(0.4, force_name)
     end,
-    ['energy-weapons-damage-6'] = function(force_name)
+    ['laser-weapons-damage-6'] = function(force_name)
         laser_buff(0.5, force_name)
     end,
-    ['energy-weapons-damage-7'] = function(force_name)
+    ['laser-weapons-damage-7'] = function(force_name)
         laser_buff(0.5, force_name)
     end,
     ['stronger-explosives'] = function(force_name)


### PR DESCRIPTION
Co-author: floortiler

Technologies from the group 'energy-weapons-damage' were silently renamed to 'laser-weapons-damage' during some of Factorio update.

Laser turret values before change:
20
20 + 4
20 + 8
20 + 14
20 + 22
20 + 32
20 + 46
20 + 60
20 + 74

After:
20
20 + 8.8
20 + 13.6
20 + 27.6
20 + 38.8
20 + 52.8
20 + 79
20 + 100
20 + 121
