### PR TITLE
Adjusting default difficulty and mutagen values

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -385,8 +385,9 @@ Public.raise_evo = function()
         return
     end
     if storage.difficulty_vote_index and 1 <= storage.difficulty_vote_index and 4 >= storage.difficulty_vote_index then
-        local x = game.ticks_played / 3600 -- current length of the match in minutes
-        storage.difficulty_vote_value = ((x / 470) ^ 3.7) + Tables.difficulties[storage.difficulty_vote_index].value
+        local matchTimeInMinutes = game.ticks_played / 3600
+        local difficultyRampDelayInMinutes = math.max(0, 30) -- 28 Apr 2025: Delay for 30 minutes
+        storage.difficulty_vote_value = ((math.max(matchTimeInMinutes - difficultyRampDelayInMinutes, 0) / 470) ^ 3.7) + Tables.difficulties[storage.difficulty_vote_index].value
     end
 
     local amount = math.ceil(storage.evo_raise_counter * 0.75)

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -35,10 +35,10 @@ Public.food_values = {
     ['automation-science-pack'] = { value = 0.0009, name = 'automation science', color = '255, 50, 50' },
     ['logistic-science-pack'] = { value = 0.0023, name = 'logistic science', color = '50, 255, 50' },
     ['military-science-pack'] = { value = 0.0095, name = 'military science', color = '105, 105, 105' },
-    ['chemical-science-pack'] = { value = 0.0260, name = 'chemical science', color = '100, 200, 255' },
-    ['production-science-pack'] = { value = 0.1029, name = 'production science', color = '150, 25, 255' },
-    ['utility-science-pack'] = { value = 0.1713, name = 'utility science', color = '210, 210, 60' },
-    ['space-science-pack'] = { value = 0.3500, name = 'space science', color = '255, 255, 255' },
+    ['chemical-science-pack'] = { value = 0.0265, name = 'chemical science', color = '100, 200, 255' },
+    ['production-science-pack'] = { value = 0.1050, name = 'production science', color = '150, 25, 255' },
+    ['utility-science-pack'] = { value = 0.2100, name = 'utility science', color = '210, 210, 60' },
+    ['space-science-pack'] = { value = 0.4375, name = 'space science', color = '255, 255, 255' },
 }
 
 Public.gui_foods = {}
@@ -133,8 +133,8 @@ Public.difficulties = {
     [1] = {
         name = "I'm Too Young to Die",
         short_name = 'ITYTD',
-        str = '25%',
-        value = 0.25,
+        str = '20%',
+        value = 0.2,
         color = {
             [GUI_VARIANTS.Dark] = { r = 0.00, g = 1.00, b = 0.00 },
             [GUI_VARIANTS.Light] = { r = 0.00, g = 0.50, b = 0.00 },
@@ -143,8 +143,8 @@ Public.difficulties = {
     [2] = {
         name = 'Have a Nice Day',
         short_name = 'HaND',
-        str = '38%',
-        value = 0.38,
+        str = '35%',
+        value = 0.35,
         color = {
             [GUI_VARIANTS.Dark] = { r = 0.33, g = 1.00, b = 0.00 },
             [GUI_VARIANTS.Light] = { r = 0.13, g = 0.40, b = 0.00 },


### PR DESCRIPTION
### Brief description of the changes:
Implementing the voted on balance changes from https://discord.com/channels/823696400797138974/1346620574218063974/1346620688777347113 
"Rebalance Science-Meta, Changes: ITYTD Diff 25% to 20% HaND Diff 38% to 35% Buff Blue Sci +6% Buff Yellow Sci +25% Buff White Sci +25% Delay Evo/Diff Ramp on all Diffs by 30 Minutes … for a test period of 5 weeks. Please read thread before voting!"

The vote passed with 67% of the community agreeing (35 pro, 17 con) 

These are three changes:
1. Changing the mutagen values of blue (250->265), yellow (1680->2100) and white science (3500->4375) (tables.lua)
2. Changing the difficulty ITYTD difficulty (25% -> 20%) and HaND difficulty (38%->35%) (tables.lua)
3. Delaying the difficulty ramping by 30 minutes (ai.lua)

Note: This reverts the changes made on 5th of March that buffed blue +4% and yellow +2% and nerved purple -2%.


### Tested Changes:
- [X] I've tested the changes locally. Screenshots attached below
- [ ] I've not tested the changes.
![adjusted mutagen values 20250428213219_1](https://github.com/user-attachments/assets/71225cad-cf61-4ea3-889b-eb062216121c)
![difficulty ramp HAND 20250428213147_1](https://github.com/user-attachments/assets/91e8529b-2fb5-41a5-b1cb-1f85ab103b05)
![difficulty ramp ITYTD 20250428213034_1](https://github.com/user-attachments/assets/cb420239-4d9a-47a9-ac1d-d72fe6523305)
