### PR TITLE
Fix gulag permission after map reset

### DIFF
--- a/utils/datastore/jail_data.lua
+++ b/utils/datastore/jail_data.lua
@@ -191,6 +191,8 @@ local teleport_player_to_gulag = function(player, action)
         p_data.position = player.physical_position
         p_data.p_group_id = player.permission_group.group_id
         p_data.locked = true
+        local gulag_group = get_gulag_permission_group()
+        gulag_group.add_player(player)
         player.character.teleport(gulag.find_non_colliding_position('character', { 0, 0 }, 128, 1), gulag.name)
         local data = {
             player = player,


### PR DESCRIPTION
Fixed a bug where the `gulag` permission would reset after the map was reset, and the player in the jail would get the `spectator` permission.

### Tested Changes:
- [x] I've tested the changes locally or with people.
- [ ] I've not tested the changes.
