### PR TITLE
Fix missing character bug when switching teams

### DIFF
--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -95,6 +95,10 @@ local function leave_corpse(player)
     end
     player.character = nil
     player.set_controller({ type = defines.controllers.god })
+    -- In a situtation when player looks at chunk which was not generated yet
+    -- removing the character and subsequent attempt to create it will fail
+    -- silently. Reposition the view to middle of the surface.
+    player.teleport({ 0, 0 })
     player.create_character()
 end
 


### PR DESCRIPTION
### Brief description of the changes:
Sometimes when player was picked in captain game their character was missing, but no fail was produced. The issue occurred when player was looking at not generated chunk and was picked/switched at the same time. Especially problematic during captain event.

Trigger mechanism found by @developer-8 