### PR TITLE
Adjusting mutagen values according to poll

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -386,9 +386,7 @@ Public.raise_evo = function()
     end
     if storage.difficulty_vote_index and 1 <= storage.difficulty_vote_index and 4 >= storage.difficulty_vote_index then
         local matchTimeInMinutes = game.ticks_played / 3600
-        ---@type uint
-        local difficultyRampDelayInMinutes = 30
-        storage.difficulty_vote_value = ((math.max(matchTimeInMinutes - difficultyRampDelayInMinutes, 0) / 470) ^ 3.7)
+        storage.difficulty_vote_value = ((matchTimeInMinutes / 470) ^ 3.7)
             + Tables.difficulties[storage.difficulty_vote_index].value
     end
 

--- a/maps/biter_battles_v2/tables.lua
+++ b/maps/biter_battles_v2/tables.lua
@@ -35,9 +35,9 @@ Public.food_values = {
     ['automation-science-pack'] = { value = 0.0009, name = 'automation science', color = '255, 50, 50' },
     ['logistic-science-pack'] = { value = 0.0023, name = 'logistic science', color = '50, 255, 50' },
     ['military-science-pack'] = { value = 0.0095, name = 'military science', color = '105, 105, 105' },
-    ['chemical-science-pack'] = { value = 0.0265, name = 'chemical science', color = '100, 200, 255' },
+    ['chemical-science-pack'] = { value = 0.0292, name = 'chemical science', color = '100, 200, 255' },
     ['production-science-pack'] = { value = 0.1050, name = 'production science', color = '150, 25, 255' },
-    ['utility-science-pack'] = { value = 0.2100, name = 'utility science', color = '210, 210, 60' },
+    ['utility-science-pack'] = { value = 0.2205, name = 'utility science', color = '210, 210, 60' },
     ['space-science-pack'] = { value = 0.4375, name = 'space science', color = '255, 255, 255' },
 }
 

--- a/tests/test-feeding.lua
+++ b/tests/test-feeding.lua
@@ -42,7 +42,7 @@ function test_feed_effects_3()
     local num_flasks = 4500
     local flask_food_value = Tables.food_values['utility-science-pack'].value * difficulty / 100
     local calc = Functions.calc_feed_effects(evo, flask_food_value, num_flasks, current_player_count, max_reanim_thresh)
-    lunatest.assert_equal('evo_increase: 0.716 threat: 30166', effects_str(calc))
+    lunatest.assert_equal('evo_increase: 0.726 threat: 31373', effects_str(calc))
 end
 
 function test_feed_effects_4()


### PR DESCRIPTION
Adjusting mutagen values according to poll https://discord.com/channels/823696400797138974/823771211421974579/1389238457678692445
The vote passed with 82% of the community agreeing (9 for, 2 against)

<img width="1246" height="342" alt="image" src="https://github.com/user-attachments/assets/7f2dab7f-fa76-429e-9c10-a7b27df18948" />

### Сhanges:
-     Blue mutagen 265 -> 292
-     Yellow sci mutagen 2100 -> 2205
-     Remove delaying the difficulty ramping by 30 minutes
-     test feeding fixed for new values

    
### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
