### PR TITLE
Biter raffle take 2

### DIFF
--- a/maps/biter_battles_v2/biter_raffle.lua
+++ b/maps/biter_battles_v2/biter_raffle.lua
@@ -3,6 +3,11 @@ local math_random = math.random
 local math_floor = math.floor
 local math_max = math.max
 
+local SMALL = 1
+local MEDIUM = 2
+local BIG = 3
+local BEHEMOTH = 4
+
 local biter_names = {
     'small-biter',
     'medium-biter',
@@ -24,32 +29,32 @@ local function get_raffle_table(level)
         return raffle_table
     end
     if level < 500 then
-        raffle_table[1] = 1000 - level * 1.75
-        raffle_table[2] = math_max(-250 + level * 1.5, 0) -- only this one can be negative for level < 500
-        raffle_table[3] = 0
-        raffle_table[4] = 0
+        raffle_table[SMALL] = 1000 - level * 1.75
+        raffle_table[MEDIUM] = math_max(-250 + level * 1.5, 0) -- only this one can be negative for level < 500
+        raffle_table[BIG] = 0
+        raffle_table[BEHEMOTH] = 0
         raffle_level = level
         return raffle_table
     end
     if level < 900 then
-        raffle_table[1] = math_max(1000 - level * 1.75, 0) -- only this one can be negative for level < 900
-        raffle_table[2] = 1000 - level
-        raffle_table[3] = (level - 500) * 2
-        raffle_table[4] = 0
+        raffle_table[SMALL] = math_max(1000 - level * 1.75, 0) -- only this one can be negative for level < 900
+        raffle_table[MEDIUM] = 1000 - level
+        raffle_table[BIG] = (level - 500) * 2
+        raffle_table[BEHEMOTH] = 0
         raffle_level = level
         return raffle_table
     end
-    raffle_table[1] = 0
-    raffle_table[2] = math_max(1000 - level, 0)
-    raffle_table[3] = (level - 500) * 2
-    raffle_table[4] = (level - 900) * 8
+    raffle_table[SMALL] = 0
+    raffle_table[MEDIUM] = math_max(1000 - level, 0)
+    raffle_table[BIG] = (level - 500) * 2
+    raffle_table[BEHEMOTH] = (level - 900) * 8
     raffle_level = level
     return raffle_table
 end
 
 local function roll(evolution_factor)
     local raffle = get_raffle_table(math_floor(evolution_factor * 1000))
-    local r = math_random(0, math_floor(raffle[1] + raffle[2] + raffle[3] + raffle[4]))
+    local r = math_random(0, math_floor(raffle[SMALL] + raffle[MEDIUM] + raffle[BIG] + raffle[BEHEMOTH]))
     local current_chance = 0
     for i = 1, 4, 1 do
         current_chance = current_chance + raffle[i]

--- a/maps/biter_battles_v2/biter_raffle.lua
+++ b/maps/biter_battles_v2/biter_raffle.lua
@@ -3,49 +3,62 @@ local math_random = math.random
 local math_floor = math.floor
 local math_max = math.max
 
+local biter_names = {
+    'small-biter',
+    'medium-biter',
+    'big-biter',
+    'behemoth-biter'
+}
+local spitter_names ={
+    'small-spitter',
+    'medium-spitter',
+    'big-spitter',
+    'behemoth-spitter'
+}
+
 local function get_raffle_table(level)
     if level < 500 then
         return {
-            ['small-'] = 1000 - level * 1.75,
-            ['medium-'] = math_max(-250 + level * 1.5, 0), -- only this one can be negative for level < 500
-            ['big-'] = 0,
-            ['behemoth-'] = 0,
+            1000 - level * 1.75,
+            math_max(-250 + level * 1.5, 0), -- only this one can be negative for level < 500
+            0,
+            0,
         }
     end
     if level < 900 then
         return {
-            ['small-'] = math_max(1000 - level * 1.75, 0), -- only this one can be negative for level < 900
-            ['medium-'] = 1000 - level,
-            ['big-'] = (level - 500) * 2,
-            ['behemoth-'] = 0,
+            math_max(1000 - level * 1.75, 0), -- only this one can be negative for level < 900
+            1000 - level,
+            (level - 500) * 2,
+            0,
         }
     end
     return {
-        ['small-'] = 0,
-        ['medium-'] = math_max(1000 - level, 0),
-        ['big-'] = (level - 500) * 2,
-        ['behemoth-'] = (level - 900) * 8,
+        0,
+        math_max(1000 - level, 0),
+        (level - 500) * 2,
+        (level - 900) * 8,
     }
 end
 
 local function roll(evolution_factor)
     local raffle = get_raffle_table(math_floor(evolution_factor * 1000))
-    local r = math_random(0, math_floor(raffle['small-'] + raffle['medium-'] + raffle['big-'] + raffle['behemoth-']))
+    local r = math_random(0, math_floor(raffle[1] + raffle[2] + raffle[3] + raffle[4]))
     local current_chance = 0
-    for k, v in pairs(raffle) do
-        current_chance = current_chance + v
+    for i=1, 4, 1 do
+        current_chance = current_chance + raffle[i]
         if r <= current_chance then
-            return k
+            return i
         end
     end
 end
 
 local function get_biter_name(evolution_factor)
-    return roll(evolution_factor) .. 'biter'
+    return biter_names[roll(evolution_factor)]
 end
 
 local function get_spitter_name(evolution_factor)
-    return roll(evolution_factor) .. 'spitter'
+    return spitter_names[roll(evolution_factor)]
 end
 
 local function get_worm_raffle_table(level)

--- a/maps/biter_battles_v2/biter_raffle.lua
+++ b/maps/biter_battles_v2/biter_raffle.lua
@@ -44,8 +44,9 @@ local function get_raffle_table(level)
 end
 
 local function roll(evolution_factor)
-    if not (evolution_factor * 1000) == raffle_level then
-        get_raffle_table(math_floor(evolution_factor * 1000))
+    local level = math_floor(evolution_factor * 1000)
+    if not (level == raffle_level) then
+        get_raffle_table(level)
     end
     local raffle = raffle_table
     local r = math_random(0, math_floor(raffle[1] + raffle[2] + raffle[3] + raffle[4]))
@@ -57,7 +58,6 @@ local function roll(evolution_factor)
         end
     end
 end
-
 local function get_biter_name(evolution_factor)
     return biter_names[roll(evolution_factor)]
 end

--- a/maps/biter_battles_v2/biter_raffle.lua
+++ b/maps/biter_battles_v2/biter_raffle.lua
@@ -18,7 +18,11 @@ local spitter_names = {
 
 local raffle_table = { 1000, 0, 0, 0 }
 local raffle_level = 0
+
 local function get_raffle_table(level)
+    if level == raffle_level then
+        return raffle_table
+    end
     if level < 500 then
         raffle_table[1] = 1000 - level * 1.75
         raffle_table[2] = math_max(-250 + level * 1.5, 0) -- only this one can be negative for level < 500
@@ -44,11 +48,7 @@ local function get_raffle_table(level)
 end
 
 local function roll(evolution_factor)
-    local level = math_floor(evolution_factor * 1000)
-    if not (level == raffle_level) then
-        get_raffle_table(level)
-    end
-    local raffle = raffle_table
+    local raffle = get_raffle_table(math_floor(evolution_factor * 1000))
     local r = math_random(0, math_floor(raffle[1] + raffle[2] + raffle[3] + raffle[4]))
     local current_chance = 0
     for i = 1, 4, 1 do

--- a/maps/biter_battles_v2/biter_raffle.lua
+++ b/maps/biter_battles_v2/biter_raffle.lua
@@ -7,45 +7,50 @@ local biter_names = {
     'small-biter',
     'medium-biter',
     'big-biter',
-    'behemoth-biter'
+    'behemoth-biter',
 }
-local spitter_names ={
+local spitter_names = {
     'small-spitter',
     'medium-spitter',
     'big-spitter',
-    'behemoth-spitter'
+    'behemoth-spitter',
 }
 
+local raffle_table = { 1000, 0, 0, 0 }
+local raffle_level = 0
 local function get_raffle_table(level)
     if level < 500 then
-        return {
-            1000 - level * 1.75,
-            math_max(-250 + level * 1.5, 0), -- only this one can be negative for level < 500
-            0,
-            0,
-        }
+        raffle_table[1] = 1000 - level * 1.75
+        raffle_table[2] = math_max(-250 + level * 1.5, 0) -- only this one can be negative for level < 500
+        raffle_table[3] = 0
+        raffle_table[4] = 0
+        raffle_level = level
+        return raffle_table
     end
     if level < 900 then
-        return {
-            math_max(1000 - level * 1.75, 0), -- only this one can be negative for level < 900
-            1000 - level,
-            (level - 500) * 2,
-            0,
-        }
+        raffle_table[1] = math_max(1000 - level * 1.75, 0) -- only this one can be negative for level < 900
+        raffle_table[2] = 1000 - level
+        raffle_table[3] = (level - 500) * 2
+        raffle_table[4] = 0
+        raffle_level = level
+        return raffle_table
     end
-    return {
-        0,
-        math_max(1000 - level, 0),
-        (level - 500) * 2,
-        (level - 900) * 8,
-    }
+    raffle_table[1] = 0
+    raffle_table[2] = math_max(1000 - level, 0)
+    raffle_table[3] = (level - 500) * 2
+    raffle_table[4] = (level - 900) * 8
+    raffle_level = level
+    return raffle_table
 end
 
 local function roll(evolution_factor)
-    local raffle = get_raffle_table(math_floor(evolution_factor * 1000))
+    if not (evolution_factor * 1000) == raffle_level then
+        get_raffle_table(math_floor(evolution_factor * 1000))
+    end
+    local raffle = raffle_table
     local r = math_random(0, math_floor(raffle[1] + raffle[2] + raffle[3] + raffle[4]))
     local current_chance = 0
-    for i=1, 4, 1 do
+    for i = 1, 4, 1 do
         current_chance = current_chance + raffle[i]
         if r <= current_chance then
             return i

--- a/tests/test-biter_raffle.lua
+++ b/tests/test-biter_raffle.lua
@@ -34,14 +34,14 @@ end
 function test_get_raffle_table()
     local levels = { -500, 0, 10, 100, 500, 900, 1000, 1500 }
     local expected_raffle_tables = {
-        [-500] = { ['small-'] = 1875, ['medium-'] = 0, ['big-'] = 0, ['behemoth-'] = 0 },
-        [0] = { ['small-'] = 1000, ['medium-'] = 0, ['big-'] = 0, ['behemoth-'] = 0 },
-        [10] = { ['small-'] = 982.5, ['medium-'] = 0, ['big-'] = 0, ['behemoth-'] = 0 },
-        [100] = { ['small-'] = 825, ['medium-'] = 0, ['big-'] = 0, ['behemoth-'] = 0 },
-        [500] = { ['small-'] = 125, ['medium-'] = 500, ['big-'] = 0, ['behemoth-'] = 0 },
-        [900] = { ['small-'] = 0, ['medium-'] = 100, ['big-'] = 800, ['behemoth-'] = 0 },
-        [1000] = { ['small-'] = 0, ['medium-'] = 0, ['big-'] = 1000, ['behemoth-'] = 800 },
-        [1500] = { ['small-'] = 0, ['medium-'] = 0, ['big-'] = 2000, ['behemoth-'] = 4800 },
+        [-500] = { [1] = 1875, [2] = 0, [3] = 0, [4] = 0 },
+        [0] = { [1] = 1000, [2] = 0, [3] = 0, [4] = 0 },
+        [10] = { [1] = 982.5, [2] = 0, [3] = 0, [4] = 0 },
+        [100] = { [1] = 825, [2] = 0, [3] = 0, [4] = 0 },
+        [500] = { [1] = 125, [2] = 500, [3] = 0, [4] = 0 },
+        [900] = { [1] = 0, [2] = 100, [3] = 800, [4] = 0 },
+        [1000] = { [1] = 0, [2] = 0, [3] = 1000, [4] = 800 },
+        [1500] = { [1] = 0, [2] = 0, [3] = 2000, [4] = 4800 },
     }
     for _, level in pairs(levels) do
         local expected_raffle_table = expected_raffle_tables[level]


### PR DESCRIPTION
### Brief description of the changes:
2 more steps of optimizing `biter_raffle`:
1) Switch `raffle` table into array - 104ms => 84ms - ~20% improvement
2) Reuse one "global" `raffle` table instead recreating it on each call - 84ms => 64ms - another ~20% improvement

Unfortunately, switching to arrays broke the tests, so they had to be updated as well.
It probably can be optimized a bit more, by skipping unnecessary `return` statements, but for sake of comparability (and in order not to break any more tests), I've left it as is for now

Based on ideas form @vadcx  in #477 

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
