### PR TITLE
Add Draft Timer to CPT picking phase

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -22,6 +22,8 @@ suspend_stats=[color=red]__1__[/color] Vs. [color=green]__2__[/color] - ( [color
 team_manager_top_button=[font=default-bold]Team Manager[/font] - Manage players & forces
 team_statistics=[font=default-bold]Team statistics[/font] - Toggle the team statistics window
 tournament_top_button=[font=default-bold]Tournament Menu[/font] - Toggle the tournament window
+blitz_clock_caption=__1__ [color=187,187,187]__plural_for_parameter__1__{1=min|rest=mins}__[/color] __2__ [color=187,187,187]__plural_for_parameter__2__{1=sec|rest=secs}__[/color]
+blitz_clock_tooltip=[color=yellow][font=default-bold]Starting time:[/font][/color] [font=count-font]__1__[/font]\n[color=yellow][font=default-bold]Time increment:[/font][/color] [font=count-font]__2__[/font]
 
 [info]
 burner_balance=You have received __1__ x [item=burner-mining-drill], check your inventory-
@@ -36,6 +38,7 @@ cmd_only_after_prepa_phase=This command is only allowed when prepa phase of even
 comms_reminder=Remember to join your team channel voice on discord of free biterbattles (discord link can be found on biterbattles.org website) if possible (even if no mic, it is fine, to just listen, it is not required though but better if you do !)
 difficulty_vote_duration=Difficulty vote ongoing for __1__s longer. Consider waiting until it is over before marking yourself as ready.
 disable_picking_announcement=Players are now free to join whatever team they want (tournament mode disabled), choice made by [color=blue]__1__[/color]
+draft_timer_enable_tooltip=[color=yellow][font=default-bold]LEFT-CLICK[/font][/color] start timer on North\n[color=yellow][font=default-bold]RIGHT-CLICK[/font][/color] start timer on South
 eject_player=[color=blue]__1__[/color] has decided that [color=orange]__2__[/color] must not be in the team anymore.
 info_caption=[font=default-bold]Captain event info[/font]
 info_content=[font=default-listbox][font=default-bold]Welcome to Biter Battles - Captains Game[/font]\n\n In the Captains Game format participants engage in highly competitive matches led by volunteer captains.\n This mode emphasizes teamwork and strategy, it is essential for all players to understand their role within the team dynamics.\n\n [font=default-bold][color=pink]STRUCTURED TEAM SELECTION[/color][/font]: Captains will choose players in a structured manner to form balanced teams, which enhances the competitiveness of each match.\n [font=default-bold][color=pink]TEAM COLLABORATION[/color][/font]: This mode does not accommodate solo play. Communication with your teammates is imperative. Utilize both [color=acid]in-game chat[/color] and [color=acid]Discord voice chat[/color] to effectively coordinate your efforts.\n [font=default-bold][color=pink]AUTHORITY OF THE CAPTAIN[/color][/font]: The captain is the highest authority on strategy and decision-making for the team. It is crucial to follow their instructions to ensure that the team functions smoothly. Non-compliance may result in removal from the team.\n\n Prepare for a focused and strategic environment as you work collaboratively towards success in the Biter Battles Captains Game.[/font]

--- a/maps/biter_battles_v2/draft_timer.lua
+++ b/maps/biter_battles_v2/draft_timer.lua
@@ -1,0 +1,255 @@
+local Event = require('utils.event')
+local Global = require('utils.global')
+local Gui = require('utils.gui')
+local Token = require('utils.token')
+local _utils = require('utils.utils')
+
+local Public = {}
+
+-- == SETUP ===================================================================
+
+local SECOND = 60
+local MINUTE = 60 * SECOND
+local HOUR = 60 * MINUTE
+local DEFAULT_STARTING_TIME = 4 * MINUTE
+local DEFAULT_INCREMENT = 10 * SECOND
+local DEFAULT_FIRST = 'north'
+local max = math.max
+local floor = math.floor
+local f = string.format
+local gui_style = _utils.gui_style
+local colors = {
+    north = { r = 0.55, g = 0.55, b = 0.99 },
+    south = { r = 0.99, g = 0.33, b = 0.33 },
+}
+
+local frame_name = Gui.uid_name()
+
+local this = {
+    enabled = false,
+    paused = false,
+    starting_time = DEFAULT_STARTING_TIME,
+    increment = DEFAULT_INCREMENT,
+    turn = DEFAULT_FIRST,
+    north = {
+        start = 0,
+        remaining = 0,
+    },
+    south = {
+        start = 0,
+        remaining = 0,
+    },
+}
+Global.register(this, function(tbl)
+    this = tbl
+end)
+
+-- == CLOCK ===================================================================
+
+---@param params
+---@field starting_time? number, in ticks
+---@field increment? number, in ticks
+---@field first? string 'north'|'south', first team to start picking
+Public.enable = function(params)
+    params = params or {}
+
+    this.starting_time = params.starting_time or DEFAULT_STARTING_TIME
+    this.increment = params.increment or DEFAULT_INCREMENT
+    this.turn = params.first or DEFAULT_FIRST
+    this.north.start = game.tick
+    this.south.start = game.tick
+    this.north.remaining = this.starting_time
+    this.south.remaining = this.starting_time
+
+    assert(this.increment >= 0, 'Time increments can only be a positive time interval')
+    assert(this.turn == 'north' or this.turn == 'south', 'Picking turns can only belong to either north or south side.')
+
+    if not this.enabled then
+        this.enabled = true
+        Event.add_removable_nth_tick(SECOND, Public.on_nth_tick_token)
+    end
+
+    Public.draw_all()
+end
+
+Public.disable = function()
+    this.north.start = 0
+    this.south.start = 0
+    this.north.remaining = 0
+    this.south.remaining = 0
+
+    if this.enabled then
+        this.enabled = false
+        Event.remove_removable_nth_tick(SECOND, Public.on_nth_tick_token)
+    end
+
+    Public.destroy_all()
+end
+
+Public.pause = function()
+    this.paused = true
+end
+
+Public.unpause = function()
+    this.paused = false
+end
+
+---@param side? string 'north'|'south', if not ptovided, it will automatically switch to next force
+Public.switch_turn = function(side)
+    this.turn = side or (this.side == 'north' and 'south' or 'north')
+
+    assert(this.turn == 'north' or this.turn == 'south', 'Picking turns can only belong to either north or south side.')
+
+    this[this.turn].remaining = this[this.turn].remaining + this.increment
+end
+
+local on_nth_tick = function()
+    if not this.enabled or this.paused then
+        return
+    end
+
+    this[this.turn].remaining = max(0, this[this.turn].remaining - SECOND)
+    Public.update_all()
+end
+
+Public.on_nth_tick_token = Token.register(on_nth_tick)
+
+-- == GUI =====================================================================
+
+---@param player LuaPlayer
+Public.draw = function(player)
+    if not (player and player.valid) then
+        return
+    end
+
+    local frame = player.gui.screen[frame_name]
+    if frame and frame.valid then
+        return frame
+    end
+
+    local data = {}
+    frame = player.gui.screen.add({
+        type = 'frame',
+        name = frame_name,
+        style = 'slot_window_frame',
+        direction = 'vertical',
+    })
+    gui_style(frame, { padding = 2 })
+    frame.location = { x = 244, y = 314 }
+
+    local flow = frame.add({ type = 'flow', name = 'flow', style = 'vertical_flow', direction = 'vertical' })
+    local inner_frame = flow.add({
+        type = 'frame',
+        name = 'inner_frame',
+        style = 'inside_shallow_frame_packed',
+        direction = 'vertical',
+    })
+
+    local subheader = inner_frame.add({ type = 'frame', name = 'subheader', style = 'subheader_frame' })
+    gui_style(subheader, { horizontally_squashable = true, horizontally_stretchable = true, maximal_height = 40 })
+
+    local subheader_flow = subheader.add({ type = 'flow', direction = 'horizontal' })
+    gui_style(subheader_flow, { horizontal_align = 'center', horizontally_stretchable = true })
+
+    local title = subheader_flow.add({ type = 'label', caption = 'Draft timer' })
+    gui_style(title, { font = 'default-semibold', font_color = { 225, 225, 225 }, left_margin = 4 })
+    data.title = title
+
+    local canvas = inner_frame.add({ type = 'frame', direction = 'horizontal', style = 'mod_gui_inside_deep_frame' })
+
+    local dragger = canvas.add({ type = 'empty-widget', style = 'draggable_space', ignored_by_interaction = false })
+    dragger.drag_target = frame
+    gui_style(dragger, { vertically_stretchable = true, width = 8, margin = 0 })
+
+    local function render_side(parent, name)
+        local side = canvas.add({ type = 'flow', direction = 'vertical' })
+        gui_style(side, { horizontal_align = 'center', padding = 6 })
+
+        local label =
+            side.add({ type = 'label', caption = (name == 'north') and 'North' or 'South', style = 'caption_label' })
+        gui_style(label, { font_color = colors[name] })
+
+        local timer = side.add({ type = 'label', caption = '---' })
+        gui_style(timer, { font = 'default-semibold' })
+
+        return timer
+    end
+
+    data.north = render_side(canvas, 'north')
+    canvas.add({ type = 'line', direction = 'vertical', style = 'dark_line' })
+    data.south = render_side(canvas, 'south')
+
+    Gui.set_data(frame, data)
+    return frame
+end
+
+Public.draw_all = function()
+    for _, player in pairs(game.connected_players) do
+        Public.draw(player)
+    end
+end
+
+---@param player LuaPlayer
+Public.destroy = function(player)
+    if not (player and player.valid) then
+        return
+    end
+
+    local frame = player.gui.screen[frame_name]
+    if frame then
+        Gui.destroy(frame)
+    end
+end
+
+Public.destroy_all = function()
+    for _, player in pairs(game.players) do
+        Public.destroy(player)
+    end
+end
+
+Public.update_all = function()
+    local tooltip = { 'gui.blitz_clock_tooltip', Public.format(this.starting_time), Public.format(this.increment) }
+    local north_time = Public.format(Public.get_time('north'))
+    local south_time = Public.format(Public.get_time('south'))
+
+    for _, player in pairs(game.players) do
+        local frame = Public.draw(player)
+        local data = Gui.get_data(frame)
+        data.north.caption = north_time
+        data.south.caption = south_time
+        data.title.tooltip = tooltip
+    end
+end
+
+-- == UTILS ===================================================================
+
+Public.get = function(key)
+    if this[key] then
+        return this[key]
+    end
+end
+
+---@param side? string 'north'|'south', if not provided, the current turn force will be used instead
+Public.get_time = function(side)
+    side = side or this.turn
+    return this[side].remaining
+end
+
+---@param ticks number
+Public.format = function(ticks)
+    local seconds = floor(ticks / SECOND)
+    local mins = floor(seconds / SECOND)
+    local secs = floor(seconds - mins * SECOND)
+
+    return { 'gui.blitz_clock_caption', f('%02d', mins), f('%02d', secs) }
+end
+
+---@param ticks number
+Public.change_time = function(ticks)
+    this.north.remaining = max(0, this.north.remaining + ticks)
+    this.south.remaining = max(0, this.south.remaining + ticks)
+end
+
+-- ============================================================================
+
+return Public


### PR DESCRIPTION
Add a draft timer for Captain picking phase, similar to chess blitz's clock, with a generous starting time at the beginning and smaller increments throughout the game.

# Changes

1. Timer can be enabled/disabled, paused/unpaused at runtime
3. Teams start with 4 mins time + a bonus 10sec for each turn they take picking (~10mins total for picking phase)
3. Timer is visible by **all** players. It cannt be interacted with, other than moving the window around 
3. If a team/CPT does not pick and timer ends, the turn is passed to other team. They will resume their turn with the due increment on their following turn.
4. Referee has additional gui buttons to change the Draft Timer settings

![Screenshot from 2025-03-16 15-13-03](https://github.com/user-attachments/assets/81c9a418-49a7-42a1-ba3b-d07bb9821605)

Ref can:
- enable/disable the draf timer completely
- pause/unpause the timer (happens simultaneously for both teams)
- add/remove 0:30/5:00 (applies to both teams at once)

### Future improvements
- add in-gui options to change start timer & increment bonus from ref gui (currently done by command line)
- change logic so if a team finishes its time and no player was picked, it automatically picks 1 (just 1) player *at random* from the picking list instead of losing the 2 picks of the turn
- further implement time management mechanics for CPT picking7prearing phases in a more cohesive way

### Tested Changes:
- [x] I've tested the changes locally
