### PR TITLE
New profiler

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -36,6 +36,7 @@ require('comfy_panel.special_games')
 ---------------- ENABLE MAPS HERE ----------------
 --![[North VS South Survival PVP, feed the opposing team's biters with science flasks. Disable Autostash, Group and Poll modules.]]--
 require('maps.biter_battles_v2.main')
+require("utils.profiler_new")
 ---------------------------------------------------------------
 
 -- Controlled via external script

--- a/utils/event.lua
+++ b/utils/event.lua
@@ -75,7 +75,7 @@ local function remove(tbl, handler)
     for i = #tbl, 1, -1 do
         if tbl[i] == handler then
             table_remove(tbl, i)
-            break
+            return i
         end
     end
 end
@@ -197,8 +197,8 @@ function Event.remove_removable(event_name, token)
     local handlers = event_handlers[event_name]
 
     remove(tokens, token)
-    remove(handlers, handler)
-
+    local index = remove(handlers, handler)
+    EventCore.remove_event_handler_path(event_name, index)
     if #handlers == 0 then
         script_on_event(event_name, nil)
     end
@@ -314,7 +314,8 @@ function Event.remove_removable_function(event_name, name)
         if n == event_name then
             local f = v.handler
             function_handlers[name][k] = nil
-            remove(handlers, f)
+            local index = remove(handlers, f)
+            EventCore.remove_event_handler_path(event_name,index)
         end
     end
 
@@ -368,8 +369,8 @@ function Event.remove_removable_nth_tick(tick, token)
     local handlers = on_nth_tick_event_handlers[tick]
 
     remove(tokens, token)
-    remove(handlers, handler)
-
+    local index = remove(handlers, handler)
+    EventCore.remove_nth_tick_event_handler_path(tick, index)
     if #handlers == 0 then
         script_on_nth_tick(tick, nil)
     end

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -19,7 +19,7 @@ local load_event_name = -2
 -- map of event_name to handlers[]
 ---@type table<EventName, fun(event: EventData)[]>
 local event_handlers = {}
-local profiler_new_player = storage.profiler_new.player
+
 -- map of nth_tick to handlers[]
 local on_nth_tick_event_handlers = {}
 
@@ -60,7 +60,7 @@ local function call_handlers_profiled(handlers, event)
         xpcall(handlers[i], errorHandler, event)
         profiler.stop()
         -- conventionally there's only handler for event in each file, so short_scr is enough to identify a function
-        helpers.write_file(path, {"", game_tick, "\t",debug_getinfo(handlers[i],"S").short_src, "\t", profiler, "\n"}, true, profiler_new_player)
+        helpers.write_file(path, {"", game_tick, "\t",debug_getinfo(handlers[i],"S").short_src, "\t", profiler, "\n"}, true, storage.profiler_new.player)
     end
 end
 
@@ -73,7 +73,7 @@ local function call_nth_tick_handlers_profiled(handlers, event)
         xpcall(handlers[i], errorHandler, event)
         profiler.stop()
         -- conventionally there's only handler for event in each file, so short_scr is enough to identify a function
-        helpers.write_file(path, {"", game_tick, "\t",debug_getinfo(handlers[i],"S").short_src, "\t", profiler, "\n"}, true, profiler_new_player)
+        helpers.write_file(path, {"", game_tick, "\t",debug_getinfo(handlers[i],"S").short_src, "\t", profiler, "\n"}, true, storage.profiler_new.player)
     end
 end
 

--- a/utils/event_core.lua
+++ b/utils/event_core.lua
@@ -16,11 +16,21 @@ end
 ---example: event_handlers_paths[defines.events.on_tick][1] = 'profiler/on_tick/maps-biter_battles_v2-main.txt'
 ---@type table<EventName, string[]>
 local event_handlers_paths = {}
-
+---@param event_name EventName
+---@param index integer?
+function Public.remove_event_handler_path(event_name, index)
+    if index then
+        log({"","Removed \t ", table.remove(event_handlers_paths[event_name],index), " at index ", index})
+    end
+end
 ---example: nth_tick_event_handlers_paths[60][1] = 'profiler/on_60th_tick/maps-biter_battles_v2-main.txt'
----@type table<unit, string[]>
+---@type table<integer, string[]>
 local nth_tick_event_handlers_paths = {}
-
+function Public.remove_nth_tick_event_handler_path(tick, index)
+    if index then
+        log({"","Removed \t ", table.remove(nth_tick_event_handlers_paths[tick],index), " at index ", index})
+    end
+end
 local init_event_name = -1
 local load_event_name = -2
 
@@ -145,7 +155,9 @@ function Public.add(event_name, handler)
         end
     end
 
-    --- save profiler log location for this handler 
+    --- save profiler log location for this handler
+    if not event_handlers_paths[event_name] then event_handlers_paths[event_name] = {} end
+    local info = debug_getinfo(handler, "S")
     table.insert(
         event_handlers_paths[event_name], 
         1, 
@@ -153,7 +165,9 @@ function Public.add(event_name, handler)
             "profiler/", 
             event_name_to_human_readable_name[event_name], 
             "/",
-            string.gsub(string.sub(debug_getinfo(handler, "S").short_scr, 11, -5), "/", "-"),
+            string.gsub(string.sub(info.short_src, 11, -5), "/", "-"),
+            "@",
+            info.linedefined,
             ".txt"
         }
     )
@@ -199,6 +213,9 @@ function Public.on_nth_tick(tick, handler)
             script_on_nth_tick(tick, on_nth_tick_event)
         end
     end
+
+    if not nth_tick_event_handlers_paths[tick] then nth_tick_event_handlers_paths[tick] = {} end
+    local info = debug_getinfo(handler, "S")
     table.insert(
         nth_tick_event_handlers_paths[tick], 
         1, 
@@ -206,7 +223,9 @@ function Public.on_nth_tick(tick, handler)
             "profiler/on_", 
             tick, 
             "th_tick/",
-            string.gsub(string.sub(debug_getinfo(handler, "S").short_scr, 11, -5), "/", "-"),
+            string.gsub(string.sub(info.short_src, 11, -5), "/", "-"),
+            "@",
+            info.linedefined,
             ".txt"
         }
     )

--- a/utils/profiler_new.lua
+++ b/utils/profiler_new.lua
@@ -64,7 +64,7 @@ local measure_tick_duration = Token.register(function(event)
     index = index + 1
     ---dump data when LocalisedString limit size is reached
     if index == 21 then
-        helpers.write_file('profiler/total_tick_duration.txt', tick_durations, true, storage.profiler_new.player)
+        helpers.write_file('profiler/cumulative/total_tick_duration.txt', tick_durations, true, storage.profiler_new.player)
         index = 2
     end
     ---start timer for this tick

--- a/utils/profiler_new.lua
+++ b/utils/profiler_new.lua
@@ -1,0 +1,145 @@
+local Event = require('utils.event')
+local Token = require('utils.token')
+
+storage.profiler_new = {
+    enabled = false,
+    player = 0,
+}
+--- starting at index 2, as first entry is a constant empty string
+local index = 2
+---preallocate array of log entries
+local tick_durations = {
+    '',
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+    {},
+}
+---preallocate array of LuaProfilers
+---@type 0[]|LuaProfiler[]
+local profilers = {
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+}
+
+--- Measure duration of each tick update.
+--- Dumping on every 19th tick to minimize number of write_file() calls
+local measure_tick_duration = Token.register(function(event)
+    ---stop the profiler started in previous tick
+    profilers[index].stop()
+    ---log its data
+    tick_durations[index] = { '', event.tick - 1, '\t', profilers[index], '\n' }
+    index = index + 1
+    ---dump data when LocalisedString limit size is reached
+    if index == 21 then
+        helpers.write_file('profiler/total_tick_duration.txt', tick_durations, true, storage.profiler_new.player)
+        index = 2
+    end
+    ---start timer for this tick
+    profilers[index].reset()
+end)
+
+---Start the profiler
+---Logs are exported only to the player that enabled the profiler
+---@param cmd CustomCommandData
+local function profiler_start(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player.admin then
+        player.print('This is admin-only command.')
+        return
+    end
+    if storage.profiler_new.enabled then
+        player.print('Profiler is already running')
+        return
+    end
+    storage.profiler_new = { enabled = true, player = cmd.player_index }
+    for i = 2, 20, 1 do
+        profilers[i] = helpers.create_profiler(true)
+    end
+    profilers[2].restart()
+    Event.add_removable(defines.events.on_tick, measure_tick_duration)
+    game.print('====Profiler started====\n')
+end
+
+---Stop the profiler
+---todo: dump the data from partially filled tick_duration array
+---@param cmd CustomCommandData
+local function profiler_stop(cmd)
+    local player = game.get_player(cmd.player_index)
+    if not player.admin then
+        player.print('This is admin-only command.')
+        return
+    end
+    if not storage.profiler_new.enabled then
+        player.print("Profiler isn't running")
+        return
+    end
+    for i = index, 20, 1 do
+        tick_durations[i] = { '', '' }
+    end
+    helpers.write_file('profiler/total_tick_duration.txt', tick_durations, true, storage.profiler_new.player)
+    index = 2
+    storage.profiler_new.enabled = false
+    profilers = {
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    }
+    Event.remove_removable(defines.events.on_tick, measure_tick_duration)
+    game.print('====Profiler stopped====\n Check logs in script-output/profiler \n')
+end
+
+commands.add_command(
+    'StartProfilerNew',
+    'Start NewProfiler. Logs are written to script-output/profiler of the player that started the profiler.',
+    profiler_start
+)
+commands.add_command('StopProfilerNew', 'Stop NewProfiler', profiler_stop)


### PR DESCRIPTION
### Brief description of the changes:
**To be tested for desyncs**

Introduce profiler logging performance of each event handler.
Data is written to dedicated file stucture in `script-output/` instead of `factorio-current.log`.
In order to keep overhead as low as possible, data is exported in raw format - processing is expected to be done by user outside of Factorio.
Data is written only to the player that started the profiler, avoiding looping over players during exporting. User is expected to share the data with other developers.

To do:
- minimize number of `write_file()` calls by buffering data
- add a filter to whitelist or blacklist given events
- hook up NewProfiler to old `/startProfiler` command, and fire one or the other based on running Factorio version/mode

### Tested Changes:
- [x] I've tested the changes locally. _**To be tested for desyncs**_
- [ ] I've not tested the changes.
