### PR TITLE
Loop handlers backwards

### DIFF
--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -20,7 +20,7 @@ local on_nth_tick_event_handlers = {}
 if not remote.interfaces['interface'] then
     remote.add_interface('interface', interface)
 end ]]
-local pcall = pcall
+local xpcall = xpcall
 local debug_getinfo = debug.getinfo
 local log = log
 local script_on_event = script.on_event
@@ -32,6 +32,7 @@ local function errorHandler(err)
     log(debug.traceback())
 end
 
+-- loop backwards to allow handlers to safely self-remove themselves
 local function call_handlers(handlers, event)
     for i = #handlers, 1, -1 do
         xpcall(handlers[i], errorHandler, event)

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -32,24 +32,9 @@ local function errorHandler(err)
     log(debug.traceback())
 end
 
-local call_handlers
-function call_handlers(handlers, event)
-    if not handlers then
-        return log('Handlers was nil!')
-    end
-    local handlers_copy = table.deepcopy(handlers)
-    for i = 1, #handlers do
-        local handler = handlers[i]
-        if handler == nil and handlers_copy[i] ~= nil then
-            if table.contains(handlers, handlers_copy[i]) then
-                handler = handlers_copy[i]
-            end
-        end
-        if handler ~= nil then
-            xpcall(handler, errorHandler, event)
-        else
-            log('nil handler')
-        end
+local function call_handlers(handlers, event)
+    for i = #handlers, 1, -1 do
+        xpcall(handlers[i], errorHandler, event)
     end
 end
 
@@ -98,7 +83,7 @@ function Public.add(event_name, handler)
         event_handlers[event_name] = { handler }
         script_on_event(event_name, on_event)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script_on_event(event_name, on_event)
         end
@@ -112,7 +97,7 @@ function Public.on_init(handler)
         event_handlers[init_event_name] = { handler }
         script.on_init(on_init)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script.on_init(on_init)
         end
@@ -126,7 +111,7 @@ function Public.on_load(handler)
         event_handlers[load_event_name] = { handler }
         script.on_load(on_load)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script.on_load(on_load)
         end
@@ -140,7 +125,7 @@ function Public.on_nth_tick(tick, handler)
         on_nth_tick_event_handlers[tick] = { handler }
         script_on_nth_tick(tick, on_nth_tick_event)
     else
-        table.insert(handlers, handler)
+        table.insert(handlers, 1, handler)
         if #handlers == 1 then
             script_on_nth_tick(tick, on_nth_tick_event)
         end


### PR DESCRIPTION
# Changes
- [x] loop handlers table backwards to allow handlers to remove themselves and not use any table deepcopy/shallowcopy
- [x] handlers are registered backwards as well to maintain load order of dependencies


Each Factorio session was launched on its own through CL option `./factorio --enable-unsafe-lua-debug-api`, and performing a similar amount of updates at `game.speed = 1` on a AMD Ryzen 7800x3D.

Comparison between #677, #678, and #681 using the in-game `/startProfiler`.

```
Deep Copy (master)
3602x "anonymous" in "event_core.lua", line 56. Total Elapsed: 417.046229ms
3602x "call_handlers" in "event_core.lua", line 36. Total Elapsed: 401.815727ms

Shallow Copy (PR #677)
3602x "anonymous" in "event_core.lua", line 56. Total Elapsed: 198.237986ms
3602x "call_handlers" in "event_core.lua", line 36. Total Elapsed: 182.213295ms

Linked List (PR #678)
3602x "anonymous" in "event_core.lua", line 48. Total Elapsed: 241.542714ms
3602x "call_handlers" in "event_core.lua", line 38. Total Elapsed: 225.639348ms

Backwards (PR #681)
3602x "anonymous" in "event_core.lua", line 41. Total Elapsed: 189.053362ms
3602x "call_handlers" in "event_core.lua", line 35. Total Elapsed: 173.403766ms
```

# Tests

### Test 1;
```
/c
local Event = _G.package.loaded['__level__/utils/event.lua']
storage.ftick = 123
local f1 = ' function(event)     game.print("f1")     local Event = require "utils.event"     Event.remove_removable_nth_tick_function(storage.ftick, "f1") end '
local f2 = ' function(event)     game.print("f2")     local Event = require "utils.event"     Event.remove_removable_nth_tick_function(storage.ftick, "f2") end '

Event.add_removable_nth_tick_function(storage.ftick, f1, "f1")
Event.add_removable_nth_tick_function(storage.ftick, f2, "f2")
```
### Test 2;
```
/c

local Event = require "utils.event"

local on_surface_deleted_1 = '
function(event)
    game.print("on_surface_deleted_1")
    local Event = require "utils.event"
    Event.remove_removable_function(defines.events.on_surface_deleted, "on_surface_deleted_1")
end
'
Event.add_removable_function(defines.events.on_surface_deleted, on_surface_deleted_1, "on_surface_deleted_1")

local on_surface_deleted_2 = '
function(event)
    game.print("on_surface_deleted_2")
    local Event = require "utils.event"
    Event.remove_removable_function(defines.events.on_surface_deleted, "on_surface_deleted_2")
end
'
Event.add_removable_function(defines.events.on_surface_deleted, on_surface_deleted_2, "on_surface_deleted_2")

local on_surface_deleted_3 = '
function(event)
    game.print("on_surface_deleted_3")
    local Event = require "utils.event"
    Event.remove_removable_function(defines.events.on_surface_deleted, "on_surface_deleted_3")
end
'
Event.add_removable_function(defines.events.on_surface_deleted, on_surface_deleted_3, "on_surface_deleted_3")
```
into `/instant-map-reset`
