### PR TITLE
Fix send all permissions on game start #689

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -289,7 +289,7 @@ function Public.feed_biters_from_inventory(player, food)
     if storage.active_special_games['captain_mode'] then
         tick = game.ticks_played
     end
-    if tick < storage.difficulty_votes_timeout then
+    if tick <= storage.difficulty_votes_timeout then
         player.print('Please wait for voting to finish before feeding')
         return
     end
@@ -342,7 +342,7 @@ function Public.feed_biters_mixed_from_inventory(player, button)
     if storage.active_special_games['captain_mode'] then
         tick = game.ticks_played
     end
-    if tick < storage.difficulty_votes_timeout then
+    if tick <= storage.difficulty_votes_timeout then
         player.print('Please wait for voting to finish before feeding')
         return
     end

--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -289,7 +289,7 @@ function Public.feed_biters_from_inventory(player, food)
     if storage.active_special_games['captain_mode'] then
         tick = game.ticks_played
     end
-    if tick <= storage.difficulty_votes_timeout then
+    if tick < storage.difficulty_votes_timeout then
         player.print('Please wait for voting to finish before feeding')
         return
     end


### PR DESCRIPTION
### Brief description of the changes:
Fix https://github.com/Factorio-Biter-Battles/Factorio-Biter-Battles/issues/689

Issue: before game starts, player is allowed to send all science but not single foods.
Correct behavior is that players shouldnt be allowed to send any packs (single/all) before game starts (which happens when 1st entity is mined or when CPT game says so).

SO the Feeding.sends_mixed should not allow time == (because 0 == 0 is always true)

### Tested Changes:
- [x] I've tested the changes locally
