### PR TITLE
Remove redundant code from event dispatcher

### DIFF
--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -32,24 +32,10 @@ local function errorHandler(err)
     log(debug.traceback())
 end
 
-local call_handlers
-function call_handlers(handlers, event)
-    if not handlers then
-        return log('Handlers was nil!')
-    end
-    local handlers_copy = table.deepcopy(handlers)
+local function call_handlers(handlers, event)
     for i = 1, #handlers do
         local handler = handlers[i]
-        if handler == nil and handlers_copy[i] ~= nil then
-            if table.contains(handlers, handlers_copy[i]) then
-                handler = handlers_copy[i]
-            end
-        end
-        if handler ~= nil then
-            xpcall(handler, errorHandler, event)
-        else
-            log('nil handler')
-        end
+        xpcall(handler, errorHandler, event)
     end
 end
 


### PR DESCRIPTION
The event dispatcher is called for every event. It's also executed inline from clone_area. Getting rid of deepclone and some checks yields ~12% performance increase per chunk in my test on random seeds. It will also impact all other events which will increase performance overall.

When I compare event core with current comfy code their implementation is much simpler in this regard so let's follow suit. I started profiler right after map started to generate.

```
6066x "anonymous" in "__level__/utils/event_core.lua", line 56. Total Elapsed: 139806.387543ms
|..............
| 2284x C function "clone_area". Total Duration: 61005.457998ms
|   282683x "anonymous" in "__level__/utils/event_core.lua", line 56. Total Duration: 58665.724417ms
|     282683x "call_handlers" in "__level__/utils/event_core.lua", line 36. Total Duration: 57933.110649ms
|       282683x "deepcopy" in "__core__/lualib/util.lua", line 6. Total Duration: 7767.222187ms
|..............
| 6066x "deepcopy" in "__core__/lualib/util.lua", line 6. Total Duration: 485.340377ms
```