### PR TITLE
Add \n and appending support to announces

### DIFF
--- a/commands/announce.lua
+++ b/commands/announce.lua
@@ -34,40 +34,59 @@ Public.announce_if_any = function()
     announcement.entity = e
 end
 
+---@param player_index number?
+---@return boolean, LuaPlayer?
+local function check_player_permission(player_index)
+    if not player_index then
+        return false
+    end
+
+    ---@type LuaPlayer?
+    local player = game.get_player(player_index)
+    if not player or not player.valid then
+        return false
+    end
+
+    if not player.admin then
+        player.print('This command can only be used by admins')
+        return false
+    end
+
+    return true, player
+end
+
+---@param player LuaPlayer?
+---@return boolean
+local function try_destroy_bubble(player)
+    local bubble = storage.announcement.entity
+    if bubble and bubble.valid then
+        local removed = bubble.destroy()
+        if not removed then
+            if player and player.valid then
+                player.print('unknown problem occured when removing the announcement')
+                player.print('save the game for later analysis')
+            end
+            return false
+        end
+    end
+
+    return true
+end
+
 ---Implements /announce command.
 ---If no parameter is set, it will clear existing announcement if any.
 ---If parameter is set, it will create new announcement or overwrite existing one.
 ---The announcement is supposed to persist across map resets.
 ---@param cmd CustomCommandData
 local function announce(cmd)
-    ---@type number?
-    local index = cmd.player_index
-    if not index then
+    local allowed, player = check_player_permission(cmd.player_index)
+    if not allowed then
         return
     end
-
-    ---@type LuaPlayer?
-    local player = game.get_player(index)
-    if not player or not player.valid then
-        return
-    end
-
-    if not player.admin then
-        player.print('This command can only be used by admins')
-        return
-    end
+    ---@cast player -nil
 
     -- In any case, we're going to clear existing announcement if any.
-    local removed = false
-    local bubble = storage.announcement.entity
-    if bubble and bubble.valid then
-        removed = bubble.destroy()
-        if not removed then
-            player.print('unknown problem occured when removing the announcement')
-            player.print('save the game for later analysis')
-            return
-        end
-    end
+    local removed = try_destroy_bubble(player)
 
     storage.announcement = {}
     local text = cmd.parameter
@@ -88,6 +107,40 @@ end
 
 commands.add_command('announce', 'Creates a text at spectator island', function(cmd)
     Utils.safe_wrap_cmd(cmd, announce, cmd)
+end)
+
+---Implements /announce-append command.
+---If no parameter is set, does nothing.
+---If parameter is set, it will create new announcement if none exist or append existing one.
+---The announcement is supposed to persist across map resets.
+---@param cmd CustomCommandData
+local function announce_append(cmd)
+    local allowed, player = check_player_permission(cmd.player_index)
+    if not allowed then
+        return
+    end
+    ---@cast player -nil
+
+    local text = cmd.parameter
+    if not text then return end
+
+    -- In any case, we're going to clear existing announcement if any.
+    try_destroy_bubble(player)
+
+    text = text:gsub("\\n", "\n")
+
+    if storage.announcement.text then
+        storage.announcement.text = storage.announcement.text .. '[font=var]' .. text .. '[/font]'
+        Core.print_admins(player.name .. ' appended an announcement')
+    else
+        storage.announcement.text = '[font=var]' .. text .. '[/font]'
+        Core.print_admins(player.name .. ' made an announcement')
+    end
+    Public.announce_if_any()
+end
+
+commands.add_command('announce-append', 'Appends to the text at spectator island', function(cmd)
+    Utils.safe_wrap_cmd(cmd, announce_append, cmd)
 end)
 
 return Public

--- a/commands/announce.lua
+++ b/commands/announce.lua
@@ -79,6 +79,8 @@ local function announce(cmd)
         return
     end
 
+    text = text:gsub("\\n", "\n")
+
     storage.announcement.text = '[font=var]' .. text .. '[/font]'
     Core.print_admins(player.name .. ' made an announcement')
     Public.announce_if_any()

--- a/commands/announce.lua
+++ b/commands/announce.lua
@@ -87,14 +87,15 @@ local function announce(cmd)
 
     -- In any case, we're going to clear existing announcement if any.
     local removed = try_destroy_bubble(player)
+    if removed then
+        Core.print_admins(player.name .. ' removed the announcement')
+    else
+        return
+    end
 
     storage.announcement = {}
     local text = cmd.parameter
     if not text then
-        if removed then
-            Core.print_admins(player.name .. ' removed the announcement')
-        end
-
         return
     end
 
@@ -125,7 +126,10 @@ local function announce_append(cmd)
     if not text then return end
 
     -- In any case, we're going to clear existing announcement if any.
-    try_destroy_bubble(player)
+    local removed = try_destroy_bubble(player)
+    if not removed then
+        return
+    end
 
     text = text:gsub("\\n", "\n")
 

--- a/commands/announce.lua
+++ b/commands/announce.lua
@@ -99,7 +99,7 @@ local function announce(cmd)
         return
     end
 
-    text = text:gsub("\\n", "\n")
+    text = text:gsub('\\n', '\n')
 
     storage.announcement.text = '[font=var]' .. text .. '[/font]'
     Core.print_admins(player.name .. ' made an announcement')
@@ -123,7 +123,9 @@ local function announce_append(cmd)
     ---@cast player -nil
 
     local text = cmd.parameter
-    if not text then return end
+    if not text then
+        return
+    end
 
     -- In any case, we're going to clear existing announcement if any.
     local removed = try_destroy_bubble(player)
@@ -131,7 +133,7 @@ local function announce_append(cmd)
         return
     end
 
-    text = text:gsub("\\n", "\n")
+    text = text:gsub('\\n', '\n')
 
     if storage.announcement.text then
         storage.announcement.text = storage.announcement.text .. '[font=var]' .. text .. '[/font]'


### PR DESCRIPTION
### Brief description of the changes:
- Adding support for new line character in the /announce command.
- Adding /announce-append command which appends to the existing announcement if any, or create a new one otherwise.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
