### PR TITLE
Another attempt at fixing player missing character during map reset

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -280,13 +280,14 @@ function Functions.combat_balance(event)
     end
 end
 
+---@param surface LuaSurface
+---Returns non-colliding position on spectator island or hardcoded coordinate
+---of island as a fallback
 local function find_teleport_point(surface)
     local p = spawn_positions[math_random(1, size_of_spawn_positions)]
-    if surface.is_chunk_generated({ 0, 0 }) then
-        return surface.find_non_colliding_position('character', p, 4, 0.5)
-    end
-
-    return p
+    -- At this point surface has to have several chunks already, but if not fallback
+    -- to random point on the island.
+    return surface.find_non_colliding_position('character', p, 4, 0.5) or p
 end
 
 function Functions.init_player(player)


### PR DESCRIPTION
Some changes to map reset:
- Latest test revealed corner case with construction bots being teleported along with player to new surface. The only way to get rid of them is to get rid of character. Too bad it wasn't documented in the code originally.
- The second issue is that calling LuaControl::clear_items_inside() did not clear all items inside a character contrary to what is specified in documentation. Items were deleted only partially.
- From now on we're going to be extra sure that some teleport point is always returned even if find_non_colliding_position has failed.
- This change sandbags character creation to the point it should be _impossible_ for it to fail with double surface or cause non recoverable exception. If some player still losses character randomly, it's reported into logs. If it does happen it's a bug in API and nothing more can be done without help from wube.

Issue doesn't reproduce locally or even in LAN with my test accounts. The likelihood of it reproducing increases with the amount of connected players.