### PR TITLE
Initialize colors of players joining the server for the first time

### DIFF
--- a/maps/biter_battles_v2/functions.lua
+++ b/maps/biter_battles_v2/functions.lua
@@ -284,6 +284,22 @@ local function find_teleport_point(surface)
     return surface.find_non_colliding_position('character', p, 4, 0.5) or p
 end
 
+---@param player LuaPlayer
+---Sets random bright color for a player that joins the server for
+---the first time. This gets rid of annoying situation where player
+---gets assigned very dark color that is barely readable.
+function Functions.set_random_color(player)
+    local color = {
+        r = math_random(150, 255),
+        g = math_random(150, 255),
+        b = math_random(150, 255),
+        a = math_random(150, 255),
+    }
+
+    player.color = color
+    player.chat_color = color
+end
+
 function Functions.init_player(player)
     if not player.connected then
         if player.force.index ~= 1 then

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -1396,6 +1396,7 @@ end
 local function on_player_joined_game(event)
     local player = game.get_player(event.player_index)
     if player.online_time == 0 then
+        Functions.set_random_color(player)
         Functions.show_intro(player)
     end
 


### PR DESCRIPTION
### Brief description of the changes:
As stated in the subject. This gets rid of annoying situation where random players join server for the first time and have dark/black colors in chat which is difficult to read.

### Tested Changes:
- [X] I've tested the changes locally or with people.
