### PR TITLE
Add admin fallbacks for new pick UI

### DIFF
--- a/comfy_panel/special_games/captain.lua
+++ b/comfy_panel/special_games/captain.lua
@@ -163,6 +163,7 @@ local function force_end_captain_event()
     storage.difficulty_votes_timeout = game.ticks_played + 36000
     clear_character_corpses()
 end
+CaptainPick.force_end_captain_event = force_end_captain_event
 
 ---@param player LuaPlayer
 ---@param force_name string
@@ -911,7 +912,7 @@ local function start_captain_event()
 end
 
 local countdown_captain_start_token = Token.register(function()
-    if storage.special_games_variables.captain_mode.countdown > 0 then
+    if storage.special_games_variables.captain_mode and storage.special_games_variables.captain_mode.countdown > 0 then
         for _, player in pairs(game.connected_players) do
             local _sprite = 'file/png/' .. storage.special_games_variables.captain_mode.countdown .. '.png'
             if player.gui.center.bb_captain_countdown then
@@ -1186,7 +1187,7 @@ local function start_picking_phase()
             next_pick_force = math_random() < northThreshold and 'north' or 'south'
             log('Next force to pick: ' .. next_pick_force)
         end
-        if Functions.get_ticks_since_game_start() > 0 then
+        if storage.use_old_pick_ui or Functions.get_ticks_since_game_start() > 0 then
             poll_alternate_picking(Public.get_player_to_make_pick(next_pick_force), next_pick_force)
         else
             CaptainPick.enable({ turn = next_pick_force })
@@ -3464,6 +3465,24 @@ commands.add_command('replaceReferee', 'Admin or referee can decide to change th
     else
         playerOfCommand.print('Usage: /replaceReferee <playerName>', { color = Color.warning })
     end
+end)
+
+commands.add_command('toggleCaptainPickUI', 'Enable/Disable new/old captain pick UI', function(cmd)
+    if not cmd.player_index then
+        return
+    end
+    local playerOfCommand = cpt_get_player(cmd.player_index)
+    if not playerOfCommand then
+        return
+    end
+    if not playerOfCommand.admin then
+        return playerOfCommand.print({ 'captain.cmd_only_admin' }, { color = Color.red })
+    end
+
+    storage.use_old_pick_ui = not storage.use_old_pick_ui
+    local status = storage.use_old_pick_ui and 'disabled' or 'enabled'
+    local color = storage.use_old_pick_ui and 'red' or 'green'
+    playerOfCommand.print(string_format('[color=%s]New Captain Pick UI %s[/color]', color, status))
 end)
 
 commands.add_command(

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -243,7 +243,14 @@ Public.disable = function()
     this.north = Public.get_force_settings()
     this.south = Public.get_force_settings()
     this.spectator.list = {}
+    table.clear_table(debounce)
     table.clear_table(favourites)
+    table.clear_table(player_preferences)
+
+    local special = CaptainUtils.get_special()
+    for _, name in pairs(special and special.listPlayers or {}) do
+        CaptainUtils.remove_from_playerList(name)
+    end
 
     if this.enabled then
         this.enabled = false
@@ -1132,7 +1139,7 @@ Public.draw_settings = function(player)
     }) do
         Gui.set_style(button, {
             maximal_height = 28,
-            minimal_width = 108,
+            minimal_width = 115,
             font_color = (i % 2 == 1) and { 140, 140, 252 } or { 252, 084, 084 },
         })
     end
@@ -1141,7 +1148,13 @@ Public.draw_settings = function(player)
         .add({ type = 'frame', style = 'bordered_frame', direction = 'horizontal', caption = 'Draft Timer settings' })
         .add({ type = 'table', column_count = 2 })
     for i, button in pairs({
-        box_2.add({ type = 'button', style = 'red_back_button', name = draft_timer_disable, caption = 'Disable' }),
+        box_2.add({
+            type = 'button',
+            style = 'red_back_button',
+            name = draft_timer_disable,
+            caption = 'Disable',
+            tooltip = 'Cancel captain game',
+        }),
         box_2.add({
             type = 'button',
             style = 'confirm_button_without_tooltip',
@@ -1182,7 +1195,7 @@ Public.draw_settings = function(player)
     }) do
         Gui.set_style(
             button,
-            { maximal_height = 28, minimal_width = 108, font = 'default-semibold', font_color = { 0, 0, 0 } }
+            { maximal_height = 28, minimal_width = 115, font = 'default-semibold', font_color = { 0, 0, 0 } }
         )
     end
 end
@@ -1427,8 +1440,14 @@ Gui.on_click(draft_timer_favor, function(event)
 end)
 
 Gui.on_click(draft_timer_enable, Public.enable)
-Gui.on_click(draft_timer_disable, Public.disable)
+
+Gui.on_click(draft_timer_disable, function(event)
+    Public.disable()
+    Public.force_end_captain_event()
+end)
+
 Gui.on_click(draft_timer_pause, Public.pause)
+
 Gui.on_click(draft_timer_unpause, Public.unpause)
 
 Gui.on_click(draft_timer_change, function(event)

--- a/comfy_panel/special_games/captain_pick.lua
+++ b/comfy_panel/special_games/captain_pick.lua
@@ -453,7 +453,7 @@ Public.perform_auto_picks = function()
         end
     end
 
-    while (side.picks - side.picked > 1) and max_attempts > 0 do
+    while (side.picks - side.picked > 0) and max_attempts > 0 do
         -- Build array of players from favourites, if any
         local candidates = cpt_index and Public.get_favourites_list(cpt_index) or {}
 
@@ -1330,6 +1330,11 @@ end)
 
 Gui.on_click(action_cast_vote, function(event)
     event.player.play_sound({ path = 'utility/gui_click' })
+
+    local player = game.get_player(event.player_index)
+    if not player or (player.force.name == 'spectator') then
+        return
+    end
 
     if Public.debounce(event.player) then
         return

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -170,6 +170,7 @@ function Public.initial_setup()
     ---@type table<string, TeamstatsPreferences>
     storage.teamstats_preferences = {}
     storage.allow_teamstats = 'always'
+    storage.use_old_pick_ui = false
     --Disable Nauvis
     local surface = game.surfaces[1]
     local map_gen_settings = surface.map_gen_settings


### PR DESCRIPTION
# Changes
- [x] fixed that previous referee could still access referee settings of Captain Pick UI
- [x] only picked players can now vote other players
- [x] Auto picks when running out of time now picks all the remaining players instead of just 1  
- [x] CaptainPick->Disable now safely disables full captain mode without resetting map (added a tooltip for it)
- [x] Added admin-only command `/toggleCaptainPickUI` to turn OFF/ON new Captain Pick UI (will simply use old).

Command:
1. needs to be run by any admin any time **before** the start of the cpt picking phase (not after the captains are already able to pick, else it needs a reset of cpt mode)
2. default will use new UI

However, I plan to remove this command and setting in storage after new UI is considered stable. This is just a handy fallback to old mode without the need to reload scenario and everything else.
If new UI breaks, Ref can Disable it from settings, run the toggle command, and proceed with old UI simply, without losing current seeded map.

# Tested Changes:
- [x] I've tested the changes locally and in MP with players

