### PR TITLE
print_message_to_players() tweaks

### DIFF
--- a/commands/chat_commands.lua
+++ b/commands/chat_commands.lua
@@ -22,12 +22,30 @@ local function chat_with_team(message, team)
         local msg = '[To ' .. team .. '] ' .. player_name .. tag .. ' (' .. player.force.name .. '): ' .. message
 
         if not Muted.is_muted(player_name) then
-            Functions.print_message_to_players(game.forces.spectator.connected_players, player_name, msg, color, do_ping)
+            Functions.print_message_to_players(
+                game.forces.spectator.connected_players,
+                player_name,
+                msg,
+                color,
+                do_ping
+            )
             if team == 'north' or player.force.name == 'north' then
-                Functions.print_message_to_players(game.forces.north.connected_players, player_name, msg, color, do_ping)
+                Functions.print_message_to_players(
+                    game.forces.north.connected_players,
+                    player_name,
+                    msg,
+                    color,
+                    do_ping
+                )
             end
             if team == 'south' or player.force.name == 'south' then
-                Functions.print_message_to_players(game.forces.south.connected_players, player_name, msg, color, do_ping)
+                Functions.print_message_to_players(
+                    game.forces.south.connected_players,
+                    player_name,
+                    msg,
+                    color,
+                    do_ping
+                )
             end
         else
             msg = '[muted] ' .. msg

--- a/commands/chat_commands.lua
+++ b/commands/chat_commands.lua
@@ -22,12 +22,12 @@ local function chat_with_team(message, team)
         local msg = '[To ' .. team .. '] ' .. player_name .. tag .. ' (' .. player.force.name .. '): ' .. message
 
         if not Muted.is_muted(player_name) then
-            Functions.print_message_to_players(game.forces.spectator.players, player_name, msg, color, do_ping)
+            Functions.print_message_to_players(game.forces.spectator.connected_players, player_name, msg, color, do_ping)
             if team == 'north' or player.force.name == 'north' then
-                Functions.print_message_to_players(game.forces.north.players, player_name, msg, color, do_ping)
+                Functions.print_message_to_players(game.forces.north.connected_players, player_name, msg, color, do_ping)
             end
             if team == 'south' or player.force.name == 'south' then
-                Functions.print_message_to_players(game.forces.south.players, player_name, msg, color, do_ping)
+                Functions.print_message_to_players(game.forces.south.connected_players, player_name, msg, color, do_ping)
             end
         else
             msg = '[muted] ' .. msg

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -475,20 +475,18 @@ end
 function Functions.print_message_to_players(forcePlayerList, playerNameSendingMessage, msgToPrint, colorChosen, ping_fn)
     local possible_pings = Functions.extract_possible_pings(msgToPrint)
     for _, playerOfForce in pairs(forcePlayerList) do
-        if playerOfForce.connected then
-            local player_name = playerOfForce.name
-            if
-                storage.ignore_lists[player_name] == nil
-                or not storage.ignore_lists[player_name][playerNameSendingMessage]
-            then
-                if ping_fn and possible_pings[player_name] then
-                    ping_fn(playerNameSendingMessage, playerOfForce, msgToPrint)
-                end
-                if colorChosen == nil then
-                    playerOfForce.print(msgToPrint)
-                else
-                    playerOfForce.print(msgToPrint, { color = colorChosen })
-                end
+        local player_name = playerOfForce.name
+        if
+            storage.ignore_lists[player_name] == nil
+            or not storage.ignore_lists[player_name][playerNameSendingMessage]
+        then
+            if ping_fn and possible_pings[player_name] then
+                ping_fn(playerNameSendingMessage, playerOfForce, msgToPrint)
+            end
+            if colorChosen == nil then
+                playerOfForce.print(msgToPrint)
+            else
+                playerOfForce.print(msgToPrint, { color = colorChosen })
             end
         end
     end

--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -483,11 +483,7 @@ function Functions.print_message_to_players(forcePlayerList, playerNameSendingMe
             if ping_fn and possible_pings[player_name] then
                 ping_fn(playerNameSendingMessage, playerOfForce, msgToPrint)
             end
-            if colorChosen == nil then
-                playerOfForce.print(msgToPrint)
-            else
-                playerOfForce.print(msgToPrint, { color = colorChosen })
-            end
+            playerOfForce.print(msgToPrint, { color = colorChosen })
         end
     end
 end

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -279,7 +279,7 @@ local function on_console_chat(event)
             return
         end
 
-        Functions.print_message_to_players(game.forces.spectator.players, player_name, msg, color, do_ping)
+        Functions.print_message_to_players(game.forces.spectator.connected_players, player_name, msg, color, do_ping)
     end
 
     if storage.tournament_mode then
@@ -298,8 +298,8 @@ local function on_console_chat(event)
         Muted.print_muted_message(player)
     end
     if not muted and player_force_name == 'spectator' then
-        Functions.print_message_to_players(game.forces.north.players, player_name, msg, nil, do_ping)
-        Functions.print_message_to_players(game.forces.south.players, player_name, msg, nil, do_ping)
+        Functions.print_message_to_players(game.forces.north.connected_players, player_name, msg, nil, do_ping)
+        Functions.print_message_to_players(game.forces.south.connected_players, player_name, msg, nil, do_ping)
     end
 
     discord_msg = discord_msg .. player_name .. ' (' .. player_force_name .. '): ' .. event.message


### PR DESCRIPTION
### Brief description of the changes:
1) Tightened the loop by iterating only on connected players
2) Removed `colorChosen == nil` check, as `print(msg, {color = nil})` works just fine
### Tested Changes:
- [ ] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
