### PR TITLE
Optimized destination position calculation in invert_entity()

### DIFF
--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -87,15 +87,13 @@ function Public.invert_entity(event)
     end
 
     -- Invert entity position to south in relation to source entity.
-    local src_pos = source.position
     local dest_pos = source.position
-    dest_pos.y = -dest_pos.y
-
     -- Check if there are no overlaps.
-    if src_pos.x == dest_pos.x and src_pos.y == dest_pos.y then
+    if dest_pos.y == 0 then
         destination.destroy()
         return
     end
+    dest_pos.y = -dest_pos.y
 
     -- It's safe to use teleport() even if final position is on top
     -- of lake.

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -66,8 +66,8 @@ function Public.clone(event)
     surface.clone_area(request)
 end
 
+---@param event EventData.on_entity_cloned
 function Public.invert_entity(event)
-    local source = event.source
     local destination = event.destination
 
     -- Don't allow soulless characters to be cloned on spawn platform.
@@ -87,7 +87,7 @@ function Public.invert_entity(event)
     end
 
     -- Invert entity position to south in relation to source entity.
-    local dest_pos = source.position
+    local dest_pos = event.source.position
     -- Check if there are no overlaps.
     if dest_pos.y == 0 then
         destination.destroy()


### PR DESCRIPTION
### Brief description of the changes:

1. Skipped `src_pos.x == dest_pos.x` check, as it is always true
2. Replaced `src_pos.y == dest_pos.y` with `dest_pos.y == 0`, as it can be true only in this case
3. Removed unused `src_pos`
4. Reordered so that `return` check is made as soon as possible
5. Replaced `local source = event.source` declaration used only once in `local dest_pos = source.position`, with direct `local dest_pos = event.source.position`

### Benchmark
3600 tick profile right after map restart:
```
before:
117502x "invert_entity". Total Duration: 19746.395700ms avg: 0.16805157ms
	1527712x "__index". Total Duration: 7555.191300ms
	117502x "teleport". Total Duration: 912.231100ms
	582x "__newindex". Total Duration: 9.324700ms
	106x "table_insert". Total Duration: 0.573600ms
after:
129379x "invert_entity". Total Duration: 20141.495500ms avg: 0.15567824ms
	1552671x "__index". Total Duration: 7659.959300ms
	129379x "teleport". Total Duration: 812.593500ms
	428x "__newindex". Total Duration: 6.881100ms
	70x "table_insert". Total Duration: 0.358600ms
```
Around 7% improvement

### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
