### PR TITLE
Add new Captain Pick UI

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -2659,7 +2659,7 @@ function Public.update_captain_player_gui(player, frame)
         if storage.chosen_team[player.name] then
             insert(
                 status_strings,
-                'On team '
+                'You are on '
                     .. storage.chosen_team[player.name]
                     .. ': '
                     .. Functions.team_name_with_color(storage.chosen_team[player.name])

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1186,8 +1186,11 @@ local function start_picking_phase()
             next_pick_force = math_random() < northThreshold and 'north' or 'south'
             log('Next force to pick: ' .. next_pick_force)
         end
-        CaptainPick.enable({ turn = next_pick_force })
-        --poll_alternate_picking(Public.get_player_to_make_pick(next_pick_force), next_pick_force)
+        if Functions.get_ticks_since_game_start() > 0 then
+            poll_alternate_picking(Public.get_player_to_make_pick(next_pick_force), next_pick_force)
+        else
+            CaptainPick.enable({ turn = next_pick_force })
+        end
     end
     Public.update_all_captain_player_guis()
 end

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -1,4 +1,5 @@
 local CaptainCommunityPick = require('comfy_panel.special_games.captain_community_pick')
+local CaptainPick = require('comfy_panel.special_games.captain_pick')
 local CaptainTaskGroup = require('comfy_panel.special_games.captain_task_group')
 local CaptainUtils = require('comfy_panel.special_games.captain_utils')
 local ClosableFrame = require('utils.ui.closable_frame')
@@ -9,12 +10,12 @@ local Event = require('utils.event')
 local Functions = require('maps.biter_battles_v2.functions')
 local Gui = require('utils.gui')
 local PlayerList = require('comfy_panel.player_list')
-local PlayerUtils = require('utils.player')
-local Session = require('utils.datastore.session_data')
+local table = require('utils.table')
 local Tables = require('maps.biter_battles_v2.tables')
 local Task = require('utils.task')
 local TeamManager = require('maps.biter_battles_v2.team_manager')
 local Token = require('utils.token')
+local starts_with = require('utils.string').starts_with
 local safe_wrap_cmd = require('utils.utils').safe_wrap_cmd
 
 local gui_style = require('utils.utils').gui_style
@@ -22,7 +23,8 @@ local frame_style = require('utils.utils').left_frame_style
 local ternary = require('utils.utils').ternary
 local pretty_print_player_list = CaptainUtils.pretty_print_player_list
 local cpt_get_player = CaptainUtils.cpt_get_player
-local table_contains = CaptainUtils.table_contains
+local table_contains = table.contains
+local table_remove_element = table.remove_element
 local insert, remove, concat, sort = table.insert, table.remove, table.concat, table.sort
 local math_floor = math.floor
 local math_random = math.random
@@ -95,61 +97,6 @@ local tournament_pages = {
 }
 
 -- == UTILS ===================================================================
----@param player LuaPlayer
----@return boolean
-local function is_test_player(player)
-    return not player.gui
-end
-
----@param player_name string
----@return boolean
-local function is_test_player_name(player_name)
-    local special = storage.special_games_variables.captain_mode
-    return special.test_players and special.test_players[player_name]
-end
-
-local function table_remove_element(tab, str)
-    for i, entry in ipairs(tab) do
-        if entry == str then
-            remove(tab, i)
-            break -- Stop the loop once the string is found and removed
-        end
-    end
-end
-
-local function add_to_trust(playerName)
-    if storage.special_games_variables.captain_mode.autoTrust then
-        local trusted = Session.get_trusted_table()
-        if not trusted[playerName] then
-            trusted[playerName] = true
-        end
-    end
-end
-
-local function switch_team_of_player(playerName, playerForceName)
-    if storage.chosen_team[playerName] then
-        if storage.chosen_team[playerName] ~= playerForceName then
-            game.print(
-                { 'captain.change_player_team_err', playerName, storage.chosen_team[playerName], playerForceName },
-                { color = Color.red }
-            )
-        end
-        return
-    end
-    local special = storage.special_games_variables.captain_mode
-    local player = cpt_get_player(playerName)
-    if not player or is_test_player(player) or not player.connected then
-        storage.chosen_team[playerName] = playerForceName
-    else
-        TeamManager.switch_force(playerName, playerForceName)
-    end
-    local forcePickName = playerForceName .. 'Picks'
-    insert(special.stats[forcePickName], playerName)
-    if not special.playerPickedAtTicks[playerName] then
-        special.playerPickedAtTicks[playerName] = Functions.get_ticks_since_game_start()
-    end
-    add_to_trust(playerName)
-end
 
 local function clear_captain_rendering()
     if not storage.special_games_variables or not storage.special_games_variables.rendering then
@@ -185,6 +132,7 @@ local function clear_gui_captain_mode()
         end
         storage.captain_ui[player.name] = {}
     end
+    CaptainPick.disable()
 end
 
 local function clear_character_corpses()
@@ -214,10 +162,6 @@ local function force_end_captain_event()
     end
     storage.difficulty_votes_timeout = game.ticks_played + 36000
     clear_character_corpses()
-end
-
-local function starts_with(text, prefix)
-    return text:find(prefix, 1, true) == 1
 end
 
 ---@param player LuaPlayer
@@ -511,29 +455,12 @@ local function auto_pick_all_of_group(cptPlayer, playerName)
             local player = cpt_get_player(playerName)
             if player then
                 game.print(playerName .. ' was automatically picked with group system', { color = Color.cyan })
-                switch_team_of_player(playerName, playerChecked.force.name)
+                CaptainUtils.switch_team_of_player(playerName, playerChecked.force.name)
                 player.print({ 'captain.comms_reminder' }, { color = Color.cyan })
                 table_remove_element(special.listPlayers, playerName)
             end
         end
     end
-end
-
----@param playerName string
----@return boolean
-local function is_player_in_group_system(playerName)
-    -- function used to balance team when a team is picked
-    if storage.special_games_variables.captain_mode.captainGroupAllowed then
-        local playerChecked = cpt_get_player(playerName)
-        if
-            playerChecked
-            and playerChecked.tag ~= ''
-            and starts_with(playerChecked.tag, ComfyPanelGroup.COMFY_PANEL_CAPTAINS_GROUP_PLAYER_TAG_PREFIX)
-        then
-            return true
-        end
-    end
-    return false
 end
 
 ---@param playerNames string[]
@@ -542,7 +469,7 @@ local function generate_groups(playerNames)
     local special = storage.special_games_variables.captain_mode
     local groups = {}
     for _, playerName in pairs(playerNames) do
-        if is_player_in_group_system(playerName) then
+        if CaptainUtils.is_player_in_group_system(playerName) then
             local player = cpt_get_player(playerName)
             if player then
                 local groupName = player.tag
@@ -569,11 +496,6 @@ local function generate_groups(playerNames)
     return groups
 end
 
-local function check_if_enough_playtime_to_play(player)
-    return (storage.total_time_online_players[player.name] or 0)
-        >= storage.special_games_variables.captain_mode.minTotalPlaytimeToPlay
-end
-
 local function allow_vote()
     local tick = game.ticks_played
     storage.difficulty_votes_timeout = tick + 999999
@@ -582,31 +504,6 @@ local function allow_vote()
         '[font=default-large-bold]Difficulty voting is opened until the referee starts the picking phase ![/font]',
         { color = Color.cyan }
     )
-end
-
-local function is_it_automatic_captain()
-    local special = storage.special_games_variables.captain_mode
-    return special.refereeName == '$@BotReferee'
-end
-
----@param player string
----@return boolean
-local function is_player_a_captain(player)
-    local special = storage.special_games_variables.captain_mode
-    return special.captainList[1] == player or special.captainList[2] == player
-end
-
----@param player string
----@return boolean
-local function player_has_captain_authority(player)
-    local special = storage.special_games_variables.captain_mode
-    local force_name = storage.chosen_team[player]
-    if force_name ~= 'north' and force_name ~= 'south' then
-        return false
-    end
-    return special.captainList[1] == player
-        or special.captainList[2] == player
-        or special.viceCaptains[force_name][player]
 end
 
 local function generate_captain_mode(refereeName, autoTrust, captainKick, specialEnabled)
@@ -679,7 +576,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
         special.groupsOrganization.south[i] = { name = 'Group ' .. i, players = {}, player_order = {} }
     end
     local referee = nil
-    if not is_it_automatic_captain() then
+    if not CaptainUtils.is_it_automatic_captain() then
         referee = cpt_get_player(special.refereeName)
         if referee == nil then
             game.print(
@@ -690,7 +587,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
             storage.active_special_games.captain_mode = false
             return
         end
-        if not check_if_enough_playtime_to_play(referee) then
+        if not CaptainUtils.check_if_enough_playtime_to_play(referee) then
             game.print(
                 'Referee does not seem to have enough playtime (which is odd), so disabling min playtime requirement',
                 { color = Color.red }
@@ -718,7 +615,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
     end
     storage.chosen_team = {}
     clear_character_corpses()
-    if is_it_automatic_captain() then
+    if CaptainUtils.is_it_automatic_captain() then
         game.print('Captain mode started !! Have fun ! No referee')
     elseif referee then
         game.print('Captain mode started !! Have fun ! Referee will be ' .. referee.name)
@@ -731,7 +628,7 @@ local function generate_captain_mode(refereeName, autoTrust, captainKick, specia
     end
     game.print('Picking system : 1-2-2-2-2...', { color = Color.cyan })
 
-    if referee and not is_it_automatic_captain() then
+    if referee and not CaptainUtils.is_it_automatic_captain() then
         referee.print(
             'Command only allowed for referee to change a captain : /replaceCaptainNorth <playerName> or /replaceCaptainSouth <playerName>',
             { color = Color.cyan }
@@ -841,7 +738,7 @@ end
 
 ---@param player LuaPlayer
 function Public.draw_willingness_to_captain_gui(player)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
     local special = storage.special_games_variables.captain_mode
@@ -904,7 +801,7 @@ function Public.end_captain_willingness_vote(force_name)
             end
             insert(list, player)
         end
-        if not is_test_player(player) then
+        if not CaptainUtils.is_test_player(player) then
             local ui = player.gui.screen.captain_willingness_vote_frame
             if ui then
                 ui.destroy()
@@ -1167,6 +1064,9 @@ end)
 
 function Public.end_of_picking_phase()
     local special = storage.special_games_variables.captain_mode
+    if not special then
+        return
+    end
     special.pickingPhase = false
     if not special.initialPickingPhaseFinished then
         special.initialPickingPhaseFinished = true
@@ -1177,6 +1077,7 @@ function Public.end_of_picking_phase()
             )
         end
     end
+    CaptainPick.disable()
     special.nextAutoPickTicks = Functions.get_ticks_since_game_start() + special.autoPickIntervalTicks
     if special.prepaPhase then
         game.print(
@@ -1189,16 +1090,18 @@ function Public.end_of_picking_phase()
                 'As a captain, you can handle your team by accessing "Team Captain" in your Tournament menu',
                 { color = Color.yellow }
             )
-            if not is_test_player(captain) then
+            if not CaptainUtils.is_test_player(captain) then
                 TeamManager.custom_team_name_gui(captain, captain.force.name)
             end
         end
-        if is_it_automatic_captain() then
+        if CaptainUtils.is_it_automatic_captain() then
             Task.set_timeout_in_ticks(60, decrement_timer_captain_prepa_token)
         end
     end
     Public.update_all_captain_player_guis()
 end
+
+CaptainPick.end_of_picking_phase = Public.end_of_picking_phase
 
 local function start_picking_phase()
     local special = storage.special_games_variables.captain_mode
@@ -1241,7 +1144,7 @@ local function start_picking_phase()
         for i, team in ipairs(picks) do
             local force_name = i == 1 and 'north' or 'south'
             for _, player in ipairs(team) do
-                switch_team_of_player(player, force_name)
+                CaptainUtils.switch_team_of_player(player, force_name)
                 table_remove_element(special.listPlayers, player)
             end
             if special.communityPickingModeCaptainVolunteers then
@@ -1283,7 +1186,8 @@ local function start_picking_phase()
             next_pick_force = math_random() < northThreshold and 'north' or 'south'
             log('Next force to pick: ' .. next_pick_force)
         end
-        poll_alternate_picking(Public.get_player_to_make_pick(next_pick_force), next_pick_force)
+        CaptainPick.enable({ turn = next_pick_force })
+        --poll_alternate_picking(Public.get_player_to_make_pick(next_pick_force), next_pick_force)
     end
     Public.update_all_captain_player_guis()
 end
@@ -1299,12 +1203,13 @@ local function prepare_for_captain()
 
     for index, force_name in pairs({ 'north', 'south' }) do
         local captainName = special.captainList[index]
-        add_to_trust(captainName)
-        switch_team_of_player(captainName, force_name)
+        CaptainUtils.add_to_trust(captainName)
+        CaptainUtils.switch_team_of_player(captainName, force_name)
+        CaptainPick.set_captain(captainName, force_name)
         table_remove_element(special.listPlayers, captainName)
     end
 
-    if is_it_automatic_captain() then
+    if CaptainUtils.is_it_automatic_captain() then
         game.print(
             '[font=default-large-bold]Beware that captains are not allowed to leave before the first picking phase is over and the preparation is over, they must stay online at least until the game starts, otherwise the event will be automatically canceled[/font]',
             { color = Color.cyan }
@@ -1349,14 +1254,14 @@ function Public.change_captain(player, force, decider)
     end
     game.print(
         string_format(
-            '[font=default-large-bold]%s[color=green]%s[/color][/font] will be the new captain of %s',
+            '%s[color=green]%s[/color] will be the new captain of %s',
             decider_text,
             player and player.name or '(nobody)',
             Functions.team_name_with_color(force)
         )
     )
     local oldCaptain = cpt_get_player(special.captainList[captain_index])
-    if oldCaptain and not is_test_player(oldCaptain) and oldCaptain.gui.screen.captain_manager_gui then
+    if oldCaptain and not CaptainUtils.is_test_player(oldCaptain) and oldCaptain.gui.screen.captain_manager_gui then
         oldCaptain.gui.screen.captain_manager_gui.destroy()
     end
     if player then
@@ -1459,7 +1364,7 @@ local cpt_ui_visibility = {
     captain_manager_gui = function(player)
         -- only to captains
         local special = storage.special_games_variables.captain_mode
-        return storage.chosen_team[player.name] and player_has_captain_authority(player.name)
+        return storage.chosen_team[player.name] and CaptainUtils.player_has_captain_authority(player.name)
     end,
     captain_organization_gui = function(player)
         -- only to picked players
@@ -1484,7 +1389,7 @@ local function on_gui_switch_state_changed(event)
         special.captainGroupAllowed = false
         if special.test_mode then
             for _, player in pairs(special.listPlayers) do
-                if is_test_player_name(player) and math_random() < 0.5 then
+                if CaptainUtils.is_test_player_name(player) and math_random() < 0.5 then
                     special.communityPicksConfirmed[player] = true
                     local pick_order = table.deepcopy(special.listPlayers)
                     -- randomize "pick_order"
@@ -1573,8 +1478,9 @@ local function on_gui_click(event)
 
     if name == 'captain_player_want_to_play' then
         if not special.pickingPhase then
-            if check_if_enough_playtime_to_play(player) then
+            if CaptainUtils.check_if_enough_playtime_to_play(player) then
                 insert_player_by_playtime(player.name)
+                CaptainPick.add_player(player.index)
                 if not special.initialPickingPhaseStarted then
                     -- make players that don't have this player in their pick order already re-confirm their pick order
                     for player_name, _ in pairs(special.communityPicksConfirmed) do
@@ -1598,6 +1504,7 @@ local function on_gui_click(event)
             table_remove_element(special.listPlayers, player.name)
             table_remove_element(special.captainList, player.name)
             special.communityPicksConfirmed[player.name] = nil
+            CaptainPick.remove_player(player.index)
             Public.update_all_captain_player_guis()
         end
     elseif name == 'captain_player_want_to_be_captain' then
@@ -1626,6 +1533,7 @@ local function on_gui_click(event)
             button.caption = ''
 
             frame.info_flow.display.visible = false
+            CaptainPick.set_player_note(player.index, '')
         end
     elseif name == 'captain_player_confirm_player_info' then
         local frame = Public.get_active_tournament_frame(player, 'captain_player_gui')
@@ -1633,9 +1541,10 @@ local function on_gui_click(event)
             local textbox = frame.info_flow.insert.captain_player_info
             local text = textbox.text
             text = text:gsub('[%(%)%[%]%=]', '')
-            if #text > 200 then
-                player.print('Player info must not exceed 200 characters', { color = Color.warning })
-                text = string_sub(text, 1, 200)
+            CaptainPick.set_player_note(player.index, text)
+            if #text > 300 then
+                player.print('Player info must not exceed 300 characters', { color = Color.warning })
+                text = string_sub(text, 1, 300)
             end
             textbox.text = text
             local button = frame.info_flow.display.captain_player_info
@@ -1698,12 +1607,12 @@ local function on_gui_click(event)
             string_format(
                 '%s was picked by%s %s',
                 playerPicked,
-                is_player_a_captain(player.name) and ' Captain' or '',
+                CaptainUtils.is_player_a_captain(player.name) and ' Captain' or '',
                 player.name
             )
         )
         local listPlayers = special.listPlayers
-        switch_team_of_player(playerPicked, forceToGo)
+        CaptainUtils.switch_team_of_player(playerPicked, forceToGo)
         cpt_get_player(playerPicked).print({ '', { 'captain.comms_reminder' } }, { color = Color.cyan })
         for index, name in pairs(listPlayers) do
             if name == playerPicked then
@@ -1711,7 +1620,7 @@ local function on_gui_click(event)
                 break
             end
         end
-        if is_player_in_group_system(playerPicked) then
+        if CaptainUtils.is_player_in_group_system(playerPicked) then
             auto_pick_all_of_group(player, playerPicked)
         end
         if #storage.special_games_variables.captain_mode.listPlayers == 0 then
@@ -1866,7 +1775,7 @@ local function on_gui_click(event)
             Public.update_all_captain_player_guis()
         end
     elseif name == 'captain_add_vice_captain' then
-        if is_player_a_captain(player.name) then
+        if CaptainUtils.is_player_a_captain(player.name) then
             local frame = Public.get_active_tournament_frame(player, 'captain_manager_gui')
             local playerNameUpdateText =
                 get_dropdown_value(frame.captain_manager_vice_captain_table.captain_add_vice_captain_playerlist)
@@ -1876,7 +1785,7 @@ local function on_gui_click(event)
             end
         end
     elseif name == 'captain_remove_vice_captain' then
-        if is_player_a_captain(player.name) then
+        if CaptainUtils.is_player_a_captain(player.name) then
             local frame = Public.get_active_tournament_frame(player, 'captain_manager_gui')
             local playerNameUpdateText =
                 get_dropdown_value(frame.captain_manager_vice_captain_table.captain_remove_vice_captain_playerlist)
@@ -1992,8 +1901,8 @@ local function on_player_left_game(event)
     end
     DifficultyVote.remove_player_from_difficulty_vote(player)
 
-    if is_player_a_captain(player.name) then
-        if is_it_automatic_captain() and special.initialPickingPhaseStarted and special.prepaPhase then
+    if CaptainUtils.is_player_a_captain(player.name) then
+        if CaptainUtils.is_it_automatic_captain() and special.initialPickingPhaseStarted and special.prepaPhase then
             game.print(
                 '[font=default-large-bold]The captain '
                     .. player.name
@@ -2073,7 +1982,7 @@ local function every_1sec(event)
                         .. tostring(math.ceil((willingness.stop_tick - event.tick) / 60))
                         .. 's'
                     for player, _ in pairs(willingness.players) do
-                        if not is_test_player(player) then
+                        if not CaptainUtils.is_test_player(player) then
                             local frame = player.gui.screen.captain_willingness_vote_frame
                             if frame then
                                 frame.time_remaining_label.caption = time_remaining
@@ -2088,7 +1997,7 @@ end
 
 -- == DRAW BUTTONS ============================================================
 function Public.draw_captain_tournament_button(player)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
     Gui.add_top_element(player, {
@@ -2161,7 +2070,7 @@ end
 
 -- == DRAW GUI =================================================================
 function Public.draw_captain_join_info(player, main_frame)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
 
@@ -2231,7 +2140,7 @@ local function captain_player_gui_header(parent, flow_name, sprite, caption)
 end
 
 function Public.draw_captain_player_gui(player, main_frame)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
 
@@ -2416,6 +2325,8 @@ function Public.draw_captain_player_gui(player, main_frame)
         gui_style(button, { horizontally_stretchable = true, width = 380 + (28 + 5) * 2, left_padding = 3 })
 
         Gui.add_pusher(display_flow)
+
+        CaptainPick.draw_enrollment_tasks(info_flow)
     end
 
     line = main_frame.add({ type = 'line' })
@@ -2481,7 +2392,7 @@ function Public.draw_captain_player_gui(player, main_frame)
 end
 
 function Public.draw_captain_referee_gui(player, main_frame)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
     if not main_frame then
@@ -2496,7 +2407,7 @@ function Public.draw_captain_referee_gui(player, main_frame)
 end
 
 function Public.draw_captain_manager_gui(player, main_frame)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
     if not main_frame then
@@ -2575,14 +2486,14 @@ function Public.draw_captain_manager_gui(player, main_frame)
 end
 
 function Public.draw_captain_organization_gui(player, main_frame)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
     CaptainTaskGroup.draw_captain_organization_gui(player, main_frame)
 end
 
 function Public.draw_captain_tournament_gui(player)
-    if is_test_player(player) then
+    if CaptainUtils.is_test_player(player) then
         return
     end
 
@@ -2694,7 +2605,7 @@ function Public.update_captain_player_gui(player, frame)
             if not special.initialPickingPhaseStarted then
                 want_to_play.visible = true
                 want_to_play.caption = 'Players (' .. #special.listPlayers .. '): ' .. get_player_list_with_groups()
-                if is_it_automatic_captain() then
+                if CaptainUtils.is_it_automatic_captain() then
                     remaining_time_before_autostart.visible = true
                     remaining_time_before_autostart.caption = '[color=red]Time remaining before automatic start : '
                         .. storage.automatic_captain_time_remaining_for_start / 60
@@ -2816,6 +2727,7 @@ function Public.update_captain_player_gui(player, frame)
         local info_flow = frame.info_flow
         info_flow.visible = (waiting_to_be_picked and not special.pickingPhase)
         info_flow.display.visible = special.player_info[player.name] ~= nil and #special.player_info[player.name] > 0
+        CaptainPick.draw_enrollment_tasks(info_flow)
     end
 
     do -- Community pick UI
@@ -2921,9 +2833,9 @@ function Public.update_captain_player_gui(player, frame)
             if player_name == special.refereeName then
                 insert(info.status, 'Referee')
             end
-            if is_player_a_captain(player_name) then
+            if CaptainUtils.is_player_a_captain(player_name) then
                 insert(info.status, 'Captain')
-            elseif player_has_captain_authority(player_name) then
+            elseif CaptainUtils.player_has_captain_authority(player_name) then
                 insert(info.status, 'Vice Captain')
             end
             if player and not player.connected then
@@ -3027,6 +2939,10 @@ function Public.update_captain_player_gui(player, frame)
             end
         else
             pick_flow.visible = false
+        end
+
+        if pick_flow.visible then
+            pick_flow.visible = not CaptainPick.get('enabled')
         end
     end
 end
@@ -3226,7 +3142,7 @@ function Public.update_captain_manager_gui(player, frame)
         frame.captain_is_ready.caption = 'Team is Ready!'
         frame.captain_is_ready.style = 'green_button'
     end
-    local is_captain = is_player_a_captain(player.name)
+    local is_captain = CaptainUtils.is_player_a_captain(player.name)
     frame.captain_manager_replace_captain_table.visible = is_captain
     frame.captain_manager_vice_captain_table.visible = is_captain
     if is_captain then
@@ -3657,6 +3573,9 @@ commands.add_command('cpt-test-func', 'Run some test-only code for captains game
     insert(special.listPlayers, game.player.name)
     insert(special.captainList, game.player.name)
     insert(special.captainList, game.player.name)
+    CaptainPick.add_player(game.player.name)
+    CaptainPick.set_captain(game.player.name, 'north')
+    CaptainPick.set_captain(game.player.name, 'south')
     Public.update_all_captain_player_guis()
 end)
 

--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -2943,10 +2943,6 @@ function Public.update_captain_player_gui(player, frame)
         else
             pick_flow.visible = false
         end
-
-        if pick_flow.visible then
-            pick_flow.visible = not CaptainPick.get('enabled')
-        end
     end
 end
 

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -322,6 +322,7 @@ Public.pick_player = function(player_index)
     this.south.list[player_index] = nil
 
     --- Create new reference on correct team and switch player to it
+    CaptainUtils.remove_from_playerList(p.name)
     CaptainUtils.switch_team_of_player(p.name, this.turn)
     p.rank = side.rounds
     PlayerMeta.get_weight(p)
@@ -515,7 +516,7 @@ local on_tick = function()
         return
     end
 
-    if #this.spectator.list == 0 then
+    if table_size(this.spectator.list) == 0 then
         Public.end_of_picking_phase()
         return
     end
@@ -1467,13 +1468,17 @@ end
 
 ---@param player LuaPlayer
 Public.debounce = function(player)
+    if game.tick_paused then
+        return true
+    end
+
     local tick = debounce[player.index]
-    if tick and tick >= game.ticks_played then
+    if tick and tick >= game.tick then
         player.print({ 'gui.debounce' })
         return true
     end
 
-    debounce[player.index] = game.ticks_played + 10 -- 166ms
+    debounce[player.index] = game.tick + 10 -- 166ms
     return false
 end
 

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -1,0 +1,1612 @@
+local CaptainUtils = require('comfy_panel.special_games.captain_utils')
+local Color = require('utils.color_presets')
+local Event = require('utils.event')
+local Global = require('utils.global')
+local Gui = require('utils.gui')
+local Session = require('utils.datastore.session_data')
+local Token = require('utils.token')
+local table = require('utils.table')
+
+local math_floor = math.floor
+local string_find = string.find
+local string_format = string.format
+local string_sub = string.sub
+local table_add_all = table.add_all
+local table_concat = table.concat
+local table_deepcopy = table.deepcopy
+local table_insert = table.insert
+local table_sort = table.sort
+
+-- == PLAYERMETA ==============================================================
+
+local PlayerMeta = {}
+
+---@param p LuaPlayer|PlayerMeta
+function PlayerMeta.new(p)
+    if p.print then
+        p = { player = p }
+    end
+
+    return {
+        ---@type string
+        name = p.player.name,
+        ---@type number
+        index = p.player.index,
+        ---@type LuaPlayer
+        player = p.player,
+        ---@type number
+        value = p.value or 0,
+        ---@type string
+        value_tooltip = p.value_tooltip or '',
+        ---@type number
+        rank = p.rank or 12,
+        ---@type number
+        weight = p.weight or 0,
+        ---@type number
+        playtime = p.playtime or 0,
+        ---@type string
+        note = p.note or '',
+        ---@type table<string, boolean>
+        tasks = table_deepcopy(p.tasks or {}),
+        ---@type table<number, number>
+        votes = table_deepcopy(p.votes or {}),
+    }
+end
+
+---@param self PlayerMeta
+function PlayerMeta.update(self)
+    PlayerMeta.get_playtime(self)
+    PlayerMeta.get_weight(self)
+    return self
+end
+
+---@param self PlayerMeta
+function PlayerMeta.get_playtime(self)
+    self.playtime = storage.total_time_online_players[self.name] or 0
+    return self.playtime
+end
+
+---@param self PlayerMeta
+function PlayerMeta.get_value(self)
+    self.value = 0
+    for _, v in pairs(self.votes) do
+        self.value = self.value + v
+    end
+    return self.value
+end
+
+---@param self PlayerMeta
+function PlayerMeta.get_weight(self)
+    self.weight = 2 ^ (math.max(0, 12 - self.rank))
+    return self.weight
+end
+
+-- ===========================================================================
+
+local Public = {}
+
+-- == SETUP ===================================================================
+
+local main_frame_name = Gui.uid_name()
+local minimize_button_name = Gui.uid_name()
+local settings_button_name = Gui.uid_name()
+local settings_frame_name = Gui.uid_name()
+local searchbox_name = Gui.uid_name()
+local enrollment_flow_name = Gui.uid_name()
+
+local action_toggle_task = Gui.uid_name()
+local action_toggle_task_filter = Gui.uid_name()
+local action_reset_task_filter = Gui.uid_name()
+local action_cast_vote = Gui.uid_name()
+local action_mark_favourite = Gui.uid_name()
+local action_pick_player = Gui.uid_name()
+local action_refresh_list = Gui.uid_name()
+local action_show_info = Gui.uid_name()
+local action_sort_by = Gui.uid_name()
+
+local draft_timer_favor = Gui.uid_name()
+local draft_timer_enable = Gui.uid_name()
+local draft_timer_disable = Gui.uid_name()
+local draft_timer_pause = Gui.uid_name()
+local draft_timer_unpause = Gui.uid_name()
+local draft_timer_change = Gui.uid_name()
+
+local SECOND = 60
+local MINUTE = 60 * SECOND
+local HOUR = 60 * MINUTE
+local DEFAULT = {
+    time_fixed = 8 * MINUTE,
+    time_increment = 10 * SECOND,
+    sorting = { 'Playtime', 'Name', 'Value' },
+    tasks = {
+        'assembling-machine-2',
+        'electric-mining-drill',
+        'grenade',
+        'lab',
+        'laser-turret',
+        'nuclear-reactor',
+        'pumpjack',
+        'rocket-part',
+        'steam-engine',
+        'stone-wall',
+    },
+    max_note_length = 300,
+}
+local Comparators = {
+    Name = function(a, b)
+        return a.name:lower() < b.name:lower()
+    end,
+    Playtime = function(a, b)
+        return a.playtime > b.playtime
+    end,
+    Value = function(a, b)
+        return a.value > b.value
+    end,
+    Rank = function(a, b)
+        return a.rank < b.rank
+    end,
+}
+local Icons = {
+    favourite_enabled = '[img=virtual-signal/signal-star]',
+    favourite_disabled = '[img=virtual-signal/signal-damage;tint=55,55,55,0]',
+    left_arrow_enabled = '[img=virtual-signal/left-arrow]',
+    left_arrow_disabled = '[img=virtual-signal/left-arrow;tint=55,55,55,0]',
+    right_arrow_enabled = '[img=virtual-signal/right-arrow]',
+    right_arrow_disabled = '[img=virtual-signal/right-arrow;tint=55,55,55,0]',
+}
+
+---@type table<number, table<string, boolean>>
+local player_preferences = {}
+---@type table<number, table<number, boolean>>
+local favourites = {}
+---@type table<number, number>
+local debounce = {}
+
+local this = {
+    -- Settings
+    enabled = false,
+    turn = false,
+    next_update = 0,
+    uptime = 0,
+    north = { list = {} },
+    south = { list = {} },
+    spectator = { list = {} },
+
+    -- Draft timer
+    time_paused = false,
+    time_fixed = 0,
+    time_increment = 0,
+}
+
+Global.register({
+    this = this,
+    debounce = debounce,
+    favourites = favourites,
+    player_preferences = player_preferences,
+}, function(tbl)
+    this = tbl.this
+    debounce = tbl.debounce
+    favourites = tbl.favourites
+    player_preferences = tbl.player_preferences
+end)
+
+Public.force_lists = function()
+    return serpent.line({ nth = #this.north.list, sth = #this.south.list, spect = #this.spectator.list })
+end
+
+Public.get = function(key)
+    if key then
+        return this[key]
+    end
+    return this
+end
+
+Public.enable = function(params)
+    params = params or {}
+
+    this.turn = params.turn or false
+    this.uptime = 0
+    this.time_fixed = params.time_fixed or DEFAULT.time_fixed
+    this.time_increment = params.time_increment or DEFAULT.time_increment
+
+    this.north = Public.get_force_settings(this.north.list)
+    this.south = Public.get_force_settings(this.south.list)
+    this.north.time = this.time_fixed
+    this.south.time = this.time_fixed
+
+    if not this.enabled then
+        this.enabled = true
+        Event.add_removable(defines.events.on_tick, Public.on_tick_token)
+    end
+
+    if not this.turn then
+        this.turn = math.random() < 0.5 and 'north' or 'south'
+    end
+
+    local side = this[this.turn]
+    side.picks = 1
+    side.picked = 0
+    side.rounds = 1
+
+    for _, p in pairs(this.spectator.list) do
+        for _, list in pairs({ this.north.list, this.south.list }) do
+            local obj = PlayerMeta.new(p)
+            list[obj.index] = obj
+        end
+    end
+
+    Public.draw_all()
+end
+
+Public.disable = function()
+    this.turn = false
+    this.time_paused = false
+    this.uptime = 0
+    this.north = Public.get_force_settings()
+    this.south = Public.get_force_settings()
+    this.spectator.list = {}
+    table.clear_table(favourites)
+
+    if this.enabled then
+        this.enabled = false
+        Event.remove_removable(defines.events.on_tick, Public.on_tick_token)
+    end
+
+    Public.destroy_all()
+end
+
+-- == PLAYER MANAGER ==========================================================
+
+---@param playerID number|string
+Public.get_player = function(playerID)
+    local player = game.get_player(playerID)
+    if not (player and player.valid) then
+        return
+    end
+
+    for _, side in pairs({ this.spectator, this.north, this.south }) do
+        if side.list[player.index] then
+            return side.list[player.index]
+        end
+    end
+end
+
+---@param playerID number|string
+Public.add_player = function(playerID)
+    local player = game.get_player(playerID)
+    if not (player and player.valid) then
+        return
+    end
+
+    if this.spectator.list[player.index] then
+        return
+    end
+
+    for _, force in pairs({ this.spectator, this.north, this.south }) do
+        local p = PlayerMeta.new(player)
+        PlayerMeta.update(p)
+        force.list[player.index] = p
+    end
+
+    if table.contains(storage.special_games_variables.captain_mode.listPlayers, player.name) then
+        table.remove_element(storage.special_games_variables.captain_mode.listPlayers, player.name)
+    end
+
+    Public.queue_update()
+    game.print('ADD player ' .. player.name)
+    game.print(Public.force_lists())
+end
+
+---@param playerID number|string
+Public.remove_player = function(playerID)
+    local player = game.get_player(playerID)
+    if not (player and player.valid) then
+        return
+    end
+
+    this.spectator.list[player.index] = nil
+    this.north.list[player.index] = nil
+    this.south.list[player.index] = nil
+
+    Public.queue_update()
+end
+
+---@param player_index number
+Public.pick_player = function(player_index)
+    local p = this.spectator.list[player_index]
+    if not p then
+        return
+    end
+
+    local side = this[this.turn]
+
+    this.spectator.list[player_index] = nil
+    this.north.list[player_index] = nil
+    this.south.list[player_index] = nil
+
+    if not p.player.tag then
+        p.player.force = { name = this.turn }
+    else
+        CaptainUtils.switch_team_of_player(p.name, this.turn)
+    end
+    p.rank = side.rounds
+    PlayerMeta.get_weight(p)
+
+    side.list[player_index] = p
+
+    Public.queue_update()
+end
+
+---@param player_index number
+---@param task_name string
+Public.toggle_enrollment_task = function(player_index, task_name)
+    local p = this.spectator.list[player_index]
+    if not p then
+        return
+    end
+
+    if p.tasks[task_name] then
+        p.tasks[task_name] = nil
+    else
+        p.tasks[task_name] = true
+    end
+end
+
+---@param actor_index number
+---@param target_index number
+---@param sign number
+Public.cast_vote = function(actor_index, target_index, sign)
+    local actor = Public.get_player(actor_index)
+    if not actor then
+        return
+    end
+
+    local side = actor.player.force.name
+    local target = this[side].list and this[side].list[target_index] or this.spectator.list[target_index]
+    if not target then
+        return
+    end
+
+    local old_vote = target.votes[actor_index]
+    local new_vote = sign * actor.weight
+
+    if old_vote == new_vote then
+        target.votes[actor_index] = nil
+    else
+        target.votes[actor_index] = new_vote
+    end
+
+    target.value_tooltip = Public.get_value_tooltip(target)
+    PlayerMeta.get_value(target)
+end
+
+---@param player_index number
+---@param text string
+Public.set_player_note = function(player_index, text)
+    local p = this.spectator.list[player_index]
+    if not p then
+        return
+    end
+
+    if #text > DEFAULT.max_note_length then
+        p.player.print(
+            string_format('Player info must not exceed %d characters', DEFAULT.max_note_length),
+            { color = Color.warning }
+        )
+        text = string_sub(text, 1, DEFAULT.max_note_length)
+    end
+
+    p.note = text
+    return text
+end
+
+---@param playerID number|string
+---@param force_name string
+Public.set_captain = function(playerID, force_name)
+    local player = game.get_player(playerID)
+    if not (player and player.valid) then
+        return
+    end
+
+    local side = this[force_name]
+    if not side then
+        return
+    end
+
+    this.spectator.list[player.index] = nil
+    this.north.list[player.index] = nil
+    this.south.list[player.index] = nil
+
+    local p = PlayerMeta.new(player)
+    p.rank = 0
+    p.weight = 5000
+    side.list[player.index] = p
+
+    CaptainUtils.switch_team_of_player(p.name, force_name)
+
+    Public.queue_update()
+end
+
+-- == TIME MANAGER ============================================================
+
+Public.pause = function()
+    this.time_paused = true
+end
+
+Public.unpause = function()
+    this.time_paused = false
+end
+
+Public.perform_auto_picks = function()
+    local side = this[this.turn]
+    local max_attempts = 5
+    while (side.picks - side.picked > 1) and max_attempts > 0 do
+        -- Build array of players
+        local candidates = {}
+        for _, p in pairs(side.list) do
+            if p.player.force.name == 'spectator' then
+                candidates[#candidates + 1] = p.index
+            end
+        end
+
+        if #candidates == 0 then
+            return
+        end
+
+        -- Draw 1 at random
+        local player_index = candidates[math.random(#candidates)]
+        Public.pick_player(player_index)
+        side.picked = side.picked + 1
+
+        max_attempts = max_attempts - 1
+    end
+
+    Public.queue_update()
+end
+
+---@param side string 'north'|'south'
+Public.switch_turn = function(side)
+    this.turn = side or (this.turn == 'north' and 'south' or 'north')
+
+    assert(this.turn == 'north' or this.turn == 'south', 'Picking turns can only belong to either north or south side.')
+
+    local active = this[this.turn]
+    active.time = active.time + this.time_increment
+    active.picks = 2
+    active.picked = 0
+    active.rounds = active.rounds + 1
+
+    local passive = this[this.turn == 'north' and 'south' or 'north']
+    passive.picks = 0
+    passive.picked = 0
+
+    Public.queue_update()
+end
+
+---@param ticks number
+Public.change_time = function(ticks)
+    this.north.time = math.max(0, this.north.time + ticks)
+    this.south.time = math.max(0, this.south.time + ticks)
+end
+
+local on_tick = function()
+    if not this.enabled or this.time_paused then
+        return
+    end
+
+    if this.next_update == game.tick then
+        Public.update_all()
+    end
+
+    if not (game.tick % SECOND == 0) then
+        return
+    end
+
+    if #this.spectator.list == 0 then
+        Public.end_of_picking_phase()
+        return
+    end
+
+    this.uptime = this.uptime + SECOND
+
+    local side = this[this.turn]
+    side.time = math.max(0, side.time - SECOND)
+    if side.picked >= side.picks then
+        Public.switch_turn()
+    elseif side.time == 0 then
+        Public.perform_auto_picks()
+        Public.switch_turn()
+    end
+
+    local timer_info = {
+        'captain.info_draft_timer',
+        Public.format_time_short(this.uptime),
+        Public.format_time_short(this.time_fixed),
+        Public.format_time_short(this.time_increment),
+    }
+    local north_time = Public.format_time_short(this.north.time)
+    local south_time = Public.format_time_short(this.south.time)
+    local north_picks = { 'captain.info_picks', this.north.rounds, this.north.picked, this.north.picks }
+    local south_picks = { 'captain.info_picks', this.south.rounds, this.south.picked, this.south.picks }
+    local north_arrow = this.turn == 'north' and Icons.left_arrow_enabled or Icons.left_arrow_disabled
+    local south_arrow = this.turn == 'south' and Icons.right_arrow_enabled or Icons.right_arrow_disabled
+    local north_players = Public.get_force_tooltip(this.north.list, 'north')
+    local south_players = Public.get_force_tooltip(this.south.list, 'south')
+
+    for _, player in pairs(game.connected_players) do
+        local frame = Public.draw(player)
+        local data = Gui.get_data(frame)
+
+        data.timer_info.tooltip = timer_info
+
+        -- North
+        data.north_time.caption = north_time
+        data.north_picks.caption = north_arrow
+        data.north_picks.tooltip = north_picks
+        data.north_team.tooltip = north_players
+
+        -- South
+        data.south_time.caption = south_time
+        data.south_picks.caption = south_arrow
+        data.south_picks.tooltip = south_picks
+        data.south_team.tooltip = south_players
+    end
+end
+
+Public.on_tick_token = Token.register(on_tick)
+
+-- == GUI =====================================================================
+
+---@param player LuaPlayer
+Public.draw = function(player)
+    if not (player and player.valid) then
+        return
+    end
+
+    local frame = player.gui.screen[main_frame_name]
+    if frame and frame.valid then
+        return frame
+    end
+
+    local show_info = {}
+    local show_filter = {}
+    local data = {
+        frame = nil,
+        columns = nil,
+        body = nil,
+        row_1 = nil,
+        row_2 = nil,
+        scroll_pane = nil,
+        refresh = nil,
+        searchbox = nil,
+        show_info = show_info,
+        show_filter = show_filter,
+        timer_info = nil,
+        north_time = '',
+        south_time = '',
+    }
+
+    frame = player.gui.screen.add({ type = 'frame', name = main_frame_name, direction = 'horizontal' })
+    Gui.set_style(frame, { horizontally_stretchable = true, top_padding = 8, bottom_padding = 8 })
+    Gui.set_data(frame, data)
+    data.frame = frame
+
+    favourites[player.index] = favourites[player.index] or {}
+    local preferences = Public.get_player_preferences(player.index)
+
+    local columns = {
+        frame.add({ type = 'flow', direction = 'vertical' }),
+        frame.add({ type = 'flow', direction = 'vertical' }),
+    }
+    data.columns = columns
+    columns[2].visible = preferences.view_settings
+
+    for _, c in pairs(columns) do
+        Gui.set_style(c, { vertically_stretchable = false })
+    end
+
+    do --- Title
+        local flow = columns[1].add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(flow, { horizontal_spacing = 8, vertical_align = 'center', bottom_padding = 4 })
+
+        local minimize = flow.add({
+            type = 'sprite-button',
+            name = minimize_button_name,
+            style = 'frame_action_button',
+            sprite = 'utility/track_button_white',
+            auto_toggle = true,
+            tooltip = 'Toggle to minimize/maximize window',
+        })
+        Gui.set_style(minimize, { padding = 1 })
+        Gui.set_data(minimize, data)
+
+        local dragger = flow.add({ type = 'empty-widget', style = 'draggable_space_header' })
+        dragger.drag_target = frame
+        Gui.set_style(dragger, { height = 24, minimal_width = 48, horizontally_stretchable = true })
+
+        local label = flow.add({ type = 'label', caption = 'Team picker', style = 'frame_title' })
+        label.drag_target = frame
+
+        local dragger = flow.add({ type = 'empty-widget', style = 'draggable_space_header' })
+        dragger.drag_target = frame
+        Gui.set_style(dragger, { height = 24, minimal_width = 48, horizontally_stretchable = true })
+
+        local settings_button = flow.add({
+            type = 'button',
+            name = settings_button_name,
+            style = 'frame_button',
+            caption = 'Settings',
+            tooltip = 'Referee settings',
+        })
+        Gui.set_style(settings_button, {
+            font_color = { 230, 230, 230 },
+            height = 24,
+            width = 80,
+            natural_width = 80,
+            font = 'heading-2',
+            left_padding = 8,
+            right_padding = 8,
+        })
+        Gui.set_data(settings_button, data)
+    end
+
+    local column_1 = columns[1].add({ type = 'frame', style = 'inside_deep_frame', direction = 'vertical' })
+    Gui.set_style(column_1, {
+        horizontally_stretchable = true,
+        natural_width = 860,
+        natural_height = 750,
+        maximal_height = 900,
+    })
+    data.body = column_1
+
+    --- Header
+    local header = column_1.add({ type = 'frame', style = 'subheader_frame', direction = 'vertical' })
+    Gui.set_style(header, { natural_height = 36, maximal_height = 200, bottom_padding = 3, top_padding = 3 })
+
+    do -- 1st row
+        local row_1 = header.add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(row_1, { vertical_align = 'center', top_margin = 3 })
+        data.row_1 = row_1
+
+        row_1.add({
+            type = 'label',
+            caption = 'Sort by',
+            style = 'subheader_semibold_label',
+            tooltip = { 'captain.sort_by_tooltip' },
+        })
+
+        local dropdown = row_1.add({
+            type = 'drop-down',
+            items = DEFAULT.sorting,
+            name = action_sort_by,
+            selected_index = table.index_of(DEFAULT.sorting, preferences.sorting),
+        })
+        Gui.set_style(dropdown, { height = 26 })
+
+        Gui.add_pusher(row_1)
+
+        row_1.add({ type = 'line', direction = 'vertical' })
+
+        Gui.add_pusher(row_1)
+
+        row_1.add({
+            type = 'label',
+            caption = 'Show',
+            style = 'subheader_semibold_label',
+            tooltip = { 'captain.show_category_tooltip' },
+        })
+        local show_flow = row_1.add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(show_flow, { horizontal_spacing = 0 })
+
+        for _, button in pairs({
+            show_flow.add({
+                type = 'button',
+                auto_toggle = true,
+                caption = 'Playtime',
+                tags = { [Gui.tag] = action_show_info, type = 'playtime' },
+                toggled = preferences.playtime,
+            }),
+            show_flow.add({
+                type = 'button',
+                auto_toggle = true,
+                caption = 'Value',
+                tags = { [Gui.tag] = action_show_info, type = 'value' },
+                toggled = preferences.value,
+                tooltip = { 'captain.expand_filters_tooltip' },
+            }),
+            show_flow.add({
+                type = 'button',
+                auto_toggle = true,
+                caption = 'Tasks',
+                tags = { [Gui.tag] = action_show_info, type = 'tasks' },
+                toggled = preferences.tasks,
+                tooltip = { 'captain.expand_filters_tooltip' },
+            }),
+            show_flow.add({
+                type = 'button',
+                auto_toggle = true,
+                caption = 'Notes',
+                tags = { [Gui.tag] = action_show_info, type = 'notes' },
+                toggled = preferences.notes,
+            }),
+        }) do
+            Gui.set_style(
+                button,
+                { height = 26, left_padding = 12, right_padding = 12, minimal_width = 85, minimal_height = 0 }
+            )
+            Gui.set_data(button, data)
+            show_info[button.tags.type] = {}
+        end
+
+        Gui.add_pusher(row_1)
+
+        row_1.add({ type = 'line', direction = 'vertical' })
+
+        Gui.add_pusher(row_1)
+
+        local label = row_1.add({
+            type = 'label',
+            caption = '[img=utility/search]',
+            style = 'subheader_semibold_label',
+            tooltip = 'Search player name/cmments',
+        })
+        local searchbox = row_1.add({ type = 'textfield', name = searchbox_name, style = 'search_popup_textfield' })
+        Gui.set_style(searchbox, { maximal_height = 26 })
+        data.searchbox = searchbox
+    end
+    do -- 2nd row
+        local row_2 = header.add({ type = 'flow', direction = 'horizontal' })
+        row_2.visible = false
+        show_filter.value = row_2
+
+        local value_info = row_2.add({ type = 'frame', style = 'bordered_frame' })
+        Gui.set_style(value_info, { bottom_padding = 0 })
+
+        value_info.add({
+            type = 'label',
+            caption = 'Player value',
+            style = 'subheader_semibold_label',
+            tooltip = { 'captain.sort_by_tasks_tooltip' },
+        })
+
+        Gui.add_pusher(value_info)
+
+        local label = value_info.add({ type = 'label', caption = { 'captain.player_value_caption' } })
+        Gui.set_style(label, { minimal_width = 300, single_line = false })
+    end
+    do -- 3rd row
+        local row_3 = header.add({ type = 'flow', direction = 'horizontal' })
+        row_3.visible = false
+        show_filter.tasks = row_3
+
+        local tasks_frame = row_3.add({ type = 'frame', style = 'bordered_frame' })
+        Gui.set_style(tasks_frame, { bottom_padding = 0 })
+
+        local tasks_flow = tasks_frame.add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(tasks_flow, { vertical_align = 'center' })
+
+        tasks_flow.add({
+            type = 'label',
+            caption = 'Sort by tasks',
+            style = 'subheader_semibold_label',
+            tooltip = { 'captain.sort_by_tasks_tooltip' },
+        })
+        Gui.add_pusher(tasks_flow)
+
+        local tasks = tasks_flow.add({ type = 'table', column_count = #DEFAULT.tasks })
+        for _, task_name in pairs(DEFAULT.tasks) do
+            local button = tasks.add({
+                type = 'sprite-button',
+                sprite = 'item/' .. task_name,
+                style = 'slot_button', --p.tasks[task_name] and 'item_and_count_select_confirm' or
+                tooltip = { 'enrollment_tasks.' .. task_name },
+                tags = { [Gui.tag] = action_toggle_task_filter, task_name = task_name },
+                auto_toggle = true,
+                toggled = preferences.filter_by_task[task_name] ~= nil,
+            })
+            Gui.set_style(button, { size = 32 })
+        end
+
+        tasks_flow.add({ type = 'line', direction = 'vertical' })
+        local reset_button = tasks_flow.add({
+            type = 'sprite-button',
+            style = 'slot_button',
+            sprite = 'utility/reset_white',
+            tooltip = 'Clear all',
+            name = action_reset_task_filter,
+        })
+        Gui.set_style(reset_button, { size = 32, padding = 4 })
+        Gui.set_data(reset_button, tasks)
+    end
+
+    do --- List
+        local scroll_pane = column_1.add({ type = 'scroll-pane', style = 'text_holding_scroll_pane' })
+        Gui.set_style(scroll_pane, {
+            vertically_stretchable = true,
+            vertically_squashable = false,
+            maximal_height = 860,
+            minimal_width = 975,
+            --minimal_height = 200,
+        })
+        scroll_pane.vertical_scroll_policy = 'always'
+        scroll_pane.horizontal_scroll_policy = 'auto-and-reserve-space'
+        data.scroll_pane = scroll_pane
+    end
+
+    do --- Subfooter
+        local subfooter =
+            column_1.add({ type = 'frame', style = 'subfooter_frame' }).add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(subfooter, {
+            horizontally_stretchable = true,
+            horizontal_align = 'right',
+            vertical_align = 'center',
+            right_padding = 10,
+        })
+
+        Gui.add_pusher(subfooter)
+
+        local north = subfooter.add({ type = 'label', style = 'caption_label', caption = 'North' })
+        Gui.set_style(north, { font_color = { 140, 140, 252 } })
+        data.north_team = north
+
+        local t1 = subfooter.add({ type = 'label', style = 'caption_label', caption = '04:09' })
+        Gui.set_style(t1, { padding = 12, font = 'default-large', font_color = { 255, 255, 255 } })
+        data.north_time = t1
+
+        local p1 = subfooter.add({ type = 'label', caption = '---' })
+        Gui.set_style(p1, { right_padding = 6, font = 'default-small' })
+        data.north_picks = p1
+
+        local timer_info = subfooter.add({
+            type = 'label',
+            style = 'caption_label',
+            caption = '[img=virtual-signal/signal-hourglass]',
+            tooltip = '---',
+        })
+        data.timer_info = timer_info
+
+        local p2 = subfooter.add({ type = 'label', caption = '---' })
+        Gui.set_style(p2, { left_padding = 6, font = 'default-small' })
+        data.south_picks = p2
+
+        local t2 = subfooter.add({ type = 'label', style = 'caption_label', caption = '02:45' })
+        Gui.set_style(t2, { padding = 12, font = 'default-large', font_color = { 255, 255, 255 } })
+        data.south_time = t2
+
+        local south = subfooter.add({ type = 'label', style = 'caption_label', caption = 'South' })
+        Gui.set_style(south, { font_color = { 252, 084, 084 } })
+        data.south_team = south
+
+        Gui.add_pusher(subfooter)
+
+        local refresh = subfooter.add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(refresh, { vertical_align = 'center' })
+        data.refresh = refresh
+
+        refresh.add({ type = 'label', caption = 'Refresh ', style = 'caption_label' })
+        local refresh_button = refresh.add({
+            type = 'sprite-button',
+            name = action_refresh_list,
+            sprite = 'utility/refresh',
+            style = 'tool_button',
+            tooltip = 'Refresh the player list',
+        })
+        Gui.set_data(refresh_button, data)
+    end
+
+    Public.update(player)
+    if preferences.view_settings then
+        Public.draw_settings(player)
+    end
+
+    frame.auto_center = true
+    return frame
+end
+
+---@param player LuaPlayer
+Public.update = function(player)
+    local data = Gui.get_data(player.gui.screen[main_frame_name])
+    if not data then
+        return
+    end
+
+    local scroll_pane = data.scroll_pane
+    Gui.clear(scroll_pane)
+
+    local show_info = { playtime = {}, value = {}, tasks = {}, notes = {} }
+    data.show_info = show_info
+
+    local preferences = Public.get_player_preferences(player.index)
+
+    local function add_player(parent, p)
+        local player_frame = parent.add({ type = 'frame', direction = 'vertical' })
+        Gui.set_style(player_frame, { horizontally_stretchable = true, bottom_padding = 0, top_padding = 0 })
+
+        local row = player_frame.add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(row, {
+            horizontal_spacing = 10,
+            vertical_align = 'center',
+            natural_height = 32,
+            maximal_width = 940,
+            top_padding = 1,
+        })
+
+        local favourite = row.add({
+            type = 'label',
+            name = action_mark_favourite,
+            caption = favourites[player.index][p.index] and Icons.favourite_enabled or Icons.favourite_disabled,
+            tooltip = favourites[player.index][p.index] and 'Remove from favourites' or 'Add to favourites',
+            tags = { player_index = p.index },
+        })
+        Gui.set_style(favourite, { font = 'default-small' })
+
+        local name = row.add({
+            type = 'button',
+            name = action_pick_player,
+            caption = p.name,
+            style = 'frame_action_button',
+            tooltip = 'Pick ' .. p.name,
+            tags = { player_index = p.index },
+        })
+        Gui.set_style(name, { font_color = p.player.color, width = 150, height = 26, margin = 0 })
+
+        local playtime = row.add({ type = 'label', caption = Public.format_time(p.playtime) })
+        Gui.set_style(playtime, { minimal_width = 50 })
+        table_insert(show_info.playtime, playtime)
+        playtime.visible = preferences.playtime
+
+        local info_value = row.add({ type = 'flow', direction = 'horizontal' })
+        Gui.set_style(info_value, { horizontal_spacing = 10, vertical_align = 'center' })
+
+        local value = info_value.add({
+            type = 'sprite-button',
+            sprite = 'item/coin',
+            style = 'transparent_slot',
+            number = p.value,
+            tooltip = p.value_tooltip,
+        })
+        Gui.set_style(value, { padding = 4 })
+        local downvote = info_value.add({
+            type = 'label',
+            style = 'heading_2_label',
+            caption = '[img=virtual-signal/down-arrow;tint=255,0,0]',
+            tooltip = 'Downvote',
+            tags = { [Gui.tag] = action_cast_vote, value = -1, player_index = p.index },
+        })
+        local upvote = info_value.add({
+            type = 'label',
+            style = 'heading_2_label',
+            caption = '[img=virtual-signal/up-arrow;tint=0,255,0]',
+            tooltip = 'Upvote',
+            tags = { [Gui.tag] = action_cast_vote, value = 1, player_index = p.index },
+        })
+        table_insert(show_info.value, info_value)
+        info_value.visible = preferences.value
+
+        local info_tasks = row.add({ type = 'frame', style = 'inside_deep_frame' })
+
+        local tasks = info_tasks.add({ type = 'table', column_count = #DEFAULT.tasks })
+        Gui.set_style(tasks, { minimal_width = 28, horizontal_spacing = 0 })
+
+        for _, task_name in pairs(DEFAULT.tasks) do
+            local button = tasks.add({
+                type = 'sprite-button',
+                sprite = 'item/' .. task_name,
+                style = p.tasks[task_name] and 'item_and_count_select_confirm' or 'slot_button',
+                tooltip = { 'enrollment_tasks.' .. task_name },
+            })
+            Gui.set_style(button, { size = 28 })
+        end
+        table_insert(show_info.tasks, info_tasks)
+        info_tasks.visible = preferences.tasks
+
+        local note = row.add({
+            type = 'label',
+            caption = p.note,
+        })
+        Gui.set_style(note, { minimal_width = 100, single_line = false })
+        table_insert(show_info.notes, note)
+        note.visible = preferences.notes
+    end
+
+    for _, params in pairs(Public.get_sorted_list(player)) do
+        if params.player.force.name == 'spectator' then
+            add_player(scroll_pane, params)
+        end
+    end
+end
+
+--- Use Public.queue_update()
+Public.update_all = function()
+    for _, player in pairs(game.connected_players) do
+        Public.update(player)
+    end
+end
+
+Public.draw_all = function()
+    for _, player in pairs(game.connected_players) do
+        Public.draw(player)
+    end
+end
+
+---@param player LuaPlayer
+Public.destroy = function(player)
+    if not (player and player.valid) then
+        return
+    end
+
+    local frame = player.gui.screen[main_frame_name]
+    if frame then
+        Gui.destroy(frame)
+    end
+end
+
+Public.destroy_all = function()
+    for _, player in pairs(game.players) do
+        Public.destroy(player)
+    end
+end
+
+---@param player LuaPlayer
+Public.draw_settings = function(player)
+    if not (player and player.valid) then
+        return
+    end
+
+    local frame = player.gui.screen[main_frame_name]
+    if not (frame and frame.valid) then
+        return
+    end
+    local column = Gui.get_data(frame).columns[2]
+    column.visible = true
+    if #column.children > 0 then
+        return column
+    end
+
+    local parent = column.add({ type = 'frame', style = 'inside_shallow_frame_with_padding', direction = 'vertical' })
+    Gui.set_style(parent, {
+        horizontally_stretchable = true,
+        vertically_stretchable = true,
+        minimal_width = 200,
+        left_margin = 6,
+    })
+
+    local box_1 = parent
+        .add({ type = 'frame', style = 'bordered_frame', direction = 'vertical', caption = 'Player picker settings' })
+        .add({ type = 'table', column_count = 2 })
+    for i, button in pairs({
+        box_1.add({
+            type = 'button',
+            style = 'frame_button',
+            caption = '+1 North',
+            tags = { [Gui.tag] = draft_timer_favor, side = 'north', delta = 1 },
+        }),
+        box_1.add({
+            type = 'button',
+            style = 'frame_button',
+            caption = '+1 South',
+            tags = { [Gui.tag] = draft_timer_favor, side = 'south', delta = 1 },
+        }),
+        box_1.add({
+            type = 'button',
+            style = 'frame_button',
+            caption = 'Favor North',
+            tags = { [Gui.tag] = draft_timer_favor, side = 'north' },
+        }),
+        box_1.add({
+            type = 'button',
+            style = 'frame_button',
+            caption = 'Favor South',
+            tags = { [Gui.tag] = draft_timer_favor, side = 'south' },
+        }),
+        box_1.add({
+            type = 'button',
+            style = 'frame_button',
+            caption = '-1 North',
+            tags = { [Gui.tag] = draft_timer_favor, side = 'north', delta = -1 },
+        }),
+        box_1.add({
+            type = 'button',
+            style = 'frame_button',
+            caption = '-1 South',
+            tags = { [Gui.tag] = draft_timer_favor, side = 'south', delta = -1 },
+        }),
+    }) do
+        Gui.set_style(button, {
+            maximal_height = 28,
+            minimal_width = 108,
+            font_color = (i % 2 == 1) and { 140, 140, 252 } or { 252, 084, 084 },
+        })
+    end
+
+    local box_2 = parent
+        .add({ type = 'frame', style = 'bordered_frame', direction = 'horizontal', caption = 'Draft Timer settings' })
+        .add({ type = 'table', column_count = 2 })
+    for i, button in pairs({
+        box_2.add({ type = 'button', style = 'red_back_button', name = draft_timer_disable, caption = 'Disable' }),
+        box_2.add({
+            type = 'button',
+            style = 'confirm_button_without_tooltip',
+            name = draft_timer_enable,
+            caption = 'Enable',
+        }),
+        box_2.add({ type = 'button', style = 'red_back_button', name = draft_timer_unpause, caption = 'Unpause' }),
+        box_2.add({
+            type = 'button',
+            style = 'confirm_button_without_tooltip',
+            name = draft_timer_pause,
+            caption = 'Pause',
+        }),
+        box_2.add({
+            type = 'button',
+            style = 'red_back_button',
+            caption = 'Remove 0:30',
+            tags = { [Gui.tag] = draft_timer_change, time = -30 * 60 },
+        }),
+        box_2.add({
+            type = 'button',
+            style = 'confirm_button_without_tooltip',
+            caption = 'Add 0:30',
+            tags = { [Gui.tag] = draft_timer_change, time = 30 * 60 },
+        }),
+        box_2.add({
+            type = 'button',
+            style = 'red_back_button',
+            caption = 'Remove 5:00',
+            tags = { [Gui.tag] = draft_timer_change, time = -5 * 60 * 60 },
+        }),
+        box_2.add({
+            type = 'button',
+            style = 'confirm_button_without_tooltip',
+            caption = 'Add 5:00',
+            tags = { [Gui.tag] = draft_timer_change, time = 5 * 60 * 60 },
+        }),
+    }) do
+        Gui.set_style(
+            button,
+            { maximal_height = 28, minimal_width = 108, font = 'default-semibold', font_color = { 0, 0, 0 } }
+        )
+    end
+end
+
+---@param parent LuaGuiElement
+Public.draw_enrollment_tasks = function(parent)
+    local p = this.spectator.list[parent.player_index]
+    local flow = parent[enrollment_flow_name]
+
+    if not p then
+        if flow then
+            Gui.destroy(flow)
+        end
+        return
+    end
+
+    local tasks
+    if not flow then
+        flow = parent.add({ type = 'flow', name = enrollment_flow_name, direction = 'horizontal' })
+        Gui.set_style(flow, { horizontal_align = 'center', margin = 8 })
+
+        Gui.add_pusher(flow)
+
+        tasks = flow.add({ type = 'frame', style = 'inside_deep_frame' })
+            .add({ type = 'table', column_count = #DEFAULT.tasks })
+        Gui.set_style(tasks, { horizontal_spacing = 0 })
+
+        Gui.add_pusher(flow)
+    else
+        tasks = flow.children[2].children[1]
+    end
+
+    tasks.clear()
+
+    for _, task_name in pairs(DEFAULT.tasks) do
+        local button = tasks.add({
+            type = 'sprite-button',
+            sprite = 'item/' .. task_name,
+            style = p.tasks[task_name] and 'item_and_count_select_confirm' or 'slot_button',
+            tooltip = { 'enrollment_tasks.' .. task_name },
+            tags = { [Gui.tag] = action_toggle_task, task_name = task_name },
+        })
+        Gui.set_data(button, parent)
+        Gui.set_style(button, { size = 40 })
+    end
+end
+
+-- == EVENTS ==================================================================
+
+Gui.on_click(minimize_button_name, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+
+    local element = event.element
+    local data = Gui.get_data(element)
+
+    data.row_1.parent.visible = not element.toggled
+    data.scroll_pane.visible = not element.toggled
+    data.refresh.visible = not element.toggled
+    if element.toggled then
+        Gui.set_style(data.body, {
+            natural_width = 0,
+            natural_height = 0,
+        })
+    else
+        Gui.set_style(data.body, {
+            natural_width = 860,
+            natural_height = 750,
+        })
+    end
+end)
+
+Gui.on_click(settings_button_name, function(event)
+    if not CaptainUtils.is_player_the_referee(event.player.name) then
+        return
+    end
+
+    local preferences = Public.get_player_preferences(event.player_index)
+    preferences.view_settings = not preferences.view_settings
+
+    if preferences.view_settings then
+        Public.draw_settings(event.player)
+    else
+        local data = Gui.get_data(event.element)
+        data.columns[2].visible = false
+    end
+end)
+
+Gui.on_click(action_toggle_task, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+
+    Public.toggle_enrollment_task(event.player_index, event.element.tags.task_name)
+    Public.draw_enrollment_tasks(Gui.get_data(event.element))
+end)
+
+Gui.on_click(action_toggle_task_filter, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+
+    local task_name = event.element.tags.task_name
+    local list = Public.get_player_preferences(event.player_index).filter_by_task
+    if not list then
+        return
+    end
+
+    if list[task_name] then
+        list[task_name] = nil
+    else
+        list[task_name] = true
+    end
+
+    Public.update(event.player)
+end)
+
+Gui.on_click(action_reset_task_filter, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+
+    local tasks = Gui.get_data(event.element)
+    for _, button in pairs(tasks.children) do
+        button.toggled = false
+    end
+
+    table.clear_table(Public.get_player_preferences(event.player_index).filter_by_task)
+    Public.update(event.player)
+end)
+
+Gui.on_click(action_cast_vote, function(event)
+    event.player.play_sound({ path = 'utility/gui_click' })
+
+    if Public.debounce(event.player) then
+        return
+    end
+
+    Public.cast_vote(event.player_index, event.element.tags.player_index, event.element.tags.value)
+    Public.queue_update()
+end)
+
+Gui.on_click(action_mark_favourite, function(event)
+    event.player.play_sound({ path = 'utility/gui_click' })
+
+    if Public.debounce(event.player) then
+        return
+    end
+
+    local viewer_index = event.element.player_index
+    local target_index = event.element.tags.player_index
+    if favourites[viewer_index][target_index] then
+        favourites[viewer_index][target_index] = nil
+    else
+        favourites[viewer_index][target_index] = true
+    end
+
+    event.element.caption = favourites[viewer_index][target_index] and Icons.favourite_enabled
+        or Icons.favourite_disabled
+    event.element.tooltip = favourites[viewer_index][target_index] and 'Remove from favourites' or 'Add to favourites'
+end)
+
+Gui.on_click(action_pick_player, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+    if not CaptainUtils.is_player_a_captain(event.player.name) then
+        return
+    end
+    if event.player.force.name ~= this.turn then
+        return
+    end
+
+    Public.pick_player(event.element.tags.player_index)
+
+    local side = this[this.turn]
+    side.picked = side.picked + 1
+    if side.picked >= side.picks then
+        Public.switch_turn()
+    end
+
+    Public.queue_update()
+end)
+
+Gui.on_click(action_refresh_list, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+
+    local data = Gui.get_data(event.element)
+    data.searchbox.text = ''
+
+    Public.get_player_preferences(event.player_index).filter = nil
+    Public.update(event.player)
+end)
+
+Gui.on_click(action_show_info, function(event)
+    if Public.debounce(event.player) then
+        return
+    end
+
+    local element = event.element
+    local category = element.tags.type
+
+    if event.button == defines.mouse_button_type.left then
+        Public.get_player_preferences(event.player_index)[category] = element.toggled
+
+        for _, child in pairs(Gui.get_data(element).show_info[category]) do
+            child.visible = element.toggled
+        end
+    elseif event.button == defines.mouse_button_type.right then
+        element.toggled = not element.toggled
+        local filters = Gui.get_data(element).show_filter
+        if filters[category] then
+            filters[category].visible = not filters[category].visible
+        end
+    end
+end)
+
+Gui.on_text_changed(searchbox_name, function(event)
+    local text = event.text
+    Public.get_player_preferences(event.player_index).filter = (text == '' and nil) or text
+    Public.update(event.player)
+end)
+
+Gui.on_selection_state_changed(action_sort_by, function(event)
+    local preferences = Public.get_player_preferences(event.player_index)
+    preferences.sorting = DEFAULT.sorting[event.element.selected_index]
+    Public.update(event.player)
+end)
+
+Gui.on_click(draft_timer_favor, function(event)
+    local side = event.element.tags.side
+    local delta = event.element.tags.delta
+
+    if delta then
+        this[side].picks = this[side].picks + delta
+    else
+        Public.switch_turn(side)
+    end
+end)
+
+Gui.on_click(draft_timer_enable, Public.enable)
+Gui.on_click(draft_timer_disable, Public.disable)
+Gui.on_click(draft_timer_pause, Public.pause)
+Gui.on_click(draft_timer_unpause, Public.unpause)
+
+Gui.on_click(draft_timer_change, function(event)
+    Public.change_time(event.element.tags.time)
+end)
+
+-- == UTILS ===================================================================
+
+---@param strings string[]
+---@param pattern string
+local function match_str(strings, pattern)
+    if not pattern then
+        return true
+    end
+
+    pattern = pattern:lower()
+    for _, str in pairs(strings) do
+        if string_find(str:lower(), pattern) then
+            return true
+        end
+    end
+
+    return false
+end
+
+---@param reference table<string, boolean>
+---@param object table<string, boolean>
+local function match_dict(reference, object)
+    for k, v in pairs(reference) do
+        if v and not object[k] then
+            return false
+        end
+    end
+
+    return true
+end
+
+Public.queue_update = function()
+    this.next_update = game.tick + 1
+end
+
+---@param player LuaPlayer
+Public.debounce = function(player)
+    if game.tick_paused then
+        return false
+    end
+
+    local tick = debounce[player.index]
+    if tick and tick >= game.tick then
+        player.print({ 'gui.debounce' })
+        return true
+    end
+
+    debounce[player.index] = game.tick + 10 -- 166ms
+    return false
+end
+
+---@param ticks number
+Public.format_time_short = function(ticks)
+    local seconds = math_floor(ticks / 60)
+    local minutes = math_floor(seconds / 60)
+
+    seconds = seconds % 60
+
+    return string_format('%02d:%02d', minutes, seconds)
+end
+
+---@param ticks number
+Public.format_time = function(ticks)
+    local seconds = math_floor(ticks / 60)
+    local minutes = math_floor(seconds / 60)
+    local hours = math_floor(minutes / 60)
+    local days = math_floor(hours / 24)
+
+    minutes = minutes % 60
+    hours = hours % 24
+
+    return string_format(
+        '[font=default-semibold]%02d[/font][font=default-small]d[/font] [font=default-semibold]%02d[/font][font=default-small]h[/font] [font=default-semibold]%02d[/font][font=default-small]m[/font]',
+        days,
+        hours,
+        minutes
+    )
+end
+
+---@param list table<number, PlayerMeta>
+Public.get_force_settings = function(list)
+    return {
+        ---@type PlayerMeta[]
+        list = list or {},
+        time = 0,
+        picks = 0,
+        rounds = 0,
+        picked = 0,
+    }
+end
+
+---@param player_index number
+Public.get_player_preferences = function(player_index)
+    local preferences = player_preferences[player_index]
+    if not preferences then
+        preferences = {
+            playtime = true,
+            value = true,
+            tasks = false,
+            notes = true,
+            sorting = 'Playtime',
+            filter = nil,
+            view_settings = false,
+            filter_by_task = {},
+        }
+        player_preferences[player_index] = preferences
+    end
+    return preferences
+end
+
+---@param player LuaPlayer
+Public.get_sorted_list = function(player)
+    local top = {}
+    local middle = {}
+    local bottom = {}
+    local preferences = Public.get_player_preferences(player.index)
+    local marked = favourites[player.index]
+    local filter = preferences.filter
+    local reference_list = this[player.force.name] and this[player.force.name].list or this.spectator.list
+
+    filter = filter and filter:lower()
+
+    for _, p in pairs(reference_list) do
+        local tasks = table_concat(table.keys(p.tasks), '')
+        if match_str({ p.name, p.note, tasks }, filter) then
+            if match_dict(preferences.filter_by_task, p.tasks) then
+                table_insert(marked[p.index] and top or middle, p)
+            else
+                table_insert(bottom, p)
+            end
+        end
+    end
+
+    table_sort(top, Comparators[preferences.sorting])
+    table_sort(middle, Comparators[preferences.sorting])
+    table_sort(bottom, Comparators[preferences.sorting])
+
+    table_add_all(top, middle)
+    table_add_all(top, bottom)
+
+    return top
+end
+
+---@param playerMeta PlayerMeta
+Public.get_value_tooltip = function(playerMeta)
+    local votes = {}
+
+    for actor_index, value in pairs(playerMeta.votes) do
+        local sign = value > 0 and '+' or '-'
+        local color = value > 0 and 'green' or 'red'
+        local actor = Public.get_player(actor_index)
+        local _c = actor.player.color
+        local actor_color = string_format('%.2f,%.2f,%.2f', _c.r, _c.g, _c.b)
+        votes[#votes + 1] = string_format(
+            '[font=default-listbox][color=%s]%s%04d[/color] - [color=%s]%s[/color][/font]',
+            color,
+            sign,
+            math.abs(value),
+            actor_color,
+            actor.name
+        )
+    end
+
+    table_sort(votes)
+    return table_concat(votes, '\n')
+end
+
+---@param list table<number, PlayerMeta>
+---@param force LuaForce
+Public.get_force_tooltip = function(list, force)
+    local tmp, result = {}, {}
+
+    for _, p in pairs(list) do
+        if p.player.force.name == force then
+            tmp[#tmp + 1] = p
+        end
+    end
+
+    table_sort(tmp, Comparators.Rank)
+
+    for _, p in pairs(tmp) do
+        local _c = p.player.color
+        local color = string_format('%.2f,%.2f,%.2f', _c.r, _c.g, _c.b)
+        result[#result + 1] =
+            string_format('[font=default-listbox]%02d - [color=%s]%s[/color][/font]', p.rank, color, p.name)
+    end
+
+    return table_concat(result, '\n')
+end
+
+-- ============================================================================
+
+return Public

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -286,10 +286,6 @@ Public.add_player = function(playerID)
         force.list[player.index] = p
     end
 
-    if table.contains(storage.special_games_variables.captain_mode.listPlayers, player.name) then
-        table.remove_element(storage.special_games_variables.captain_mode.listPlayers, player.name)
-    end
-
     Public.queue_update()
 end
 

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -29,7 +29,7 @@ function PlayerMeta.new(p)
     return {
         ---@type string
         name = p.player.name,
-        ---@type number
+        ---@type integer
         index = p.player.index,
         ---@type LuaPlayer
         player = p.player,
@@ -47,7 +47,7 @@ function PlayerMeta.new(p)
         note = p.note or '',
         ---@type table<string, boolean>
         tasks = table_deepcopy(p.tasks or {}),
-        ---@type table<number, number>
+        ---@type table<integer, number>
         votes = table_deepcopy(p.votes or {}),
     }
 end
@@ -154,11 +154,11 @@ local Icons = {
     right_arrow_disabled = '[img=virtual-signal/right-arrow;tint=55,55,55,0]',
 }
 
----@type table<number, table<string, boolean>>
+---@type table<integer, table<string, boolean>>
 local player_preferences = {}
----@type table<number, table<number, boolean>>
+---@type table<integer, table<integer, boolean>>
 local favourites = {}
----@type table<number, number>
+---@type table<integer, number>
 local debounce = {}
 
 local this = {
@@ -255,7 +255,7 @@ end
 
 -- == PLAYER MANAGER ==========================================================
 
----@param playerID number|string
+---@param playerID integer|string
 Public.get_player = function(playerID)
     local player = game.get_player(playerID)
     if not (player and player.valid) then
@@ -269,7 +269,7 @@ Public.get_player = function(playerID)
     end
 end
 
----@param playerID number|string
+---@param playerID integer|string
 Public.add_player = function(playerID)
     local player = game.get_player(playerID)
     if not (player and player.valid) then
@@ -293,7 +293,7 @@ Public.add_player = function(playerID)
     Public.queue_update()
 end
 
----@param playerID number|string
+---@param playerID integer|string
 Public.remove_player = function(playerID)
     local player = game.get_player(playerID)
     if not (player and player.valid) then
@@ -307,7 +307,7 @@ Public.remove_player = function(playerID)
     Public.queue_update()
 end
 
----@param player_index number
+---@param player_index integer
 Public.pick_player = function(player_index)
     local p = this.spectator.list[player_index]
     if not p then
@@ -335,7 +335,7 @@ Public.pick_player = function(player_index)
     Public.queue_update()
 end
 
----@param player_index number
+---@param player_index integer
 ---@param task_name string
 Public.toggle_enrollment_task = function(player_index, task_name)
     local p = this.spectator.list[player_index]
@@ -350,8 +350,8 @@ Public.toggle_enrollment_task = function(player_index, task_name)
     end
 end
 
----@param actor_index number
----@param target_index number
+---@param actor_index integer
+---@param target_index integer
 ---@param sign number
 Public.cast_vote = function(actor_index, target_index, sign)
     local actor = Public.get_player(actor_index)
@@ -378,7 +378,7 @@ Public.cast_vote = function(actor_index, target_index, sign)
     PlayerMeta.get_value(target)
 end
 
----@param player_index number
+---@param player_index integer
 ---@param text string
 Public.set_player_note = function(player_index, text)
     local p = this.spectator.list[player_index]
@@ -398,7 +398,7 @@ Public.set_player_note = function(player_index, text)
     return text
 end
 
----@param playerID number|string
+---@param playerID integer|string
 ---@param force_name string
 Public.set_captain = function(playerID, force_name)
     local player = game.get_player(playerID)
@@ -457,7 +457,7 @@ Public.perform_auto_picks = function()
         if #candidates == 0 then
             for _, p in pairs(side.list) do
                 if p.player.force.name == 'spectator' then
-                    candidates[#candidates + 1] = p.index
+                    table_insert(candidates, p.index)
                 end
             end
         end
@@ -1505,7 +1505,7 @@ Public.format_time = function(ticks)
     )
 end
 
----@param list table<number, PlayerMeta>
+---@param list table<integer, PlayerMeta>
 Public.get_force_settings = function(list)
     return {
         ---@type PlayerMeta[]
@@ -1517,7 +1517,7 @@ Public.get_force_settings = function(list)
     }
 end
 
----@param player_index number
+---@param player_index integer
 Public.get_player_preferences = function(player_index)
     local preferences = player_preferences[player_index]
     if not preferences then
@@ -1536,12 +1536,12 @@ Public.get_player_preferences = function(player_index)
     return preferences
 end
 
----@param player_index number
+---@param player_index integer
 Public.get_favourites_list = function(player_index)
     local result = {}
 
     for k, _ in pairs(favourites[player_index] or {}) do
-        result[#result + 1] = k
+        table_insert(result, k)
     end
 
     return result
@@ -1590,13 +1590,16 @@ Public.get_value_tooltip = function(playerMeta)
         local actor = Public.get_player(actor_index)
         local _c = actor.player.color
         local actor_color = string_format('%.2f,%.2f,%.2f', _c.r, _c.g, _c.b)
-        votes[#votes + 1] = string_format(
-            '[font=default-listbox][color=%s]%s%04d[/color] - [color=%s]%s[/color][/font]',
-            color,
-            sign,
-            math.abs(value),
-            actor_color,
-            actor.name
+        table_insert(
+            votes,
+            string_format(
+                '[font=default-listbox][color=%s]%s%04d[/color] - [color=%s]%s[/color][/font]',
+                color,
+                sign,
+                math.abs(value),
+                actor_color,
+                actor.name
+            )
         )
     end
 
@@ -1604,14 +1607,14 @@ Public.get_value_tooltip = function(playerMeta)
     return table_concat(votes, '\n')
 end
 
----@param list table<number, PlayerMeta>
+---@param list table<integer, PlayerMeta>
 ---@param force LuaForce
 Public.get_force_tooltip = function(list, force)
     local tmp, result = {}, {}
 
     for _, p in pairs(list) do
         if p.player.force.name == force then
-            tmp[#tmp + 1] = p
+            table_insert(tmp, p)
         end
     end
 
@@ -1620,8 +1623,10 @@ Public.get_force_tooltip = function(list, force)
     for _, p in pairs(tmp) do
         local _c = p.player.color
         local color = string_format('%.2f,%.2f,%.2f', _c.r, _c.g, _c.b)
-        result[#result + 1] =
+        table_insert(
+            result,
             string_format('[font=default-listbox]%02d - [color=%s]%s[/color][/font]', p.rank, color, p.name)
+        )
     end
 
     return table_concat(result, '\n')

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -641,6 +641,9 @@ Public.draw = function(player)
         local label = flow.add({ type = 'label', caption = 'Team picker', style = 'frame_title' })
         label.drag_target = frame
 
+        local label = flow.add({ type = 'label', caption = '[img=info]', tooltip = { 'captain.team_picker_tooltip' } })
+        label.drag_target = frame
+
         local dragger = flow.add({ type = 'empty-widget', style = 'draggable_space_header' })
         dragger.drag_target = frame
         Gui.set_style(dragger, { height = 24, minimal_width = 48, horizontally_stretchable = true })

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -190,10 +190,6 @@ Global.register({
     player_preferences = tbl.player_preferences
 end)
 
-Public.force_lists = function()
-    return serpent.line({ nth = #this.north.list, sth = #this.south.list, spect = #this.spectator.list })
-end
-
 Public.get = function(key)
     if key then
         return this[key]
@@ -293,8 +289,6 @@ Public.add_player = function(playerID)
     end
 
     Public.queue_update()
-    game.print('ADD player ' .. player.name)
-    game.print(Public.force_lists())
 end
 
 ---@param playerID number|string

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -634,7 +634,12 @@ Public.draw = function(player)
         dragger.drag_target = frame
         Gui.set_style(dragger, { height = 24, minimal_width = 48, horizontally_stretchable = true })
 
-        local label = flow.add({ type = 'label', caption = 'Team picker', style = 'frame_title' })
+        local label = flow.add({
+            type = 'label',
+            caption = 'Team picker',
+            style = 'frame_title',
+            tooltip = { 'captain.team_picker_tooltip' },
+        })
         label.drag_target = frame
 
         local label = flow.add({ type = 'label', caption = '[img=info]', tooltip = { 'captain.team_picker_tooltip' } })

--- a/comfy_panel/special_games/captain_task_group.lua
+++ b/comfy_panel/special_games/captain_task_group.lua
@@ -5,8 +5,9 @@ local Event = require('utils.event')
 local Gui = require('utils.gui')
 local gui_style = require('utils.utils').gui_style
 local frame_style = require('utils.utils').left_frame_style
+local table = require('utils.table')
 local concat, insert, remove = table.concat, table.insert, table.remove
-local table_contains = CaptainUtils.table_contains
+local table_contains = table.contains
 local string_sub = string.sub
 
 local CaptainTaskGroup = {}

--- a/comfy_panel/special_games/captain_utils.lua
+++ b/comfy_panel/special_games/captain_utils.lua
@@ -4,14 +4,17 @@ local Functions = require('maps.biter_battles_v2.functions')
 local player_utils = require('utils.player')
 local Session = require('utils.datastore.session_data')
 local starts_with = require('utils.string').starts_with
+local Table = require('utils.table')
 local TeamManager = require('maps.biter_battles_v2.team_manager')
-local insert, concat = table.insert, table.concat
+local insert, concat, contains = table.insert, table.concat, Table.contains
+local table_remove_element = Table.remove_element
 
 local CaptainUtils = {}
 
 local get_special = function()
     return storage.special_games_variables.captain_mode
 end
+CaptainUtils.get_special = get_special
 
 ---@param playerName string
 function CaptainUtils.add_to_trust(playerName)
@@ -22,6 +25,27 @@ function CaptainUtils.add_to_trust(playerName)
             trusted[playerName] = true
         end
     end
+end
+
+---@param playerName string
+function CaptainUtils.add_to_playerList(playerName)
+    local special = get_special()
+    if not special then
+        return
+    end
+    if contains(special.listPlayers, playerName) then
+        return
+    end
+    insert(special.listPlayers, playerName)
+end
+
+---@param playerName string
+function CaptainUtils.remove_from_playerList(playerName)
+    local special = get_special()
+    if not special then
+        return
+    end
+    table_remove_element(special.listPlayers, playerName)
 end
 
 ---@param player LuaPlayer

--- a/comfy_panel/special_games/captain_utils.lua
+++ b/comfy_panel/special_games/captain_utils.lua
@@ -1,17 +1,37 @@
+local Color = require('utils.color_presets')
+local ComfyPanelGroup = require('comfy_panel.group')
+local Functions = require('maps.biter_battles_v2.functions')
 local player_utils = require('utils.player')
+local Session = require('utils.datastore.session_data')
+local starts_with = require('utils.string').starts_with
+local TeamManager = require('maps.biter_battles_v2.team_manager')
+local insert, concat = table.insert, table.concat
 
 local CaptainUtils = {}
 
----@param tab table
----@param str any
----@return boolean
-function CaptainUtils.table_contains(tab, str)
-    for _, entry in ipairs(tab) do
-        if entry == str then
-            return true
+local get_special = function()
+    return storage.special_games_variables.captain_mode
+end
+
+---@param playerName string
+function CaptainUtils.add_to_trust(playerName)
+    local special = get_special()
+    if special and special.autoTrust then
+        local trusted = Session.get_trusted_table()
+        if not trusted[playerName] then
+            trusted[playerName] = true
         end
     end
-    return false
+end
+
+---@param player LuaPlayer
+---@return boolean
+function CaptainUtils.check_if_enough_playtime_to_play(player)
+    local special = get_special()
+    if not special then
+        return true
+    end
+    return (storage.total_time_online_players[player.name] or 0) >= (special.minTotalPlaytimeToPlay or 0)
 end
 
 ---@param playerName string|integer
@@ -20,7 +40,7 @@ function CaptainUtils.cpt_get_player(playerName)
     if not playerName then
         return nil
     end
-    local special = storage.special_games_variables.captain_mode
+    local special = get_special()
     if special and special.test_players and special.test_players[playerName] then
         local res = table.deepcopy(special.test_players[playerName])
         res.print = function(msg, options)
@@ -32,13 +52,102 @@ function CaptainUtils.cpt_get_player(playerName)
     return game.get_player(playerName)
 end
 
+function CaptainUtils.is_it_automatic_captain()
+    local special = get_special()
+    return special and (special.refereeName == '$@BotReferee')
+end
+
+function CaptainUtils.is_player_the_referee(playerName)
+    local special = get_special()
+    return (special and special.refereeName == playerName) or false
+end
+
+---@param player string
+---@return boolean
+function CaptainUtils.is_player_a_captain(playerName)
+    local special = get_special()
+    return (special ~= nil) and (special.captainList[1] == playerName or special.captainList[2] == playerName)
+end
+
+---@param playerName string
+---@return boolean
+function CaptainUtils.is_player_in_group_system(playerName)
+    -- function used to balance team when a team is picked
+    local special = get_special()
+    if sspecial and special.captainGroupAllowed then
+        local playerChecked = CaptainUtils.cpt_get_player(playerName)
+        if
+            playerChecked
+            and playerChecked.tag ~= ''
+            and starts_with(playerChecked.tag, ComfyPanelGroup.COMFY_PANEL_CAPTAINS_GROUP_PLAYER_TAG_PREFIX)
+        then
+            return true
+        end
+    end
+    return false
+end
+
+---@param player LuaPlayer
+---@return boolean
+function CaptainUtils.is_test_player(player)
+    return not player.gui
+end
+
+---@param player_name string
+---@return boolean
+function CaptainUtils.is_test_player_name(player_name)
+    local special = get_special()
+    return special.test_players and special.test_players[player_name]
+end
+
+---@param player string
+---@return boolean
+function CaptainUtils.player_has_captain_authority(player)
+    local special = get_special()
+    local force_name = storage.chosen_team[player]
+    if force_name ~= 'north' and force_name ~= 'south' then
+        return false
+    end
+    return special.captainList[1] == player
+        or special.captainList[2] == player
+        or special.viceCaptains[force_name][player]
+end
+
 ---@param names string[]
 ---@return string
 function CaptainUtils.pretty_print_player_list(names)
-    return table.concat(
-        player_utils.get_colored_player_list(player_utils.get_lua_players_from_player_names(names)),
-        ', '
-    )
+    return concat(player_utils.get_colored_player_list(player_utils.get_lua_players_from_player_names(names)), ', ')
+end
+
+---@param playerName string
+---@param playerForceName string
+function CaptainUtils.switch_team_of_player(playerName, playerForceName)
+    if storage.chosen_team[playerName] then
+        if storage.chosen_team[playerName] ~= playerForceName then
+            game.print(
+                { 'captain.change_player_team_err', playerName, storage.chosen_team[playerName], playerForceName },
+                { color = Color.red }
+            )
+        end
+        return
+    end
+
+    local special = get_special()
+    local player = CaptainUtils.cpt_get_player(playerName)
+    if special and (not player or CaptainUtils.is_test_player(player) or not player.connected) then
+        storage.chosen_team[playerName] = playerForceName
+    else
+        TeamManager.switch_force(playerName, playerForceName)
+    end
+
+    local forcePickName = playerForceName .. 'Picks'
+    if special then
+        insert(special.stats[forcePickName], playerName)
+        if not special.playerPickedAtTicks[playerName] then
+            special.playerPickedAtTicks[playerName] = Functions.get_ticks_since_game_start()
+        end
+    end
+    CaptainUtils.add_to_trust(playerName)
 end
 
 return CaptainUtils

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -22,6 +22,7 @@ suspend_stats=[color=red]__1__[/color] Vs. [color=green]__2__[/color] - ( [color
 team_manager_top_button=[font=default-bold]Team Manager[/font] - Manage players & forces
 team_statistics=[font=default-bold]Team statistics[/font] - Toggle the team statistics window
 tournament_top_button=[font=default-bold]Tournament Menu[/font] - Toggle the tournament window
+debounce=[font=default-dialog-button][img=utility/warning_icon] [[color=yellow]WARNING[/color]][/font]: Oops! It seems you are clicking too fast. Please take a quick break…
 
 [info]
 burner_balance=You have received __1__ x [item=burner-mining-drill], check your inventory-
@@ -39,6 +40,25 @@ disable_picking_announcement=Players are now free to join whatever team they wan
 eject_player=[color=blue]__1__[/color] has decided that [color=orange]__2__[/color] must not be in the team anymore.
 info_caption=[font=default-bold]Captain event info[/font]
 info_content=[font=default-listbox][font=default-bold]Welcome to Biter Battles - Captains Game[/font]\n\n In the Captains Game format participants engage in highly competitive matches led by volunteer captains.\n This mode emphasizes teamwork and strategy, it is essential for all players to understand their role within the team dynamics.\n\n [font=default-bold][color=pink]STRUCTURED TEAM SELECTION[/color][/font]: Captains will choose players in a structured manner to form balanced teams, which enhances the competitiveness of each match.\n [font=default-bold][color=pink]TEAM COLLABORATION[/color][/font]: This mode does not accommodate solo play. Communication with your teammates is imperative. Utilize both [color=acid]in-game chat[/color] and [color=acid]Discord voice chat[/color] to effectively coordinate your efforts.\n [font=default-bold][color=pink]AUTHORITY OF THE CAPTAIN[/color][/font]: The captain is the highest authority on strategy and decision-making for the team. It is crucial to follow their instructions to ensure that the team functions smoothly. Non-compliance may result in removal from the team.\n\n Prepare for a focused and strategic environment as you work collaboratively towards success in the Biter Battles Captains Game.[/font]
-player_info_textbox_caption=Enter any info you want to be visible during the picking phase\ni.e. "I will be on discord", "I can threatfarm", "I can build lots of power"
+player_info_textbox_caption=Enter any info you want to be visible during the picking phase\nand select any n. of tasks that you would like to contribute with\ni.e. "I will be on discord", "I can threatfarm", "I can build lots of power"
 player_info_textbox_tooltip=Enter any info you want to be visible during the picking phase
 replace_referee_announcement=[color=blue]__1__[/color] has decided that [color=green]__2__[/color] will be the new referee instead of [color=orange]__3__[/color]
+info_picks=[font=var]Round[/font]: [font=count-font][color=yellow]__1__[/color][/font]\n[font=var]Picks[/font]: [font=count-font][color=red]__2__[/color][/font] / [font=count-font][color=green]__3__[/color][/font]
+info_draft_timer=[color=yellow][font=count-font]__1__[/font][/color] - [font=default-listbox]Uptime[/font]\n[color=yellow][font=count-font]__2__[/font][/color] - [font=default-listbox]Time (fixed)[/font]\n[color=yellow][font=count-font]__3__[/font][/color] - [font=default-listbox]Time (increment)[/font]
+expand_filters_tooltip=__CONTROL_LEFT_CLICK__ to toggle the column visibility\n__CONTROL_RIGHT_CLICK__ to toggle additional filters/info
+sort_by_tooltip=Sort players by the selected criteria.\nFavourite players ([img=virtual-signal/signal-star]) will always remain on top.
+show_category_tooltip=__CONTROL_LEFT_CLICK__ to toggle the column visibility
+sort_by_tasks_tooltip=Select one or more Task tags to sort player with matching criteria on top of the list. Use [img=utility/reset_white] to clear the filters.
+player_value_caption=The value ([img=item/coin]) is a currency aimed at showing how much value your teammates have attributed to target player. \nWhile spectating, players will downvote ([img=virtual-signal/down-arrow;tint=255,0,0]) / upvote ([img=virtual-signal/up-arrow;tint=0,255,0]) by 1 and everyone is able to see the casted votes. \nAfter being picked, team members can vote again the remaining players to be picked, by attributing values \n proportional to their rank (how early they were picked) to help captain recognise players of great value \n among the remaining ones to pick. Votes casted while on a team are not visible to the other team / spectators.
+
+[enrollment_tasks]
+assembling-machine-2=Main builder
+electric-mining-drill=Support
+grenade=Threatfarm
+lab=Science spam
+laser-turret=Lasers
+nuclear-reactor=Nuclear
+pumpjack=Oil
+rocket-part=Rocket
+steam-engine=Power
+stone-wall=Wall/defenses

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -50,6 +50,7 @@ sort_by_tooltip=Sort players by the selected criteria.\nFavourite players ([img=
 show_category_tooltip=__CONTROL_LEFT_CLICK__ to toggle the column visibility
 sort_by_tasks_tooltip=Select one or more Task tags to sort player with matching criteria on top of the list. Use [img=utility/reset_white] to clear the filters.
 player_value_caption=The value ([img=item/coin]) is a currency aimed at showing how much value your teammates have attributed to target player. \nWhile spectating, players will downvote ([img=virtual-signal/down-arrow;tint=255,0,0]) / upvote ([img=virtual-signal/up-arrow;tint=0,255,0]) by 1 and everyone is able to see the casted votes. \nAfter being picked, team members can vote again the remaining players to be picked, by attributing values \n proportional to their rank (how early they were picked) to help captain recognise players of great value \n among the remaining ones to pick. Votes casted while on a team are not visible to the other team / spectators.
+team_picker_tooltip=This is the screen that captains see to make picking decisions.\nInfo about who is picking and how much time remains are at the bottom with tooltips.\n\nPlayers that have already been picked to a team can\ncommunicate preferences to the captain \nwith the [img=virtual-signal/down-arrow;tint=255,0,0]/[img=virtual-signal/up-arrow;tint=0,255,0] arrow buttons.\n\nPlayers that have not yet been picked can mostly just look,\nbut they can set up preferences in advance of being picked if they want to.
 
 [enrollment_tasks]
 assembling-machine-2=Main builder

--- a/utils/gui.lua
+++ b/utils/gui.lua
@@ -22,6 +22,9 @@ Gui.token = Global.register({ data = data, element_map = element_map }, function
     element_map = tbl.element_map
 end)
 
+Gui.tag = '__@biter_battles'
+Gui.set_style = gui_style
+
 local top_elements = {}
 local on_visible_handlers = {}
 local on_pre_hidden_handlers = {}
@@ -255,7 +258,8 @@ local function handler_factory(event_id)
             return
         end
 
-        local handler = handlers[element.name]
+        local tag = element.tags and element.tags[Gui.tag]
+        local handler = handlers[tag or element.name]
         if not handler then
             return
         end

--- a/utils/string.lua
+++ b/utils/string.lua
@@ -14,4 +14,8 @@ function Public.position_from_gps_tag(text)
     return nil
 end
 
+function Public.starts_with(text, prefix)
+    return text:find(prefix, 1, true) == 1
+end
+
 return Public


### PR DESCRIPTION
### Tested Changes:
- [x] I've tested the changes locally & with people

### Changes:
- [x] moved some utils functions crom `captain.lua` to `captain_utils.lua`
- [x] Refactor the CPT picking UI with new GUI & functionalities (ld one has not been removed but is instead made invisible when using the new one). Here's the new workflow & features explained:

---

> Enrollment
Players volunteer to CPT games & CPT role with usual UI: when clicking "I want to play", in addition to the note field, a list of "Tasks" will also be visible: player can click upon any number of task to mark what they could contribute with (buttons have tooltips with the meaning of the task)
![Screenshot from 2025-03-28 17-56-04](https://github.com/user-attachments/assets/3a3ed9f3-8b3a-4853-9dd7-1c09449bba38)

---

# Picking UI
> This is how the new UI will look like at first:
![Screenshot from 2025-03-28 17-57-22](https://github.com/user-attachments/assets/8c3bb277-e732-41bf-b49f-c1d616258070)

## Top row (left to right)
- "Pin" button to Minimize/Maximize window
- "Settings" button (Referee only)

> Minimized version of the full window
![Screenshot from 2025-03-28 18-00-21](https://github.com/user-attachments/assets/c3e901a0-cbe2-48a7-80e7-683d1c019f32)

Minimized version will only show the chess clock & tooltips of displayed info (see "Footer" section for more details)

> Referee's settings menu
![Screenshot from 2025-03-28 18-00-11](https://github.com/user-attachments/assets/34ed920f-10d9-47a4-bafc-3b5d5a55ecce)

Referee settings menu is self explanatory, referee can:
- add/remove +1/-1 picks to each team individually (current round, default settings 1-2-2-2...)
- force a team to be current team to pick
- enable/disable new picking UI
- pause/unpause time (clock will be stopped but game will not)
- add/remove 30s or 5mins to both teams

When a team runs out of time, and if more than 1 picks are remaining for that team, the script will automatically pick 1 player at random (first from the captain's favourites list, if available, then from whole player list) and pass the turn to other team.

## Second row (left to right)
- "Sort by" dropdown
- "Show info" toggle buttons
- "Searchbar" textfield

![Screenshot from 2025-03-28 18-00-11-2](https://github.com/user-attachments/assets/59511dae-c6ac-4380-8d8d-307c0d085e8d)

**Sort by**: Playtime (highest to lowest) / Name (alphabetically) / Value (highest to lowest)
**Show info**: LEFT MOUSE CLICK to toggle the column visibility from the playerlist (playtime, value, tasks, notes), RIGHT CLICK to open/close the info settings (i.e. Tasks will open/close the Tasks tag filter submenu)
**Searchbar**: filter shown players by name/comment from the text in the textbox. Can use RIGHT MOUSE CLICK or REFRESH button to clear the field. Non-matching entries will not be shown.

## Third row
- Tasks filters / clear tasks filter buttons
- Value info

**Tasks filters**: Allow to filter by task tags. Players meeting all the toggled tasks will show on top of the player list, while remaining non-matching will show at the bottom of the list. Can select more than one. Can use "Clear" button to clear all the tags selected.
**Value info**: the value info is computed by "community vote": players can only upvote/downvote players individually (no ordering) to give +1/-1. Votes may help CPTs draft players/order players by perceived community value. While in spectators, vote will only be +1/-1 and everyone among spectators is able to see them, while voting from a team will only make the votes visible to CPT & team members and are proportional to the rank of the player following the powers of 2 (CPT +-5000, 1st pick +-2048, 3rd pick +-1024, 4th +-512 ... until +-1).

> Example of player values viewed withing a team
![Screenshot from 2025-03-28 17-59-16-3](https://github.com/user-attachments/assets/7eb8353a-5a63-436d-9e60-d6abadf8438b)

## Body playerlist with (left to right)
- favorite/none toggle (yellow star)
- player name (aka picking button)
- player value + up/down vote buttons
- player tasks tags
- player personal notes

Quite self explanatory. Marking as Favorite is per-player (so everyone will see their custom list), and players marked as favourite will generally remain at the top of the list unless (a). not matching the text search filter or (b). not matching the task tags filters. Otherwise, they will always stay on top and be ordered by the sort by algorithm of choice.

![Screenshot from 2025-03-28 17-59-16](https://github.com/user-attachments/assets/98a157c4-23cc-45f7-86ab-5f1b2b7b8edb)

## Footer
- Team names (tooltip -> past picks ordered)
- remaining time for each team 
- enlightened/opaque picking arrow to signal whos turn is (tooltip -> round number, number of picks remaining/done)
- hourglass with stats (tooltip -> uptime, fixed time, incremental time settings)
- refresh button (to manually refresh UI, in case)

> Example of tooltip when hovering over a team name (North)
![Screenshot from 2025-03-28 17-58-12](https://github.com/user-attachments/assets/10488756-d22c-457a-87ae-5bdb66a8be32)

> Example of tooltip when hovering over the picking arrow (round, picks done / picks remaining)
![Screenshot from 2025-03-28 17-58-21-6](https://github.com/user-attachments/assets/8425d31f-a0c5-462f-b80c-e38be8ab7a66)

> Example of tooltip when hovering over the hourglass (total uptime of picking, settings for picking clock)
![Screenshot from 2025-03-28 17-58-17-5](https://github.com/user-attachments/assets/b98d2e62-a376-46bf-948a-f9120642aca9)

# Testing & Debugging

The best way to test & debug it yourself is host a game with the new UI on LAN, and have other instances of Factorio running on your desktop connecting with local game with different player names. Recommended 4+ accounts (2 caps + 2 picks)