### PR TITLE
Ignore LuaPlayer::spectator in spectate()

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -1129,9 +1129,7 @@ function spectate(player, forced_join, stored_position)
             end
         end
     end
-    if player.spectator then
-        return
-    end
+
     if not forced_join then
         if storage.tournament_mode and not storage.active_special_games.captain_mode then
             player.print(


### PR DESCRIPTION
### Brief description of the changes:
Don't use LuaPlayer::spectator property to judge whether player is in fact spectator or not. This property has nothing to do with force assignment and can be manipulated from player setting in comfy panel at will. This can lead to a situation where player without a character is moved to spectator island and spectator initialization code is not executed for them.

### Tested Changes:
- [X] I've tested the changes locally or with people.
