### PR TITLE
event_core: use shallow copy

### DIFF
--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -37,7 +37,7 @@ function call_handlers(handlers, event)
     if not handlers then
         return log('Handlers was nil!')
     end
-    local handlers_copy = table.deepcopy(handlers)
+    local handlers_copy = { table.unpack(handlers) }
     for i = 1, #handlers do
         local handler = handlers[i]
         if handler == nil and handlers_copy[i] ~= nil then


### PR DESCRIPTION
### Brief description of the changes:
Use shallow instead of deep copy of event handlers.

In profiling the time spent copying handlers is reduced by a full second:
OLD
```
3830x "deepcopy" in "__core__/lualib/util.lua", line 6. Total Duration: 1027.455492ms
```
NEW
```
3826x C function "unpack". Total Duration: 25.720687ms
```

### Tested Changes:
- [x] I've tested the changes locally.