### PR TITLE
Game over perf tweaks

### DIFF
--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -162,7 +162,7 @@ local function show_endgame_gui(player)
             maximal_height = 180,
         })
 
-        local icon = subheader.add({
+        subheader.add({
             type = 'sprite-button',
             sprite = 'utility/side_menu_achievements_icon',
             style = 'transparent_slot',
@@ -177,7 +177,7 @@ local function show_endgame_gui(player)
         )
 
         Gui.add_pusher(subheader)
-        local icon = subheader.add({
+        subheader.add({
             type = 'sprite-button',
             sprite = 'utility/side_menu_achievements_icon',
             style = 'transparent_slot',
@@ -201,16 +201,14 @@ local function show_endgame_gui(player)
         local subheader = inner_frame.add({ type = 'frame', style = 'subheader_frame' })
         gui_style(subheader, { horizontally_squashable = true, maximal_height = 40, use_header_filler = true })
 
-        local icon =
-            subheader.add({ type = 'sprite-button', sprite = 'utility/empty_armor_slot', style = 'transparent_slot' })
+        subheader.add({ type = 'sprite-button', sprite = 'utility/empty_armor_slot', style = 'transparent_slot' })
         Gui.add_pusher(subheader)
 
         local label = subheader.add({ type = 'label', caption = 'MVPs' })
         gui_style(label, { font = 'default-semibold', font_color = { 165, 165, 165 }, left_margin = 4 })
 
         Gui.add_pusher(subheader)
-        local icon =
-            subheader.add({ type = 'sprite-button', sprite = 'utility/empty_armor_slot', style = 'transparent_slot' })
+        subheader.add({ type = 'sprite-button', sprite = 'utility/empty_armor_slot', style = 'transparent_slot' })
 
         local sp =
             inner_frame.add({ type = 'scroll-pane', style = 'scroll_pane_under_subheader', direction = 'vertical' })
@@ -224,19 +222,28 @@ local function show_endgame_gui(player)
             local t = f.add({ type = 'table', column_count = 2 })
 
             gui_style(t.add({ type = 'label', caption = 'Defender >> ' }), category_style)
-                
-            gui_style(t.add({ type = 'label', caption = {'', mvp.killscore.name, ' with a score of ', mvp.killscore.score} }), winner_style)
+
+            gui_style(
+                t.add({ type = 'label', caption = { '', mvp.killscore.name, ' with a score of ', mvp.killscore.score } }),
+                winner_style
+            )
 
             gui_style(t.add({ type = 'label', caption = 'Builder >> ' }), category_style)
 
-            gui_style(t.add({
-                type = 'label',
-                caption = {'', mvp.built_entities.nam, ' built ', mvp.built_entities.score, ' things'},
-            }), winner_style)
+            gui_style(
+                t.add({
+                    type = 'label',
+                    caption = { '', mvp.built_entities.name, ' built ', mvp.built_entities.score, ' things' },
+                }),
+                winner_style
+            )
 
             gui_style(t.add({ type = 'label', caption = 'Deaths >> ' }), category_style)
 
-            gui_style(t.add({ type = 'label', caption = {'', mvp.deaths.name, ' died ', mvp.deaths.score, ' times'} }), winner_style)
+            gui_style(
+                t.add({ type = 'label', caption = { '', mvp.deaths.name, ' died ', mvp.deaths.score, ' times' } }),
+                winner_style
+            )
 
             if not storage.results_sent_north then
                 Server.to_discord_embed(table.concat({
@@ -252,7 +259,7 @@ local function show_endgame_gui(player)
                     mvp.deaths.name,
                     ' died ',
                     mvp.deaths.score,
-                    ' times'
+                    ' times',
                 }))
                 storage.results_sent_north = true
             end
@@ -266,21 +273,29 @@ local function show_endgame_gui(player)
 
             local t = f.add({ type = 'table', column_count = 2 })
 
-
             gui_style(t.add({ type = 'label', caption = 'Defender >> ' }), category_style)
-                
-            gui_style(t.add({ type = 'label', caption = {'', mvp.killscore.name, ' with a score of ', mvp.killscore.score} }), winner_style)
+
+            gui_style(
+                t.add({ type = 'label', caption = { '', mvp.killscore.name, ' with a score of ', mvp.killscore.score } }),
+                winner_style
+            )
 
             gui_style(t.add({ type = 'label', caption = 'Builder >> ' }), category_style)
 
-            gui_style(t.add({
-                type = 'label',
-                caption = {'', mvp.built_entities.name, ' built ', mvp.built_entities.score, ' things'},
-            }), winner_style)
+            gui_style(
+                t.add({
+                    type = 'label',
+                    caption = { '', mvp.built_entities.name, ' built ', mvp.built_entities.score, ' things' },
+                }),
+                winner_style
+            )
 
             gui_style(t.add({ type = 'label', caption = 'Deaths >> ' }), category_style)
 
-            gui_style(t.add({ type = 'label', caption = {'', mvp.deaths.name, ' died ', mvp.deaths.score, ' times'} }), winner_style)
+            gui_style(
+                t.add({ type = 'label', caption = { '', mvp.deaths.name, ' died ', mvp.deaths.score, ' times' } }),
+                winner_style
+            )
 
             if not storage.results_sent_south then
                 Server.to_discord_embed(table.concat({
@@ -296,7 +311,7 @@ local function show_endgame_gui(player)
                     mvp.deaths.name,
                     ' died ',
                     mvp.deaths.score,
-                    ' times'
+                    ' times',
                 }))
                 storage.results_sent_south = true
             end
@@ -440,7 +455,7 @@ function Public.silo_death(event)
 
         set_victory_time()
         team_stats_compare.game_over()
-        local players = {north = {'NORTH PLAYERS: \\n'}, south = {'SOUTH PLAYERS: \\n'}}
+        local players = { north = { 'NORTH PLAYERS: \\n' }, south = { 'SOUTH PLAYERS: \\n' } }
         for _, player in pairs(game.connected_players) do
             player.play_sound({ path = 'utility/game_won', volume_modifier = 1 })
             local main_frame = Gui.get_left_element(player, 'bb_main_gui')
@@ -449,7 +464,7 @@ function Public.silo_death(event)
             end
             show_endgame_gui(player)
 
-            table.insert(players[player.force.name], player.name)   --players with force other than north or south should automatically fall into other, unused fields
+            table.insert(players[player.force.name], player.name) --players with force other than north or south should automatically fall into other, unused fields
         end
 
         storage.spy_fish_timeout.north = game.tick + 999999
@@ -469,17 +484,13 @@ function Public.silo_death(event)
             ' has won! ***',
             '\\n',
             storage.victory_time,
-            '\\n\\n',
-            'North Evo: ',
+            '\\n\\nNorth Evo: ',
             north_evo,
-            '%\\n',
-            'North Threat: ',
+            '%\\nNorth Threat: ',
             north_threat,
-            '\\n\\n',
-            'South Evo: ',
+            '\\n\\nSouth Evo: ',
             south_evo,
-            '%\\n',
-            'South Threat: ',
+            '%\\nSouth Threat: ',
             south_threat,
             '\\n\\n',
             table.concat(players.north, '    '),
@@ -508,35 +519,56 @@ function Public.silo_death(event)
             log_to_db('>Game has ended\n', false)
 
             local log_message = {
-                '[RefereeName]', special.stats.InitialReferee, '\n',
-                 (special.stats.NorthInitialCaptain and ('[CaptainNorth]' .. special.stats.NorthInitialCaptain .. '\n')) or '',
-                 (special.stats.SouthInitialCaptain and ('[CaptainSouth]' .. special.stats.SouthInitialCaptain .. '\n')) or '',
-                 '[NorthTeam]', table.concat(special.stats.northPicks, ';'), '\n',
-                 '[SouthTeam]', table.concat(special.stats.southPicks, ';'), '\n',
-                 '[Gamelength]', game.ticks_played, '\n',
-                 '[StartTick]', special.stats.tickGameStarting, '\n',
-                 '[WinnerTeam]', storage.bb_game_won_by_team, '\n',
-                 '[ExtraInfo]', special.stats.extrainfo, '\n',
-                 '[SpecialEnabled]', special.stats.specialEnabled, '\n',
-                 '[CommunityPickMode]', tostring(special.communityPickingMode), '\n'
-             }
-
+                '[RefereeName]',
+                special.stats.InitialReferee,
+                '\n',
+                (special.stats.NorthInitialCaptain and ('[CaptainNorth]' .. special.stats.NorthInitialCaptain .. '\n'))
+                    or '',
+                (special.stats.SouthInitialCaptain and ('[CaptainSouth]' .. special.stats.SouthInitialCaptain .. '\n'))
+                    or '',
+                '[NorthTeam]',
+                table.concat(special.stats.northPicks, ';'),
+                '\n[SouthTeam]',
+                table.concat(special.stats.southPicks, ';'),
+                '\n[Gamelength]',
+                game.ticks_played,
+                '\n[StartTick]',
+                special.stats.tickGameStarting,
+                '\n[WinnerTeam]',
+                storage.bb_game_won_by_team,
+                '\n[ExtraInfo]',
+                special.stats.extrainfo,
+                '\n[SpecialEnabled]',
+                special.stats.specialEnabled,
+                '\n[CommunityPickMode]',
+                tostring(special.communityPickingMode),
+                '\n',
+            }
 
             for _, player in pairs(game.players) do
                 if player.connected and (player.force.name == 'north' or player.force.name == 'south') then
                     Captain_special.captain_log_end_time_player(player)
                 end
                 if special.stats.playerPlaytimes[player.name] ~= nil then
-                    table.insert(log_message,
-                        table.concat{'[Playtime][', player.name, ']', special.stats.playerPlaytimes[player.name], '\n'}
+                    table.insert(
+                        log_message,
+                        table.concat({
+                            '[Playtime][',
+                            player.name,
+                            ']',
+                            special.stats.playerPlaytimes[player.name],
+                            '\n',
+                        })
                     )
                 end
             end
             if special.stats.communityPickInfo then
-                table.insert(log_message, table.concat{'[CommunityPickInfo]', helpers.table_to_json(special.stats.communityPickInfo), '\n'})
+                table.insert(
+                    log_message,
+                    table.concat({ '[CommunityPickInfo]', helpers.table_to_json(special.stats.communityPickInfo), '\n' })
+                )
             end
-            table.insert(log_message, table.concat{'[TeamStats]', helpers.table_to_json(storage.team_stats), '\n'})
-            table.insert(log_message, '>End of log')
+            table.insert(log_message, table.concat({ '[TeamStats]', helpers.table_to_json(storage.team_stats), '\n>End of log' }))
             log_to_db(log_message, true)
         end
     end
@@ -560,7 +592,7 @@ local function chat_with_everyone(event)
     if not enemy then
         return
     end
-    game.forces[enemy].print({'', player.name, '[auto-shout]: ', event.message}, { color = player.chat_color })
+    game.forces[enemy].print({ '', player.name, '[auto-shout]: ', event.message }, { color = player.chat_color })
 end
 
 ---@return number, number, number #success percent[0-1], yes count, no count

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -223,41 +223,37 @@ local function show_endgame_gui(player)
 
             local t = f.add({ type = 'table', column_count = 2 })
 
-            local l = t.add({ type = 'label', caption = 'Defender >> ' })
-            gui_style(l, category_style)
+            gui_style(t.add({ type = 'label', caption = 'Defender >> ' }), category_style)
+                
+            gui_style(t.add({ type = 'label', caption = {'', mvp.killscore.name, ' with a score of ', mvp.killscore.score} }), winner_style)
 
-            local l =
-                t.add({ type = 'label', caption = mvp.killscore.name .. ' with a score of ' .. mvp.killscore.score })
-            gui_style(l, winner_style)
+            gui_style(t.add({ type = 'label', caption = 'Builder >> ' }), category_style)
 
-            local l = t.add({ type = 'label', caption = 'Builder >> ' })
-            gui_style(l, category_style)
-
-            local l = t.add({
+            gui_style(t.add({
                 type = 'label',
-                caption = mvp.built_entities.name .. ' built ' .. mvp.built_entities.score .. ' things',
-            })
-            gui_style(l, winner_style)
+                caption = {'', mvp.built_entities.nam, ' built ', mvp.built_entities.score, ' things'},
+            }), winner_style)
 
-            local l = t.add({ type = 'label', caption = 'Deaths >> ' })
-            gui_style(l, category_style)
+            gui_style(t.add({ type = 'label', caption = 'Deaths >> ' }), category_style)
 
-            local l = t.add({ type = 'label', caption = mvp.deaths.name .. ' died ' .. mvp.deaths.score .. ' times' })
-            gui_style(l, winner_style)
+            gui_style(t.add({ type = 'label', caption = {'', mvp.deaths.name, ' died ', mvp.deaths.score, ' times'} }), winner_style)
 
             if not storage.results_sent_north then
-                local result = {}
-                table.insert(result, 'NORTH: \\n')
-                table.insert(result, 'MVP Defender: \\n')
-                table.insert(result, mvp.killscore.name .. ' with a score of ' .. mvp.killscore.score .. '\\n')
-                table.insert(result, '\\n')
-                table.insert(result, 'MVP Builder: \\n')
-                table.insert(result, mvp.built_entities.name .. ' built ' .. mvp.built_entities.score .. ' things\\n')
-                table.insert(result, '\\n')
-                table.insert(result, 'MVP Deaths: \\n')
-                table.insert(result, mvp.deaths.name .. ' died ' .. mvp.deaths.score .. ' times')
-                local message = table.concat(result)
-                Server.to_discord_embed(message)
+                Server.to_discord_embed(table.concat({
+                    'NORTH: \\nMVP Defender: \\n',
+                    mvp.killscore.name,
+                    ' with a score of ',
+                    mvp.killscore.score,
+                    '\\n\\nMVP Builder: \\n',
+                    mvp.built_entities.name,
+                    ' built ',
+                    mvp.built_entities.score,
+                    ' things\\n\\nMVP Deaths: \\n',
+                    mvp.deaths.name,
+                    ' died ',
+                    mvp.deaths.score,
+                    ' times'
+                }))
                 storage.results_sent_north = true
             end
         end
@@ -270,41 +266,38 @@ local function show_endgame_gui(player)
 
             local t = f.add({ type = 'table', column_count = 2 })
 
-            local l = t.add({ type = 'label', caption = 'Defender >> ' })
-            gui_style(l, category_style)
 
-            local l =
-                t.add({ type = 'label', caption = mvp.killscore.name .. ' with a score of ' .. mvp.killscore.score })
-            gui_style(l, winner_style)
+            gui_style(t.add({ type = 'label', caption = 'Defender >> ' }), category_style)
+                
+            gui_style(t.add({ type = 'label', caption = {'', mvp.killscore.name, ' with a score of ', mvp.killscore.score} }), winner_style)
 
-            local l = t.add({ type = 'label', caption = 'Builder >> ' })
-            gui_style(l, category_style)
+            gui_style(t.add({ type = 'label', caption = 'Builder >> ' }), category_style)
 
-            local l = t.add({
+            gui_style(t.add({
                 type = 'label',
-                caption = mvp.built_entities.name .. ' built ' .. mvp.built_entities.score .. ' things',
-            })
-            gui_style(l, winner_style)
+                caption = {'', mvp.built_entities.name, ' built ', mvp.built_entities.score, ' things'},
+            }), winner_style)
 
-            local l = t.add({ type = 'label', caption = 'Deaths >> ' })
-            gui_style(l, category_style)
+            gui_style(t.add({ type = 'label', caption = 'Deaths >> ' }), category_style)
 
-            local l = t.add({ type = 'label', caption = mvp.deaths.name .. ' died ' .. mvp.deaths.score .. ' times' })
-            gui_style(l, winner_style)
+            gui_style(t.add({ type = 'label', caption = {'', mvp.deaths.name, ' died ', mvp.deaths.score, ' times'} }), winner_style)
 
             if not storage.results_sent_south then
-                local result = {}
-                table.insert(result, 'SOUTH: \\n')
-                table.insert(result, 'MVP Defender: \\n')
-                table.insert(result, mvp.killscore.name .. ' with a score of ' .. mvp.killscore.score .. '\\n')
-                table.insert(result, '\\n')
-                table.insert(result, 'MVP Builder: \\n')
-                table.insert(result, mvp.built_entities.name .. ' built ' .. mvp.built_entities.score .. ' things\\n')
-                table.insert(result, '\\n')
-                table.insert(result, 'MVP Deaths: \\n')
-                table.insert(result, mvp.deaths.name .. ' died ' .. mvp.deaths.score .. ' times')
-                local message = table.concat(result)
-                Server.to_discord_embed(message)
+                Server.to_discord_embed(table.concat({
+                    'SOUTH: \\nMVP Defender: \\n',
+                    mvp.killscore.name,
+                    ' with a score of ',
+                    mvp.killscore.score,
+                    '\\n\\nMVP Builder: \\n',
+                    mvp.built_entities.name,
+                    ' built ',
+                    mvp.built_entities.score,
+                    ' things\\n\\nMVP Deaths: \\n',
+                    mvp.deaths.name,
+                    ' died ',
+                    mvp.deaths.score,
+                    ' times'
+                }))
                 storage.results_sent_south = true
             end
         end
@@ -447,9 +440,7 @@ function Public.silo_death(event)
 
         set_victory_time()
         team_stats_compare.game_over()
-        local north_players = 'NORTH PLAYERS: \\n'
-        local south_players = 'SOUTH PLAYERS: \\n'
-
+        local players = {north = {'NORTH PLAYERS: \\n'}, south = {'SOUTH PLAYERS: \\n'}}
         for _, player in pairs(game.connected_players) do
             player.play_sound({ path = 'utility/game_won', volume_modifier = 1 })
             local main_frame = Gui.get_left_element(player, 'bb_main_gui')
@@ -457,11 +448,8 @@ function Public.silo_death(event)
                 main_frame.visible = false
             end
             show_endgame_gui(player)
-            if player.force.name == 'south' then
-                south_players = south_players .. player.name .. '   '
-            elseif player.force.name == 'north' then
-                north_players = north_players .. player.name .. '   '
-            end
+
+            table.insert(players[player.force.name], player.name)   --players with force other than north or south should automatically fall into other, unused fields
         end
 
         storage.spy_fish_timeout.north = game.tick + 999999
@@ -494,9 +482,9 @@ function Public.silo_death(event)
             'South Threat: ',
             south_threat,
             '\\n\\n',
-            north_players,
+            table.concat(players.north, '    '),
             '\\n\\n',
-            south_players,
+            table.concat(players.south, '    '),
         })
 
         Server.to_discord_embed(discord_message)
@@ -518,39 +506,38 @@ function Public.silo_death(event)
                 Server.send_special_game_state('[CAPTAIN-SPECIAL]')
             end
             log_to_db('>Game has ended\n', false)
-            log_to_db('[RefereeName]' .. special.stats.InitialReferee .. '\n', true)
-            if special.stats.NorthInitialCaptain then
-                log_to_db('[CaptainNorth]' .. special.stats.NorthInitialCaptain .. '\n', true)
-            end
-            if special.stats.SouthInitialCaptain then
-                log_to_db('[CaptainSouth]' .. special.stats.SouthInitialCaptain .. '\n', true)
-            end
-            local listPicks = table.concat(special.stats.northPicks, ';')
-            log_to_db('[NorthTeam]' .. listPicks .. '\n', true)
-            listPicks = table.concat(special.stats.southPicks, ';')
-            log_to_db('[SouthTeam]' .. listPicks .. '\n', true)
-            log_to_db('[Gamelength]' .. game.ticks_played .. '\n', true)
-            log_to_db('[StartTick]' .. special.stats.tickGameStarting .. '\n', true)
-            log_to_db('[WinnerTeam]' .. storage.bb_game_won_by_team .. '\n', true)
-            log_to_db('[ExtraInfo]' .. special.stats.extrainfo .. '\n', true)
-            log_to_db('[SpecialEnabled]' .. special.stats.specialEnabled .. '\n', true)
-            log_to_db('[CommunityPickMode]' .. tostring(special.communityPickingMode) .. '\n', true)
+
+            local log_message = {
+                '[RefereeName]', special.stats.InitialReferee, '\n',
+                 (special.stats.NorthInitialCaptain and ('[CaptainNorth]' .. special.stats.NorthInitialCaptain .. '\n')) or '',
+                 (special.stats.SouthInitialCaptain and ('[CaptainSouth]' .. special.stats.SouthInitialCaptain .. '\n')) or '',
+                 '[NorthTeam]', table.concat(special.stats.northPicks, ';'), '\n',
+                 '[SouthTeam]', table.concat(special.stats.southPicks, ';'), '\n',
+                 '[Gamelength]', game.ticks_played, '\n',
+                 '[StartTick]', special.stats.tickGameStarting, '\n',
+                 '[WinnerTeam]', storage.bb_game_won_by_team, '\n',
+                 '[ExtraInfo]', special.stats.extrainfo, '\n',
+                 '[SpecialEnabled]', special.stats.specialEnabled, '\n',
+                 '[CommunityPickMode]', tostring(special.communityPickingMode), '\n'
+             }
+
+
             for _, player in pairs(game.players) do
                 if player.connected and (player.force.name == 'north' or player.force.name == 'south') then
                     Captain_special.captain_log_end_time_player(player)
                 end
                 if special.stats.playerPlaytimes[player.name] ~= nil then
-                    log_to_db(
-                        '[Playtime][' .. player.name .. ']' .. special.stats.playerPlaytimes[player.name] .. '\n',
-                        true
+                    table.insert(log_message,
+                        table.concat{'[Playtime][', player.name, ']', special.stats.playerPlaytimes[player.name], '\n'}
                     )
                 end
             end
             if special.stats.communityPickInfo then
-                log_to_db('[CommunityPickInfo]' .. helpers.table_to_json(special.stats.communityPickInfo) .. '\n', true)
+                table.insert(log_message, table.concat{'[CommunityPickInfo]', helpers.table_to_json(special.stats.communityPickInfo), '\n'})
             end
-            log_to_db('[TeamStats]' .. helpers.table_to_json(storage.team_stats) .. '\n', true)
-            log_to_db('>End of log', true)
+            table.insert(log_message, table.concat{'[TeamStats]', helpers.table_to_json(storage.team_stats), '\n'})
+            table.insert(log_message, '>End of log')
+            log_to_db(log_message, true)
         end
     end
 end
@@ -573,8 +560,7 @@ local function chat_with_everyone(event)
     if not enemy then
         return
     end
-    local message = player.name .. '[auto-shout]: ' .. event.message
-    game.forces[enemy].print(message, { color = player.chat_color })
+    game.forces[enemy].print({'', player.name, '[auto-shout]: ', event.message}, { color = player.chat_color })
 end
 
 ---@return number, number, number #success percent[0-1], yes count, no count

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -568,7 +568,10 @@ function Public.silo_death(event)
                     table.concat({ '[CommunityPickInfo]', helpers.table_to_json(special.stats.communityPickInfo), '\n' })
                 )
             end
-            table.insert(log_message, table.concat({ '[TeamStats]', helpers.table_to_json(storage.team_stats), '\n>End of log' }))
+            table.insert(
+            log_message,
+                table.concat({ '[TeamStats]', helpers.table_to_json(storage.team_stats), '\n>End of log' })
+            )
             log_to_db(log_message, true)
         end
     end

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -569,7 +569,7 @@ function Public.silo_death(event)
                 )
             end
             table.insert(
-            log_message,
+                log_message,
                 table.concat({ '[TeamStats]', helpers.table_to_json(storage.team_stats), '\n>End of log' })
             )
             log_to_db(log_message, true)


### PR DESCRIPTION
### Brief description of the changes:
Improved performance by:
- using `table.concat` or `LocalisedString` instead of string concat
- creating finalized table in one go instead of using `table.insert`
- reducing number of `write_file` calls by combining the exported data
- skipping unnecessary variable assignments

### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
