### PR TITLE
event_core: use linked list class

### DIFF
--- a/utils/event.lua
+++ b/utils/event.lua
@@ -505,10 +505,10 @@ end
 
 local function add_handlers()
     for event_name, tokens in pairs(token_handlers) do
-        for i = 1, #tokens do
-            local handler = Token.get(tokens[i])
+        tokens:traverse(function(token)
+            local handler = Token.get(token)
             core_add(event_name, handler)
-        end
+        end)
     end
 
     for name, funcs in pairs(function_handlers) do
@@ -528,10 +528,10 @@ local function add_handlers()
     end
 
     for tick, tokens in pairs(token_nth_tick_handlers) do
-        for i = 1, #tokens do
-            local handler = Token.get(tokens[i])
+        tokens:traverse(function(token)
+            local handler = Token.get(token)
             core_on_nth_tick(tick, handler)
-        end
+        end)
     end
 
     for name, funcs in pairs(function_nth_tick_handlers) do

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -305,8 +305,7 @@ function Event.remove_removable_function(event_name, name)
 
     local handlers = event_handlers[event_name]
 
-    function_table[name]:traverse(function(node)
-        local v = node.value
+    function_table[name]:traverse(function(v)
         local n = v.event_name
         if n == event_name then
             local f = v.handler
@@ -457,8 +456,7 @@ function Event.remove_removable_nth_tick_function(tick, name)
     local handlers = on_nth_tick_event_handlers[tick]
     local f = function_nth_tick_table[name]
 
-    function_nth_tick_table[name]:traverse(function(node)
-        local v = node.value
+    function_nth_tick_table[name]:traverse(function(v)
         local t = v.tick
         if t == tick then
             f = v.handler
@@ -467,8 +465,7 @@ function Event.remove_removable_nth_tick_function(tick, name)
 
     handlers:remove(f)
 
-    function_nth_tick_handlers[name]:traverse(function(node)
-        local v = node.value
+    function_nth_tick_handlers[name]:traverse(function(v)
         local t = v.tick
         if t == tick then
             function_nth_tick_handlers[name]:remove(k)
@@ -515,8 +512,7 @@ local function add_handlers()
     end
 
     for name, funcs in pairs(function_handlers) do
-        funcs:traverse(function(node)
-            local func = node.value
+        funcs:traverse(function(func)
             local e_name = func.event_name
             local func_string = func.handler
             local handler = assert(load('return ' .. func_string))()
@@ -539,8 +535,7 @@ local function add_handlers()
     end
 
     for name, funcs in pairs(function_nth_tick_handlers) do
-        funcs:traverse(function(node)
-            local func = node.value
+        funcs:traverse(function(func)
             local tick = func.tick
             local func_string = func.handler
             local handler = assert(load('return ' .. func_string))()

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -5,6 +5,7 @@
 ---To create custom events, use script.generate_event_name and use its return value as an event name.
 ---To raise that event, use script.raise_event
 
+local LinkedList = require('utils.linked_list')
 local EventCore = require('utils.event_core')
 local Global = require('utils.global')
 local Token = require('utils.token')
@@ -163,9 +164,9 @@ function Event.add_removable(event_name, token)
     local tokens = token_handlers[event_name]
     if not tokens then
         token_handlers[event_name] = LinkedList:new()
-        token_handlers[event_name].append(token)
+        token_handlers[event_name]:append(token)
     else
-        tokens.append(token)
+        tokens:append(token)
     end
 
     if handlers_added then
@@ -276,7 +277,7 @@ function Event.add_removable_function(event_name, func, remove_token)
         func_table = function_table[name]
     end
 
-    func_table.append({ event_name = event_name, handler = f })
+    func_table:append({ event_name = event_name, handler = f })
 
     if handlers_added then
         core_add(event_name, f)
@@ -336,9 +337,9 @@ function Event.add_removable_nth_tick(tick, token)
     local tokens = token_nth_tick_handlers[tick]
     if not tokens then
         token_nth_tick_handlers[tick] = LinkedList:new()
-        token_nth_tick_handlers[tick].append(token)
+        token_nth_tick_handlers[tick]:append(token)
     else
-        tokens.append(token)
+        tokens:append(token)
     end
 
     if handlers_added then

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -305,14 +305,15 @@ function Event.remove_removable_function(event_name, name)
 
     local handlers = event_handlers[event_name]
 
-    for k, v in pairs(function_table[name]) do
+    function_table[name]:traverse(function(node)
+        local v = node.value
         local n = v.event_name
         if n == event_name then
             local f = v.handler
             function_handlers[name][k] = nil
             remove(handlers, f)
         end
-    end
+    end)
 
     if handlers:isEmpty() then
         script_on_event(event_name, nil)

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -456,21 +456,23 @@ function Event.remove_removable_nth_tick_function(tick, name)
     local handlers = on_nth_tick_event_handlers[tick]
     local f = function_nth_tick_table[name]
 
-    for k, v in pairs(function_nth_tick_table[name]) do
+    function_nth_tick_table[name]:traverse(function(node)
+        local v = node.value
         local t = v.tick
         if t == tick then
             f = v.handler
         end
-    end
+    end)
 
     handlers:remove(f)
 
-    for k, v in pairs(function_nth_tick_handlers[name]) do
+    function_nth_tick_handlers[name]:traverse(function(node)
+        local v = node.value
         local t = v.tick
         if t == tick then
-            function_nth_tick_handlers[name][k] = nil
+            function_nth_tick_handlers[name]:remove(k)
         end
-    end
+    end)
 
     if handlers:isEmpty() then
         script_on_nth_tick(tick, nil)

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -309,7 +309,7 @@ function Event.remove_removable_function(event_name, name)
         local n = v.event_name
         if n == event_name then
             local f = v.handler
-            function_handlers[name][k] = nil
+            function_handlers[name]:remove(v)
             remove(handlers, f)
         end
     end)

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -195,7 +195,7 @@ function Event.remove_removable(event_name, token)
     remove(tokens, token)
     remove(handlers, handler)
 
-    if handlers:size() == 0 then
+    if handlers:isEmpty() then
         script_on_event(event_name, nil)
     end
 end
@@ -314,12 +314,8 @@ function Event.remove_removable_function(event_name, name)
         end
     end
 
-    if handlers:size() == 0 then
+    if handlers:isEmpty() then
         script_on_event(event_name, nil)
-    end
-
-    if function_handlers[name]:size() == 0 then
-        function_handlers[name] = nil
     end
 end
 
@@ -367,7 +363,7 @@ function Event.remove_removable_nth_tick(tick, token)
     remove(tokens, token)
     remove(handlers, handler)
 
-    if handlers:size() == 0 then
+    if handlers:isEmpty() then
         script_on_nth_tick(tick, nil)
     end
 end
@@ -476,11 +472,7 @@ function Event.remove_removable_nth_tick_function(tick, name)
         end
     end
 
-    if function_nth_tick_handlers[name]:size() == 0 then
-        function_nth_tick_handlers[name] = nil
-    end
-
-    if handlers:size() == 0 then
+    if handlers:isEmpty() then
         script_on_nth_tick(tick, nil)
     end
 end

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -71,13 +71,7 @@ local function remove(tbl, handler)
         return
     end
 
-    -- the handler we are looking for is more likly to be at the back of the array.
-    for i = #tbl, 1, -1 do
-        if tbl[i] == handler then
-            table_remove(tbl, i)
-            break
-        end
-    end
+    tbl:remove(handler)
 end
 
 ---Register a handler for the event_name event, can only be used during control, init or load cycles.</br>
@@ -168,9 +162,10 @@ function Event.add_removable(event_name, token)
 
     local tokens = token_handlers[event_name]
     if not tokens then
-        token_handlers[event_name] = { token }
+        token_handlers[event_name] = LinkedList:new()
+        token_handlers[event_name].append(token)
     else
-        tokens[#tokens + 1] = token
+        tokens.append(token)
     end
 
     if handlers_added then
@@ -199,7 +194,7 @@ function Event.remove_removable(event_name, token)
     remove(tokens, token)
     remove(handlers, handler)
 
-    if #handlers == 0 then
+    if handlers:size() == 0 then
         script_on_event(event_name, nil)
     end
 end
@@ -269,19 +264,19 @@ function Event.add_removable_function(event_name, func, remove_token)
 
     local funcs = function_handlers[name]
     if not funcs then
-        function_handlers[name] = {}
+        function_handlers[name] = LinkedList:new()
         funcs = function_handlers[name]
     end
 
-    funcs[#funcs + 1] = { event_name = event_name, handler = func }
+    funcs:append({ event_name = event_name, handler = func })
 
     local func_table = function_table[name]
     if not func_table then
-        function_table[name] = {}
+        function_table[name] = LinkedList:new()
         func_table = function_table[name]
     end
 
-    func_table[#func_table + 1] = { event_name = event_name, handler = f }
+    func_table.append({ event_name = event_name, handler = f })
 
     if handlers_added then
         core_add(event_name, f)
@@ -318,11 +313,11 @@ function Event.remove_removable_function(event_name, name)
         end
     end
 
-    if #handlers == 0 then
+    if handlers:size() == 0 then
         script_on_event(event_name, nil)
     end
 
-    if #function_handlers[name] == 0 then
+    if function_handlers[name]:size() == 0 then
         function_handlers[name] = nil
     end
 end
@@ -340,9 +335,10 @@ function Event.add_removable_nth_tick(tick, token)
 
     local tokens = token_nth_tick_handlers[tick]
     if not tokens then
-        token_nth_tick_handlers[tick] = { token }
+        token_nth_tick_handlers[tick] = LinkedList:new()
+        token_nth_tick_handlers[tick].append(token)
     else
-        tokens[#tokens + 1] = token
+        tokens.append(token)
     end
 
     if handlers_added then
@@ -370,7 +366,7 @@ function Event.remove_removable_nth_tick(tick, token)
     remove(tokens, token)
     remove(handlers, handler)
 
-    if #handlers == 0 then
+    if handlers:size() == 0 then
         script_on_nth_tick(tick, nil)
     end
 end
@@ -423,19 +419,19 @@ function Event.add_removable_nth_tick_function(tick, func, remove_token)
 
     local funcs = function_nth_tick_handlers[name]
     if not funcs then
-        function_nth_tick_handlers[name] = {}
+        function_nth_tick_handlers[name] = LinkedList:new()
         funcs = function_nth_tick_handlers[name]
     end
 
-    funcs[#funcs + 1] = { tick = tick, handler = func }
+    funcs:append({ tick = tick, handler = func })
 
     local func_table = function_nth_tick_table[name]
     if not func_table then
-        function_nth_tick_table[name] = {}
+        function_nth_tick_table[name] = LinkedList:new()
         func_table = function_nth_tick_table[name]
     end
 
-    func_table[#func_table + 1] = { tick = tick, handler = f }
+    func_table:append({ tick = tick, handler = f })
 
     if handlers_added then
         core_on_nth_tick(tick, f)
@@ -470,7 +466,7 @@ function Event.remove_removable_nth_tick_function(tick, name)
         end
     end
 
-    remove(handlers, f)
+    handlers:remove(f)
 
     for k, v in pairs(function_nth_tick_handlers[name]) do
         local t = v.tick
@@ -479,11 +475,11 @@ function Event.remove_removable_nth_tick_function(tick, name)
         end
     end
 
-    if #function_nth_tick_handlers[name] == 0 then
+    if function_nth_tick_handlers[name]:size() == 0 then
         function_nth_tick_handlers[name] = nil
     end
 
-    if #handlers == 0 then
+    if handlers:size() == 0 then
         script_on_nth_tick(tick, nil)
     end
 end
@@ -523,19 +519,20 @@ local function add_handlers()
     end
 
     for name, funcs in pairs(function_handlers) do
-        for i, func in pairs(funcs) do
+        funcs:traverse(function(node)
+            local func = node.value
             local e_name = func.event_name
             local func_string = func.handler
             local handler = assert(load('return ' .. func_string))()
             local func_handler = function_table[name]
             if not func_handler then
-                function_table[name] = {}
+                function_table[name] = LinkedList:new()
                 func_handler = function_table[name]
             end
 
-            func_handler[#func_handler + 1] = { event_name = e_name, handler = handler }
+            func_handler:append({ event_name = e_name, handler = handler })
             core_add(e_name, handler)
-        end
+        end)
     end
 
     for tick, tokens in pairs(token_nth_tick_handlers) do
@@ -546,19 +543,20 @@ local function add_handlers()
     end
 
     for name, funcs in pairs(function_nth_tick_handlers) do
-        for i, func in pairs(funcs) do
+        funcs:traverse(function(node)
+            local func = node.value
             local tick = func.tick
             local func_string = func.handler
             local handler = assert(load('return ' .. func_string))()
             local func_handler = function_nth_tick_table[name]
             if not func_handler then
-                function_nth_tick_table[name] = {}
+                function_nth_tick_table[name] = LinkedList:new()
                 func_handler = function_nth_tick_table[name]
             end
 
-            func_handler[#func_handler + 1] = { tick = tick, handler = handler }
+            func_handler:append({ tick = tick, handler = handler })
             core_on_nth_tick(tick, handler)
-        end
+        end)
     end
 
     handlers_added = true

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -91,8 +91,9 @@ function Public.add(event_name, handler)
         event_handlers[event_name]:append(handler)
         script_on_event(event_name, on_event)
     else
+        local isEmpty = handlers:isEmpty()
         handlers:append(handler)
-        if handlers:size() == 1 then
+        if isEmpty then
             script_on_event(event_name, on_event)
         end
     end
@@ -106,8 +107,9 @@ function Public.on_init(handler)
         event_handlers[init_event_name]:append(handler)
         script.on_init(on_init)
     else
+        local isEmpty = handlers:isEmpty()
         handlers:append(handler)
-        if handlers:size() == 1 then
+        if isEmpty then
             script.on_init(on_init)
         end
     end
@@ -121,8 +123,9 @@ function Public.on_load(handler)
         event_handlers[load_event_name]:append(handler)
         script.on_load(on_load)
     else
+        local isEmpty = handlers:isEmpty()
         handlers:append(handler)
-        if handlers:size() == 1 then
+        if isEmpty then
             script.on_load(on_load)
         end
     end
@@ -136,8 +139,9 @@ function Public.on_nth_tick(tick, handler)
         on_nth_tick_event_handlers[tick]:append(handler)
         script_on_nth_tick(tick, on_nth_tick_event)
     else
+        local isEmpty = handlers:isEmpty()
         handlers:append(handler)
-        if handlers:size() == 1 then
+        if isEmpty then
             script_on_nth_tick(tick, on_nth_tick_event)
         end
     end

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -22,7 +22,7 @@ local on_nth_tick_event_handlers = {}
 if not remote.interfaces['interface'] then
     remote.add_interface('interface', interface)
 end ]]
-local pcall = pcall
+local xpcall = xpcall
 local debug_getinfo = debug.getinfo
 local log = log
 local script_on_event = script.on_event

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -40,8 +40,8 @@ function call_handlers(handlers, event)
         return log('Handlers was nil!')
     end
 
-    handlers:traverse(function(node)
-        xpcall(node.value, errorHandler, event)
+    handlers:traverse(function(handler)
+        xpcall(handler, errorHandler, event)
     end)
 end
 

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -87,64 +87,56 @@ function Public.add(event_name, handler)
     end
     local handlers = event_handlers[event_name]
     if not handlers then
-        event_handlers[event_name] = LinkedList:new()
-        event_handlers[event_name]:append(handler)
-        script_on_event(event_name, on_event)
-    else
-        local isEmpty = handlers:isEmpty()
-        handlers:append(handler)
-        if isEmpty then
-            script_on_event(event_name, on_event)
-        end
+        handlers = LinkedList:new()
+        event_handlers[event_name] = handlers
     end
+
+    if handlers:isEmpty() then
+        script_on_event(event_name, on_event)
+    end
+    event_handlers[event_name]:append(handler)
 end
 
 --- Do not use this function, use Event.on_init instead as it has safety checks.
 function Public.on_init(handler)
     local handlers = event_handlers[init_event_name]
     if not handlers then
-        event_handlers[init_event_name] = LinkedList:new()
-        event_handlers[init_event_name]:append(handler)
-        script.on_init(on_init)
-    else
-        local isEmpty = handlers:isEmpty()
-        handlers:append(handler)
-        if isEmpty then
-            script.on_init(on_init)
-        end
+        handlers = LinkedList:new()
+        event_handlers[init_event_name] = handlers
     end
+
+    if handlers:isEmpty() then
+        script.on_init(on_init)
+    end
+    handlers:append(handler)
 end
 
 --- Do not use this function, use Event.on_load instead as it has safety checks.
 function Public.on_load(handler)
     local handlers = event_handlers[load_event_name]
     if not handlers then
-        event_handlers[load_event_name] = LinkedList:new()
-        event_handlers[load_event_name]:append(handler)
-        script.on_load(on_load)
-    else
-        local isEmpty = handlers:isEmpty()
-        handlers:append(handler)
-        if isEmpty then
-            script.on_load(on_load)
-        end
+        handlers  = LinkedList:new()
+        event_handlers[load_event_name] = handlers
     end
+
+    if handlers:isEmpty() then
+        script.on_load(on_load)
+    end
+    handlers:append(handler)
 end
 
 --- Do not use this function, use Event.on_nth_tick instead as it has safety checks.
 function Public.on_nth_tick(tick, handler)
     local handlers = on_nth_tick_event_handlers[tick]
     if not handlers then
-        on_nth_tick_event_handlers[tick] = LinkedList:new()
-        on_nth_tick_event_handlers[tick]:append(handler)
-        script_on_nth_tick(tick, on_nth_tick_event)
-    else
-        local isEmpty = handlers:isEmpty()
-        handlers:append(handler)
-        if isEmpty then
-            script_on_nth_tick(tick, on_nth_tick_event)
-        end
+        handlers = LinkedList:new()
+        on_nth_tick_event_handlers[tick] = handlers
     end
+
+    if handlers:isEmpty() then
+        script_on_nth_tick(tick, on_nth_tick_event)
+    end
+    handlers:append(handler)
 end
 
 function Public.get_event_handlers()

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -67,7 +67,7 @@ end
 ----@return nil
 function LinkedList:remove(value)
     if value == self._head.value then
-        self._head = self._hed.next
+        self._head = self._head.next
     end
     local node = self._head
     while node do

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -73,7 +73,9 @@ function LinkedList:remove(value)
     while node do
         local prev = node
         node = node._next
-        if node == nil then return nil end
+        if node == nil then
+            return nil
+        end
         if value == node.value then
             prev._next = node._next
             return nil

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -1,0 +1,178 @@
+-- copied from https://www.whoop.ee/post/linked-list.html
+---@class Node
+---@field value any
+---@field next Node | nil
+local Node = {}
+Node.__index = Node
+
+---@param value any
+---@param next? Node | nil
+---@return Node
+function Node:new(value, next)
+    return setmetatable({
+        value = value,
+        next = next,
+    }, self)
+end
+
+---@class LinkedList
+---@field private _head Node | nil
+---@field private _size number
+local LinkedList = {}
+LinkedList.__index = LinkedList
+
+---@return LinkedList
+function LinkedList:new()
+    local t = {
+        _head = nil,
+        _size = 0,
+    }
+    return setmetatable(t, self)
+end
+
+---@return Node | nil
+function LinkedList:head()
+    return self._head
+end
+
+---Complexity O(n)
+---@return Node | nil
+function LinkedList:tail()
+    local tail = nil
+    self:traverse(function(node)
+        tail = node
+    end)
+    return tail
+end
+
+---@return number
+function LinkedList:size()
+    return self._size
+end
+
+---@return boolean
+function LinkedList:isEmpty()
+    return self._size == 0
+end
+
+---Prepends the node with a value to the beginning of the list.
+---@param value any
+---@return Node
+function LinkedList:prepend(value)
+    self._size = self._size + 1
+    self._head = Node:new(value, self._head)
+    return self._head
+end
+
+---Appends the node with a value to the end of the list.
+---@param value any
+---@return Node
+function LinkedList:append(value)
+    local node = Node:new(value)
+    if self._head == nil then
+        self._head = node
+    else
+        local ptr = self._head
+        while ptr and ptr.next do
+            ptr = ptr.next
+        end
+        ptr.next = node
+    end
+    self._size = self._size + 1
+    return self._head
+end
+
+---Inserts a new node with value after given node. If after node is nil,
+---then it will be inserted at the beginning of the list.
+---@param after Node
+---@param value any
+---@return Node | nil
+function LinkedList:insertAfter(after, value)
+    if after == nil then
+        return nil
+    end
+    self._size = self._size + 1
+    local node = Node:new(value, after.next)
+    after.next = node
+    return node
+end
+
+---Removes and returns the head. Pointer moves to next node. If next node is
+---not exists nil is returned.
+---@return Node | nil
+function LinkedList:removeHead()
+    local tmp = self._head
+    if not tmp then
+        return nil
+    end
+    self._head = self._head.next
+    return tmp
+end
+
+---Removes and returns a node after given node. If given node not found nil is
+---returned.
+---@param node Node
+---@return Node | nil
+function LinkedList:removeAfter(node)
+    local tmp = node.next
+    node.next = tmp and tmp.next
+    return tmp
+end
+
+function LinkedList:remove(value)
+    if value == self._head.value then
+        self._head = self._hed.next
+    end
+    local node = self._head
+    while node do
+        local prev = node
+        node = node._next
+        if value == node.value then
+            prev._next = node._next
+        end
+    end
+end
+
+---Chekcs if the list contins a give value.
+---@param value any
+---@return boolean
+function LinkedList:contains(value)
+    return self:findByValue(value) ~= nil
+end
+
+---Finds the first occurrence of the value.
+---@param value any
+---@return Node | nil
+function LinkedList:findByValue(value)
+    local node = self._head
+    while node do
+        if node.value == value then
+            return node
+        end
+        node = node.next
+    end
+    return nil
+end
+
+---Traversal of a linked list.
+---@param fn fun(node: Node)
+function LinkedList:traverse(fn)
+    local node = self._head
+    while node do
+        fn(node)
+        node = node.next
+    end
+end
+
+---@param sep? string
+---@return string
+function LinkedList:toString(sep)
+    sep = sep or ' -> '
+    local t = {}
+    self:traverse(function(node)
+        t[#t + 1] = tostring(node.value)
+    end)
+    return table.concat(t, sep)
+end
+
+return LinkedList

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -30,29 +30,9 @@ function LinkedList:new()
     return setmetatable(t, self)
 end
 
----@return Node | nil
-function LinkedList:head()
-    return self._head
-end
-
----Complexity O(n)
----@return Node | nil
-function LinkedList:tail()
-    local tail = nil
-    self:traverse(function(node)
-        tail = node
-    end)
-    return tail
-end
-
----@return number
-function LinkedList:size()
-    return self._size
-end
-
 ---@return boolean
 function LinkedList:isEmpty()
-    return self._size == 0
+    return self._head == nil
 end
 
 ---Prepends the node with a value to the beginning of the list.
@@ -82,43 +62,6 @@ function LinkedList:append(value)
     return self._head
 end
 
----Inserts a new node with value after given node. If after node is nil,
----then it will be inserted at the beginning of the list.
----@param after Node
----@param value any
----@return Node | nil
-function LinkedList:insertAfter(after, value)
-    if after == nil then
-        return nil
-    end
-    self._size = self._size + 1
-    local node = Node:new(value, after.next)
-    after.next = node
-    return node
-end
-
----Removes and returns the head. Pointer moves to next node. If next node is
----not exists nil is returned.
----@return Node | nil
-function LinkedList:removeHead()
-    local tmp = self._head
-    if not tmp then
-        return nil
-    end
-    self._head = self._head.next
-    return tmp
-end
-
----Removes and returns a node after given node. If given node not found nil is
----returned.
----@param node Node
----@return Node | nil
-function LinkedList:removeAfter(node)
-    local tmp = node.next
-    node.next = tmp and tmp.next
-    return tmp
-end
-
 function LinkedList:remove(value)
     if value == self._head.value then
         self._head = self._hed.next
@@ -133,27 +76,6 @@ function LinkedList:remove(value)
     end
 end
 
----Chekcs if the list contins a give value.
----@param value any
----@return boolean
-function LinkedList:contains(value)
-    return self:findByValue(value) ~= nil
-end
-
----Finds the first occurrence of the value.
----@param value any
----@return Node | nil
-function LinkedList:findByValue(value)
-    local node = self._head
-    while node do
-        if node.value == value then
-            return node
-        end
-        node = node.next
-    end
-    return nil
-end
-
 ---Traversal of a linked list.
 ---@param fn fun(node: Node)
 function LinkedList:traverse(fn)
@@ -162,17 +84,6 @@ function LinkedList:traverse(fn)
         fn(node)
         node = node.next
     end
-end
-
----@param sep? string
----@return string
-function LinkedList:toString(sep)
-    sep = sep or ' -> '
-    local t = {}
-    self:traverse(function(node)
-        t[#t + 1] = tostring(node.value)
-    end)
-    return table.concat(t, sep)
 end
 
 return LinkedList

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -73,6 +73,7 @@ function LinkedList:remove(value)
     while node do
         local prev = node
         node = node._next
+        if node == nil then return nil end
         if value == node.value then
             prev._next = node._next
             return nil

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -62,6 +62,9 @@ function LinkedList:append(value)
     return self._head
 end
 
+----Removes the first occruenace of the value.
+----@param value any
+----@return nil
 function LinkedList:remove(value)
     if value == self._head.value then
         self._head = self._hed.next
@@ -72,6 +75,7 @@ function LinkedList:remove(value)
         node = node._next
         if value == node.value then
             prev._next = node._next
+            return nil
         end
     end
 end

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -17,7 +17,6 @@ end
 
 ---@class LinkedList
 ---@field private _head Node | nil
----@field private _size number
 local LinkedList = {}
 LinkedList.__index = LinkedList
 
@@ -25,7 +24,6 @@ LinkedList.__index = LinkedList
 function LinkedList:new()
     local t = {
         _head = nil,
-        _size = 0,
     }
     return setmetatable(t, self)
 end
@@ -39,7 +37,6 @@ end
 ---@param value any
 ---@return Node
 function LinkedList:prepend(value)
-    self._size = self._size + 1
     self._head = Node:new(value, self._head)
     return self._head
 end
@@ -58,7 +55,6 @@ function LinkedList:append(value)
         end
         ptr.next = node
     end
-    self._size = self._size + 1
     return self._head
 end
 

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -88,7 +88,7 @@ end
 function LinkedList:traverse(fn)
     local node = self._head
     while node do
-        fn(node)
+        fn(node.value)
         node = node.next
     end
 end

--- a/utils/linked_list.lua
+++ b/utils/linked_list.lua
@@ -68,12 +68,12 @@ function LinkedList:remove(value)
     local node = self._head
     while node do
         local prev = node
-        node = node._next
+        node = node.next
         if node == nil then
             return nil
         end
         if value == node.value then
-            prev._next = node._next
+            prev.next = node.next
             return nil
         end
     end


### PR DESCRIPTION
### Brief description of the changes:
Use linked list class instead of deep copy of event handlers.

In profiling the time spent copying handlers is reduced by a full second:
OLD
```
3830x "deepcopy" in "__core__/lualib/util.lua", line 6. Total Duration: 1027.455492ms
```
NEW
```
```

### Tested Changes:
- [x] I've tested the changes locally.