### PR TITLE
Skip mixed_ore generation in biter area

### DIFF
--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -508,13 +508,16 @@ function Public.generate(event)
     local left_top_x = left_top.x
     local left_top_y = left_top.y
 
-    if storage.active_special_games['mixed_ore_map'] then
-        mixed_ore_map(surface, left_top_x, left_top_y)
+    local pos = { x = left_top_x, y = left_top_y }
+    if not Functions.is_biter_area(pos) then
+        if storage.active_special_games['mixed_ore_map'] then
+            mixed_ore_map(surface, left_top_x, left_top_y)
 
-    -- Since a chunk size is 32 in Factorio, therefore we draw mixed ore from -16 to +16. But also we make sure that in the 300x300
-    -- square that we have in Main, we don't draw mixed ore patches. (thats bounded by -150 and +150)
-    elseif left_top_x + 16 < -150 or left_top_x + 16 > 150 or left_top_y + 16 < -150 then
-        mixed_ore(surface, left_top_x, left_top_y)
+        -- Since a chunk size is 32 in Factorio, therefore we draw mixed ore from -16 to +16. But also we make sure that in the 300x300
+        -- square that we have in Main, we don't draw mixed ore patches. (thats bounded by -150 and +150)
+        elseif left_top_x + 16 < -150 or left_top_x + 16 > 150 or left_top_y + 16 < -150 then
+            mixed_ore(surface, left_top_x, left_top_y)
+        end
     end
     generate_river(surface, left_top_x, left_top_y)
     draw_biter_area(surface, left_top_x, left_top_y)


### PR DESCRIPTION
Skip mixed_ore generation in biter area

Before:
```
2025-02-04T15:37:31.375903                              1510x "generate" in "__level__/maps/biter_battles_v2/terrain.lua", line 505. Total Duration: 235337.148407ms
2025-02-04T15:37:31.375983                                      1510x "mixed_ore" in "__level__/maps/biter_battles_v2/terrain.lua", line 468. Total Duration: 196888.773431ms
2025-02-04T15:37:31.376043                                              1627524x C function "__index". Total Duration: 3601.123141ms
2025-02-04T15:37:31.376117                                              1547750x "GetNoise" in "__level__/utils/get_noise.lua", line 149. Total Duration: 169798.487947ms
2025-02-04T15:37:31.376197                                                      4643250x "simplex_noise" in "__level__/utils/simplex_noise.lua", line 306. Total Duration: 152004.246402ms
2025-02-04T15:37:31.376273                                                              12600376x "dot2" in "__level__/utils/simplex_noise.lua", line 290. Total Duration: 26878.502317ms
2025-02-04T15:37:31.376335                                                              9286500x C function "bit32_band". Total Duration: 18148.223671ms
2025-02-04T15:37:31.376403                                                              9286500x C function "math_floor". Total Duration: 17785.937749ms
```

After
```
2025-02-04T22:14:27.259510                              1551x "generate" in "__level__/maps/biter_battles_v2/terrain.lua", line 505. Total Duration: 41273.195918ms
2025-02-04T22:14:27.259605                                      1551x "is_biter_area" in "__level__/maps/biter_battles_v2/functions.lua", line 377. Total Duration: 15.164426ms
2025-02-04T22:14:27.263216                                      21x "mixed_ore" in "__level__/maps/biter_battles_v2/terrain.lua", line 468. Total Duration: 3035.597631ms
```

### Tested Changes:
Tested by waiting for map reveal to finish and then exploring biter area with /editor.