### PR TITLE
fix: cursor stack no longer lost when disconnecting. 

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -234,6 +234,7 @@ end
 
 ---@param player LuaPlayer
 function Public.clear_copy_history(player)
+    player.clear_cursor() -- move items from cursor stack to inventory otherwise they would be lost
     if player and player.valid and player.cursor_stack then
         for i = 1, 21 do
             -- Imports blueprint of single burner miner into the cursor stack

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -233,9 +233,9 @@ local function get_captain_caption(force)
 end
 
 ---@param player LuaPlayer
-function Public.clear_copy_history(player)
-    player.clear_cursor() -- move items from cursor stack to inventory otherwise they would be lost
+function Public.clear_copy_history(player)    
     if player and player.valid and player.cursor_stack then
+        player.clear_cursor() -- move items from cursor stack to inventory otherwise they would be lost
         for i = 1, 21 do
             -- Imports blueprint of single burner miner into the cursor stack
             stack = player.cursor_stack.import_stack(

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -233,7 +233,7 @@ local function get_captain_caption(force)
 end
 
 ---@param player LuaPlayer
-function Public.clear_copy_history(player)    
+function Public.clear_copy_history(player)
     if player and player.valid and player.cursor_stack then
         player.clear_cursor() -- move items from cursor stack to inventory otherwise they would be lost
         for i = 1, 21 do


### PR DESCRIPTION
### Brief description of the changes:
added player.clear_cursor() in Gui.clear_copy_history(player) function, before cursor stack is overwritten by new one.
is it ok?

### Tested Changes:
- [x] I've tested the changes locally.

