### PR TITLE
Add the ability for spectators to see power networks

### DIFF
--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -112,6 +112,7 @@ function Public.initial_setup()
         defines.input_action.gui_text_changed,
         defines.input_action.gui_value_changed,
         defines.input_action.map_editor_action,
+        defines.input_action.open_gui,
         defines.input_action.open_character_gui,
         defines.input_action.quick_bar_set_selected_page,
         defines.input_action.quick_bar_set_slot,


### PR DESCRIPTION
### Brief description of the changes:
Give spectators the ability to see inside machines/ power poles, but not to modify recipes or contents.
This change mostly does not impact seeing inside machines as users can already see this from the tooltips, however it does give spectators the ability to view power networks.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
