### PR TITLE
Conceal CPT team chats during planning

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -759,7 +759,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
         game.print('>>> Players have been frozen!', { color = { r = 111, g = 111, b = 255 } })
     end
     allow_vote()
-    game.print('Teams\' chat have been concealed until game begins!', { color = Color.cyan })
+    game.print("Teams' chat have been concealed until game begins!", { color = Color.cyan })
 
     local y = 0
     if storage.special_games_variables.rendering == nil then
@@ -964,7 +964,7 @@ local function start_captain_event()
         storage.freeze_players = false
         TeamManager.unfreeze_players()
         game.print('>>> Players have been unfrozen!', { color = { r = 255, g = 77, b = 77 } })
-        game.print('Teams\' chat have been revealed!', { color = Color.cyan })
+        game.print("Teams' chat have been revealed!", { color = Color.cyan })
         log('Players have been unfrozen! Game starts now!')
     end
     local special = storage.special_games_variables.captain_mode

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -964,7 +964,7 @@ local function start_captain_event()
         storage.freeze_players = false
         TeamManager.unfreeze_players()
         game.print('>>> Players have been unfrozen!', { color = { r = 255, g = 77, b = 77 } })
-        game.print("Teams' chat have been revealed!", { color = Color.cyan })
+        game.print("Teams' chat have been revealed to spectators!", { color = Color.cyan })
         log('Players have been unfrozen! Game starts now!')
     end
     local special = storage.special_games_variables.captain_mode

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -759,6 +759,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
         game.print('>>> Players have been frozen!', { color = { r = 111, g = 111, b = 255 } })
     end
     allow_vote()
+    game.print('Teams\' chat have been concealed until game begins!', { color = Color.cyan })
 
     local y = 0
     if storage.special_games_variables.rendering == nil then
@@ -963,6 +964,7 @@ local function start_captain_event()
         storage.freeze_players = false
         TeamManager.unfreeze_players()
         game.print('>>> Players have been unfrozen!', { color = { r = 255, g = 77, b = 77 } })
+        game.print('Teams\' chat have been revealed!', { color = Color.cyan })
         log('Players have been unfrozen! Game starts now!')
     end
     local special = storage.special_games_variables.captain_mode

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -759,7 +759,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
         game.print('>>> Players have been frozen!', { color = { r = 111, g = 111, b = 255 } })
     end
     allow_vote()
-    game.print("Teams' chat have been concealed until game begins!", { color = Color.cyan })
+    game.print("Teams' chat have been hidden from spectators until game begins!", { color = Color.cyan })
 
     local y = 0
     if storage.special_games_variables.rendering == nil then

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -273,6 +273,12 @@ local function on_console_chat(event)
         return player_force_name == ping_player.force.name
     end)
     if not muted and (player_force_name == 'north' or player_force_name == 'south') then
+        -- Do not share team's chat with spectators during CPT preparation phase
+        local special = storage.special_games_variables.captain_mode
+        if special and special.prepaPhase then
+            return
+        end
+
         Functions.print_message_to_players(game.forces.spectator.players, player_name, msg, color, do_ping)
     end
 


### PR DESCRIPTION
### Brief description of the changes:
As per poll on discord: [Make NORTH and SOUTH chat not visible to spectators in CPT games during picking phase to keep plans secret during preparation phase until game has started](https://discord.com/channels/823696400797138974/823705092372430869/1330209572757049577): 21 in favor vs 0 against. 

Does not forward NTH ans STH chats to spectator force during preparation phase of cpt games. Lifts the curtains once the game starts.

Added game.prints to inform all players (nth, sth, spect) of when the chat is hidden/revealed

### Tested Changes:
- [x] I've tested the changes locally in single player.
- [ ] I've not tested the changes in multiplayer.
