### PR TITLE
Change so captains during the special join random forces

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1288,6 +1288,9 @@ end
 
 local function prepare_for_captain()
     local special = storage.special_games_variables.captain_mode
+    if math_random(2) == 1 then
+        special.captainList[1], special.captainList[2] = special.captainList[2], special.captainList[1]
+    end
     for index, force_name in pairs({ 'north', 'south' }) do
         local captainName = special.captainList[index]
         add_to_trust(captainName)

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1288,9 +1288,13 @@ end
 
 local function prepare_for_captain()
     local special = storage.special_games_variables.captain_mode
+
+    -- randomize captain forces, otherwise it's too deterministic
+    -- for example, first volunteer/most playtime player always end up on north
     if math_random(2) == 1 then
         special.captainList[1], special.captainList[2] = special.captainList[2], special.captainList[1]
     end
+
     for index, force_name in pairs({ 'north', 'south' }) do
         local captainName = special.captainList[index]
         add_to_trust(captainName)


### PR DESCRIPTION
Currently during captain special it's easy to predict on which forces captains end up:
* If captains accepted by a referee, the earliest willing captain (first in the captain volunteer list) will end up on north.
* If it's auto captain special, the player from captain volunteer list with the most play time will end up on north.

This change makes so it's objectively unpredictive on which sides captains end up.